### PR TITLE
ext(orchestrator workflow): execute work in parallel for batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "forge_provider",
  "forge_tool",
  "forge_walker",
+ "futures",
  "handlebars",
  "insta",
  "pretty_assertions",

--- a/crates/forge_server/Cargo.toml
+++ b/crates/forge_server/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3"
 colorize = "0.1.0"
 async-trait = "0.1.83"
+futures = "0.3.31"
 forge_tool = { path = "../forge_tool" }
 forge_provider = { path = "../forge_provider" }
 forge_walker = { path = "../forge_walker" }


### PR DESCRIPTION
With this change, the agent tool can execute batches in parallel, but the orchestrator must send the work in batches.