### PR TITLE
feat: enhance user input handling with reload command

### DIFF
--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -4,20 +4,32 @@ use strum_macros::AsRefStr;
 
 use crate::console::CONSOLE;
 
+/// Represents the different types of user inputs that can be processed by the
+/// system.
 #[derive(Debug)]
 pub enum UserInput {
+    /// End the current session and exit the application
     End,
+    /// Start a new conversation while preserving history
     New,
+    /// Reload the conversation by clearing the conversation ID and starting
+    /// fresh
+    Reload,
+    /// A regular text message from the user to be processed
     Message(String),
 }
 
+/// Internal representation of input types including system commands
 #[derive(Debug, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
 enum InputKind {
+    /// Display help information about available commands
     Help,
+    /// Regular user input including commands and messages
     User(UserInput),
 }
 
+/// Provides command autocompletion functionality for the input prompt
 #[derive(Clone)]
 struct CommandCompleter {
     commands: Vec<String>,
@@ -65,15 +77,24 @@ impl Autocomplete for CommandCompleter {
 }
 
 impl InputKind {
+    /// Returns a list of all available command strings
     fn available_commands() -> Vec<String> {
-        vec!["/end".to_string(), "/new".to_string(), "/help".to_string()]
+        vec![
+            "/end".to_string(),
+            "/new".to_string(),
+            "/reload".to_string(),
+            "/help".to_string(),
+        ]
     }
 
+    /// Parses a string input into an InputKind, handling both commands and
+    /// regular messages
     fn parse(input: &str) -> Result<Self> {
         let trimmed = input.trim();
         match trimmed {
             "/end" => Ok(InputKind::User(UserInput::End)),
             "/new" => Ok(InputKind::User(UserInput::New)),
+            "/reload" => Ok(InputKind::User(UserInput::Reload)),
             "/help" => Ok(InputKind::Help),
             cmd if cmd.starts_with('/') => {
                 let available_commands = Self::available_commands();
@@ -87,21 +108,36 @@ impl InputKind {
         }
     }
 
+    /// Returns a formatted help text describing all available commands and
+    /// usage instructions
     fn get_help_text() -> String {
         "Available Commands:
-/new   - Start a new conversation
-/end   - End the current conversation and exit
+/new    - Start a new conversation with a clean history. You will need to provide
+          the initial prompt or task to begin the conversation.
+
+/reload - Reset and restart the current conversation using the original prompt
+          or file that started this session. This preserves the initial context
+          but clears all subsequent conversation history.
+
+/end    - End the current conversation and exit the application.
 
 Other Usage:
 - Type your message directly to chat with the AI
 - Commands are case-sensitive and must start with '/'
 - Use tab completion to quickly enter commands
-- Arrow keys can be used to navigate command history"
+- Arrow keys can be used to navigate command history
+
+Quick Guide:
+- Use /new when you want to start a completely fresh conversation
+- Use /reload when you want to retry the current task from the beginning
+- Use /end when you're finished with all conversations"
             .to_string()
     }
 }
 
 impl UserInput {
+    /// Prompts for user input, handling commands and messages appropriately.
+    /// Continues prompting if help is requested.
     pub fn prompt() -> Result<Self> {
         loop {
             CONSOLE.writeln("")?;
@@ -123,6 +159,8 @@ impl UserInput {
         }
     }
 
+    /// Prompts for the initial input when starting a conversation.
+    /// Only accepts messages and help commands, ignoring other commands.
     pub fn prompt_initial() -> Result<String> {
         loop {
             let text = inquire::Text::new("")

--- a/crates/forge_main/src/main.rs
+++ b/crates/forge_main/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize API: {}", e))?;
 
-    let mut content = initial_content;
+    let mut content = initial_content.clone(); // Clone here to keep original
 
     loop {
         let model = ModelId::from_env(api.env());
@@ -109,6 +109,11 @@ async fn main() -> Result<()> {
                 CONSOLE.writeln("Starting fresh conversation...")?;
                 current_conversation_id = None;
                 content = UserInput::prompt_initial()?;
+            }
+            UserInput::Reload => {
+                CONSOLE.writeln("Reloading conversation with original prompt...")?;
+                current_conversation_id = None;
+                content = initial_content.clone();
             }
             UserInput::Message(msg) => {
                 content = msg;


### PR DESCRIPTION
This PR adds a new reload command that allows users to restart conversations with the original prompt, along with improved help text documentation for all commands.

Changes:
- Added new /reload command to restart conversations
- Enhanced help text with detailed command descriptions
- Clear distinction between /new and /reload behaviors
- Improved code documentation