### PR TITLE
chore: avoid Crash on invalid command

### DIFF
--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -6,6 +6,7 @@ use strum_macros::AsRefStr;
 use tokio::fs;
 
 use crate::console::CONSOLE;
+use crate::StatusDisplay;
 
 /// Represents user input types in the chat application.
 ///
@@ -231,7 +232,7 @@ impl UserInput {
                     InputKind::User(input) => return Ok(input),
                 },
                 Err(e) => {
-                    eprintln!("Error: {}", e);
+                    CONSOLE.writeln(StatusDisplay::failed(e.to_string()).format())?;
                 }
             }
         }


### PR DESCRIPTION
fixes: #133

In this pr, in case the user writes incorrect command. Instead of crashing, it will print an error message with available options for command and asks for new command.