### PR TITLE
feat: support multi-line texts in cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,8 +581,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+source = "git+https://github.com/laststylebender14/dialoguer.git?branch=feat%2Fimpl-autocomplete-with-input#7163f29b9b46cf070ee84a3c383071666f43e9db"
 dependencies = [
  "console",
  "shell-words",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -575,6 +576,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -883,6 +897,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "derive_setters",
+ "dialoguer",
  "forge_app",
  "forge_domain",
  "inquire",
@@ -1141,7 +1156,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1635,7 +1650,7 @@ dependencies = [
  "newline-converter",
  "once_cell",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2898,6 +2913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,6 +3633,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.11.0"
-source = "git+https://github.com/laststylebender14/dialoguer.git?branch=feat%2Fimpl-autocomplete-with-input#7163f29b9b46cf070ee84a3c383071666f43e9db"
+source = "git+https://github.com/laststylebender14/dialoguer.git?branch=feat%2Fimpl-autocomplete-with-input#18ccba6ac0f82f7ee414b0446836c87220343b06"
 dependencies = [
  "console",
  "shell-words",

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -22,6 +22,7 @@ derive_setters = "0.1"
 lazy_static = "1.4.0"
 serde_json = "1.0"
 thiserror = "2.0"
+dialoguer = { version = "0.11.0", features = ["completion"]}
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -22,7 +22,8 @@ derive_setters = "0.1"
 lazy_static = "1.4.0"
 serde_json = "1.0"
 thiserror = "2.0"
-dialoguer = { version = "0.11.0", features = ["completion"]}
+dialoguer = { git = "https://github.com/laststylebender14/dialoguer.git", branch = "feat/impl-autocomplete-with-input",features = ["completion"] }
+
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -65,11 +65,14 @@ impl Completion for Completer {
 
     fn get_suggestions(&self, input: &str) -> Vec<String> {
         let (suggestion, trigger_char) = Completer::find_last_trigger_position(input);
+        if suggestion.is_empty() {
+            return vec![];
+        }
         let result = match trigger_char {
             '/' => self
                 .commands
                 .iter()
-                .filter(|cmd| cmd.starts_with(suggestion))
+                .filter(|cmd| cmd.contains(suggestion))
                 .cloned()
                 .collect(),
             '@' => self

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -14,28 +14,78 @@ use crate::StatusDisplay;
 ///
 /// This struct maintains a list of available commands and implements
 /// the Autocomplete trait to provide suggestions as the user types.
-#[derive(Clone)]
-struct CommandCompleter {
+#[derive(Clone, Debug)]
+struct Completer {
     commands: Vec<String>,
+    files: Vec<String>,
 }
 
 /// Console implementation for handling user input via command line.
-#[derive(Debug, Default)]
-pub struct Console;
+#[derive(Debug)]
+pub struct Console {
+    commands: Vec<String>,
+    files: Vec<String>,
+}
 
-impl CommandCompleter {
-    /// Creates a new command completer with the list of available commands
-    fn new() -> Self {
-        Self { commands: Command::available_commands() }
+impl Console {
+    pub fn new(files: Vec<String>, commands: Vec<String>) -> Self {
+        Self { commands, files }
     }
 }
 
-impl Completion for CommandCompleter {
+impl From<&Console> for Completer {
+    fn from(console: &Console) -> Self {
+        Completer {
+            commands: console.commands.clone(),
+            files: console.files.clone(),
+        }
+    }
+}
+
+impl Completer {
+    fn find_last_trigger_position(input: &str) -> (&str, char) {
+        if let Some(pos) = input.rfind('@').or_else(|| input.rfind('/')) {
+            let trigger_char = input.chars().nth(pos).unwrap();
+            let suggestion = &input[pos + 1..];
+            (suggestion, trigger_char)
+        } else {
+            // Return an empty suggestion and a default trigger character if none found
+            ("", ' ') // or any other default character
+        }
+    }
+}
+
+impl Completion for Completer {
     fn get(&self, input: &str) -> Option<String> {
         self.commands
             .iter()
             .find(|cmd| cmd.starts_with(input))
             .cloned()
+    }
+
+    fn get_suggestions(&self, input: &str) -> Vec<String> {
+        let (suggestion, trigger_char) = Completer::find_last_trigger_position(input);
+        let result = match trigger_char {
+            '/' => self
+                .commands
+                .iter()
+                .filter(|cmd| cmd.starts_with(suggestion))
+                .cloned()
+                .collect(),
+            '@' => self
+                .files
+                .iter()
+                .filter(|file| {
+                    let file_name = file.split('/').last().unwrap_or(file);
+                    file_name.contains(suggestion)
+                })
+                .take(5)
+                .cloned()
+                .collect(),
+            _ => vec![],
+        };
+
+        result
     }
 }
 
@@ -54,7 +104,7 @@ impl UserInput for Console {
         initial_text: Option<&str>,
     ) -> anyhow::Result<Command> {
         let theme = ColorfulTheme::default();
-        let completion = CommandCompleter::new();
+        let completion = Completer::from(self);
         let help = help_text.map(|a| a.bright_white().to_string()).unwrap_or({
             let commands = Command::available_commands().join(", ");
             format!("[Available commands: {}]", commands)

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+use colored::Colorize;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Completion, Input};
 use forge_domain::{Command, Usage, UserInput};
@@ -56,13 +57,17 @@ impl UserInput for Console {
         let completion = CommandCompleter::new();
         loop {
             CONSOLE.writeln("")?;
-            let help = help_text.map(|a| a.to_string()).unwrap_or(format!(
-                "Available commands: {}",
-                Command::available_commands().join(", ")
-            ));
+            let help = help_text.map(|a| a.bright_white().to_string()).unwrap_or({
+                let commands = Command::available_commands()
+                    .join(", ")
+                    .bright_cyan()
+                    .to_string();
+                format!("{} {}", "Available commands:".white(), commands)
+            });
+            CONSOLE.writeln(help)?;
 
             let input = Input::<String>::with_theme(&theme)
-                .with_prompt(&help)
+                .with_prompt("")
                 .completion_with(&completion)
                 .with_initial_text(initial_text.unwrap_or(""));
 

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -55,16 +55,15 @@ impl UserInput for Console {
     ) -> anyhow::Result<Command> {
         let theme = ColorfulTheme::default();
         let completion = CommandCompleter::new();
+        let help = help_text.map(|a| a.bright_white().to_string()).unwrap_or({
+            let commands = Command::available_commands().join(", ");
+            format!("[Available commands: {}]", commands)
+                .bright_cyan()
+                .to_string()
+        });
         loop {
             CONSOLE.writeln("")?;
-            let help = help_text.map(|a| a.bright_white().to_string()).unwrap_or({
-                let commands = Command::available_commands()
-                    .join(", ")
-                    .bright_cyan()
-                    .to_string();
-                format!("{} {}", "Available commands:".white(), commands)
-            });
-            CONSOLE.writeln(help)?;
+            CONSOLE.writeln(&help)?;
 
             let input = Input::<String>::with_theme(&theme)
                 .with_prompt("")

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -33,11 +33,12 @@ impl UI {
         custom_instructions: Option<PathBuf>,
     ) -> Result<Self> {
         let api = Arc::new(Service::api_service().await?);
+        let files = api.completions().await?.into_iter().filter(|f| !f.is_dir).map(|f| f.path).collect();
 
         Ok(Self {
             state: Default::default(),
             api,
-            console: Console,
+            console: Console::new(files, Command::available_commands()),
             verbose,
             exec,
             custom_instructions,


### PR DESCRIPTION
# Switch to dialoguer for Input Handling

Switched from `inquire` to `dialoguer` because inquire doesn't support multiline input text. While inquire has good autocompletion, but multiline support for complex commands and queries isn't there. Dialoguer provides both features with a simple API. autocompletion is bit tricky as it only returns one match.