### PR TITLE
refactor: convert status labels to lowercase

### DIFF
--- a/crates/forge_main/src/status.rs
+++ b/crates/forge_main/src/status.rs
@@ -21,10 +21,10 @@ impl Kind {
 
     fn label(&self) -> &'static str {
         match self {
-            Kind::Execute => "EXECUTE",
-            Kind::Success => "SUCCESS",
-            Kind::Failed => "FAILED",
-            Kind::Task => "TASK",
+            Kind::Execute => "execute",
+            Kind::Success => "success",
+            Kind::Failed => "failed",
+            Kind::Task => "task",
         }
     }
 }


### PR DESCRIPTION
- Modified status labels in Kind::label() to use lowercase
- Updated EXECUTE, SUCCESS, FAILED, TASK labels
- Maintains existing functionality with improved readability
- All tests passing