### PR TITLE
fix: provider flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "derive_setters",
  "futures",
  "insta",
+ "lazy_static",
  "nom 8.0.0",
  "pretty_assertions",
  "schemars",

--- a/crates/forge_domain/Cargo.toml
+++ b/crates/forge_domain/Cargo.toml
@@ -31,3 +31,4 @@ tracing = "0.1.41"
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["json"] }
 pretty_assertions = "1.4.1"
+lazy_static = "1.5.0"

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -67,10 +67,12 @@ impl Provider {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use lazy_static::lazy_static;
     use std::env;
     use std::sync::Mutex;
+
+    use lazy_static::lazy_static;
+
+    use super::*;
 
     lazy_static! {
         static ref ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -160,7 +160,6 @@ mod tests {
 
     #[test]
     fn test_provider_from_env_with_no_keys() {
-        reset_env();
         let provider = Provider::from_env();
         assert_eq!(provider, None);
     }


### PR DESCRIPTION
The tests were failing randomly because multiple tests were changing environment variables at the same time.