### PR TITLE
feat: add overwrite option to FSWriteInput for file writing behavior

### DIFF
--- a/crates/forge_app/src/tools/fs/fs_write.rs
+++ b/crates/forge_app/src/tools/fs/fs_write.rs
@@ -18,6 +18,10 @@ pub struct FSWriteInput {
     /// content of the file, without any truncation or omissions. You MUST
     /// include ALL parts of the file, even if they haven't been modified.
     pub content: String,
+    /// If set to true, existing files will be overwritten. If not set and the file exists, 
+    /// an error will be returned with the content of the existing file.
+    #[serde(default)]
+    pub overwrite: bool,
 }
 
 /// Use it to create a new file at a specified path with the provided content.
@@ -54,8 +58,21 @@ impl ExecutableTool for FSWrite {
                 .with_context(|| format!("Failed to create directories: {}", input.path))?;
         }
 
+        // Check if the file exists
+        let file_exists = path.is_file();
+        
+        // If file exists and overwrite flag is not set, return an error with the existing content
+        if file_exists && !input.overwrite {
+            let existing_content = tokio::fs::read_to_string(path).await?;
+            return Err(anyhow::anyhow!(
+                "File already exists at {}. If you need to overwrite it, set overwrite to true.\n\nExisting content:\n{}",
+                input.path,
+                existing_content
+            ));
+        }
+
         // record the file content before they're modified
-        let old_content = if path.is_file() {
+        let old_content = if file_exists {
             // if file already exists, we should be able to read it.
             tokio::fs::read_to_string(path).await?
         } else {
@@ -110,6 +127,7 @@ mod test {
             .call(FSWriteInput {
                 path: file_path.to_string_lossy().to_string(),
                 content: content.to_string(),
+                overwrite: false,
             })
             .await
             .unwrap();
@@ -133,6 +151,7 @@ mod test {
             .call(FSWriteInput {
                 path: file_path.to_string_lossy().to_string(),
                 content: "fn main() { let x = ".to_string(),
+                overwrite: false,
             })
             .await;
 
@@ -151,6 +170,7 @@ mod test {
             .call(FSWriteInput {
                 path: file_path.to_string_lossy().to_string(),
                 content: content.to_string(),
+                overwrite: false,
             })
             .await;
 
@@ -175,6 +195,7 @@ mod test {
             .call(FSWriteInput {
                 path: nested_path.to_string_lossy().to_string(),
                 content: content.to_string(),
+                overwrite: false,
             })
             .await
             .unwrap();
@@ -205,6 +226,7 @@ mod test {
             .call(FSWriteInput {
                 path: deep_path.to_string_lossy().to_string(),
                 content: content.to_string(),
+                overwrite: false,
             })
             .await
             .unwrap();
@@ -234,7 +256,11 @@ mod test {
 
         let fs_write = FSWrite;
         let result = fs_write
-            .call(FSWriteInput { path: path_str, content: content.to_string() })
+            .call(FSWriteInput { 
+                path: path_str, 
+                content: content.to_string(),
+                overwrite: false,
+            })
             .await
             .unwrap();
 
@@ -260,6 +286,7 @@ mod test {
             .call(FSWriteInput {
                 path: "relative/path/file.txt".to_string(),
                 content: "test content".to_string(),
+                overwrite: false,
             })
             .await;
 
@@ -268,5 +295,71 @@ mod test {
             .unwrap_err()
             .to_string()
             .contains("Path must be absolute"));
+    }
+
+    #[tokio::test]
+    async fn test_fs_write_no_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test_overwrite.txt");
+        let original_content = "Original content";
+        
+        // First, create the file
+        fs::write(&file_path, original_content).await.unwrap();
+        
+        // Now attempt to write without overwrite flag
+        let fs_write = FSWrite;
+        let result = fs_write
+            .call(FSWriteInput {
+                path: file_path.to_string_lossy().to_string(),
+                content: "New content".to_string(),
+                overwrite: false,
+            })
+            .await;
+        
+        // Should result in an error
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        
+        // Error should mention overwrite flag
+        assert!(error_msg.contains("set overwrite to true"));
+        
+        // Error should contain the original file content
+        assert!(error_msg.contains(original_content));
+        
+        // Make sure the file wasn't changed
+        let content = fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, original_content);
+    }
+
+    #[tokio::test]
+    async fn test_fs_write_with_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test_overwrite.txt");
+        let original_content = "Original content";
+        let new_content = "New content";
+        
+        // First, create the file
+        fs::write(&file_path, original_content).await.unwrap();
+        
+        // Now attempt to write with overwrite flag
+        let fs_write = FSWrite;
+        let result = fs_write
+            .call(FSWriteInput {
+                path: file_path.to_string_lossy().to_string(),
+                content: new_content.to_string(),
+                overwrite: true,
+            })
+            .await;
+        
+        // Should be successful
+        assert!(result.is_ok());
+        let success_msg = result.unwrap();
+        
+        // Success message should contain expected text
+        assert!(success_msg.contains("Successfully wrote"));
+        
+        // Verify file was actually overwritten
+        let content = fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, new_content);
     }
 }

--- a/crates/forge_app/src/tools/fs/fs_write.rs
+++ b/crates/forge_app/src/tools/fs/fs_write.rs
@@ -18,8 +18,9 @@ pub struct FSWriteInput {
     /// content of the file, without any truncation or omissions. You MUST
     /// include ALL parts of the file, even if they haven't been modified.
     pub content: String,
-    /// If set to true, existing files will be overwritten. If not set and the file exists, 
-    /// an error will be returned with the content of the existing file.
+    /// If set to true, existing files will be overwritten. If not set and the
+    /// file exists, an error will be returned with the content of the
+    /// existing file.
     #[serde(default)]
     pub overwrite: bool,
 }
@@ -60,8 +61,9 @@ impl ExecutableTool for FSWrite {
 
         // Check if the file exists
         let file_exists = path.is_file();
-        
-        // If file exists and overwrite flag is not set, return an error with the existing content
+
+        // If file exists and overwrite flag is not set, return an error with the
+        // existing content
         if file_exists && !input.overwrite {
             let existing_content = tokio::fs::read_to_string(path).await?;
             return Err(anyhow::anyhow!(
@@ -256,8 +258,8 @@ mod test {
 
         let fs_write = FSWrite;
         let result = fs_write
-            .call(FSWriteInput { 
-                path: path_str, 
+            .call(FSWriteInput {
+                path: path_str,
                 content: content.to_string(),
                 overwrite: false,
             })
@@ -302,10 +304,10 @@ mod test {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test_overwrite.txt");
         let original_content = "Original content";
-        
+
         // First, create the file
         fs::write(&file_path, original_content).await.unwrap();
-        
+
         // Now attempt to write without overwrite flag
         let fs_write = FSWrite;
         let result = fs_write
@@ -315,17 +317,17 @@ mod test {
                 overwrite: false,
             })
             .await;
-        
+
         // Should result in an error
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
-        
+
         // Error should mention overwrite flag
         assert!(error_msg.contains("set overwrite to true"));
-        
+
         // Error should contain the original file content
         assert!(error_msg.contains(original_content));
-        
+
         // Make sure the file wasn't changed
         let content = fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(content, original_content);
@@ -337,10 +339,10 @@ mod test {
         let file_path = temp_dir.path().join("test_overwrite.txt");
         let original_content = "Original content";
         let new_content = "New content";
-        
+
         // First, create the file
         fs::write(&file_path, original_content).await.unwrap();
-        
+
         // Now attempt to write with overwrite flag
         let fs_write = FSWrite;
         let result = fs_write
@@ -350,14 +352,14 @@ mod test {
                 overwrite: true,
             })
             .await;
-        
+
         // Should be successful
         assert!(result.is_ok());
         let success_msg = result.unwrap();
-        
+
         // Success message should contain expected text
         assert!(success_msg.contains("Successfully wrote"));
-        
+
         // Verify file was actually overwritten
         let content = fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(content, new_content);


### PR DESCRIPTION
## Description

This PR adds an optional  flag to the  struct used by the file system write tool. When  is set to  (the default) and the file exists, the tool will now return an error with the existing file content rather than silently overwriting the file.

## Changes

- Added an optional  boolean field to  with a default value of 
- Updated the file writing logic to check if the file exists and whether the overwrite flag is set
- Added comprehensive test cases for both overwrite enabled and disabled scenarios
- All existing tests continue to pass with the new functionality

## Why

This improves safety by preventing accidental file overwrites while providing clear feedback to users. The error message includes the content of the existing file and instructions on how to enable overwriting if needed.

## Testing

All tests pass, including new tests that specifically verify the overwrite behavior.