### PR TITLE
refactor: Make system_prompt and user_prompt fields optional for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ Each agent needs tools to perform tasks, configured in the `tools` field:
 - `tools` - List of tools the agent can use
 - `subscribe` - Events the agent listens to
 - `ephemeral` - If true, agent is destroyed after task completion
-- `system_prompt` - Instructions for how the agent should behave
-- `user_prompt` - Format for user inputs
+- `system_prompt` - (Optional) Instructions for how the agent should behave. While optional, it's recommended to provide clear instructions for best results.
+- `user_prompt` - (Optional) Format for user inputs. If not provided, the raw event value is used.
 
 #### Built-in Templates
 

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -50,8 +50,10 @@ pub struct Agent {
     pub id: AgentId,
     pub model: ModelId,
     pub description: Option<String>,
-    pub system_prompt: Template<SystemContext>,
-    pub user_prompt: Template<UserContext>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<Template<SystemContext>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_prompt: Option<Template<UserContext>>,
 
     /// When set to true all user events will also contain a suggestions field
     /// that is prefilled with the matching information from vector store.


### PR DESCRIPTION
This PR makes the system_prompt and user_prompt fields optional for agents.

## Changes:
- Modified the Agent struct to make system_prompt and user_prompt optional fields
- Updated the orchestrator to handle cases when these fields are not provided
- Updated documentation in README.md to reflect the optional nature of these fields

When system_prompt is not provided, no system message will be added to the context.
When user_prompt is not provided, the raw event value will be used as input.

The documentation now indicates these fields are optional but recommends providing system_prompt for best results.