### PR TITLE
fix: Make walker depth optional and more flexible in template agent

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+# ignore files for auto-complete
+*.snap

--- a/crates/forge_app/src/template.rs
+++ b/crates/forge_app/src/template.rs
@@ -42,10 +42,15 @@ impl<F: Infrastructure, T: ToolService> TemplateService for ForgeTemplateService
     ) -> anyhow::Result<String> {
         let env = self.infra.environment_service().get_environment();
 
-        let walker_depth = agent.walker_depth;
+        // Build the walker, only setting max_depth if a value was provided
+        let mut walker = Walker::max_all();
 
-        let mut files = Walker::max_all()
-            .max_depth(walker_depth)
+        // Only set max_depth if the value is provided
+        if let Some(depth) = agent.max_walker_depth {
+            walker = walker.max_depth(depth);
+        }
+
+        let mut files = walker
             .cwd(env.cwd.clone())
             .get()
             .await?

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -37,13 +37,6 @@ impl From<ToolName> for AgentId {
     }
 }
 
-impl Agent {
-    /// Default walker depth for file traversal.
-    pub fn default_walker_depth() -> usize {
-        5
-    }
-}
-
 fn is_true(value: &bool) -> bool {
     *value
 }
@@ -92,9 +85,10 @@ pub struct Agent {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_turns: Option<u64>,
 
-    /// Depth to which the file walker should traverse for this agent
-    #[serde(default = "Agent::default_walker_depth")]
-    pub walker_depth: usize,
+    /// Maximum depth to which the file walker should traverse for this agent
+    /// If not provided, the maximum possible depth will be used
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_walker_depth: Option<usize>,
 }
 
 /// Transformations that can be applied to the agent's context before sending it


### PR DESCRIPTION
- Change `walker_depth` field to `max_walker_depth` (Option<usize>)
- Remove default walker depth method
- Only set max depth when explicitly provided
- Add .ignore file for auto-complete snapshots
