### PR TITLE
feat: add Forge version display in /info endpoint

### DIFF
--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -77,5 +77,12 @@ impl fmt::Display for Info {
     }
 }
 
+pub fn display_info() -> Info {
+    let version = env!("CARGO_PKG_VERSION"); 
+    Info::new()
+        .add_title("Forge Information")
+        .add_item("Version", version) 
+}
+
 // The display_info function has been removed and its implementation will be
 // inlined in the caller


### PR DESCRIPTION
### Description:
This PR adds the Forge version to the /info endpoint, ensuring that users can retrieve the current version of Forge when querying the endpoint.

/claim #433