### PR TITLE
chore: add nextest.toml configuration for test timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+# Set default test timeouts - mark tests as SLOW after 30 seconds
+slow-timeout = { period = "1s", terminate-after = 30, grace-period = "0s" }


### PR DESCRIPTION
This PR adds a nextest.toml configuration file in the .config directory to set default test timeouts. Tests will be marked as SLOW after 1 second and will be terminated after 30 seconds.