### PR TITLE
feat(patch): support multiple-patch operations in a single call

### DIFF
--- a/crates/forge_app/src/tools/fs/fs_write.rs
+++ b/crates/forge_app/src/tools/fs/fs_write.rs
@@ -97,7 +97,8 @@ impl ExecutableTool for FSWrite {
 
         // record the file content after they're modified
         let new_content = tokio::fs::read_to_string(path).await?;
-        let diff = DiffFormat::format(path.to_path_buf(), &old_content, &new_content);
+        let title = if file_exists { "overwrite" } else { "create" };
+        let diff = DiffFormat::format(title, path.to_path_buf(), &old_content, &new_content);
         println!("{}", diff);
 
         Ok(result)

--- a/crates/forge_app/src/tools/patch/apply.rs
+++ b/crates/forge_app/src/tools/patch/apply.rs
@@ -191,7 +191,7 @@ impl ExecutableTool for ApplyPatch {
             .await
             .map_err(Error::FileOperation)?;
         // Generate diff between old and new content
-        let diff = DiffFormat::format(path.to_path_buf(), &old_content, &new_content);
+        let diff = DiffFormat::format("patch", path.to_path_buf(), &old_content, &new_content);
         println!("{}", diff);
 
         Ok(result)

--- a/crates/forge_app/src/tools/patch/apply_json.rs
+++ b/crates/forge_app/src/tools/patch/apply_json.rs
@@ -6,6 +6,7 @@ use forge_domain::{ExecutableTool, NamedTool, ToolDescription, ToolName};
 use forge_tool_macros::ToolDescription;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use strum_macros::AsRefStr;
 use thiserror::Error;
 use tokio::fs;
 
@@ -160,7 +161,7 @@ fn apply_replacement(
 }
 
 /// Operation types that can be performed on matched text
-#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, PartialEq, AsRefStr)]
 #[serde(rename_all = "snake_case")]
 pub enum Operation {
     /// Prepend content before the matched text
@@ -180,9 +181,6 @@ pub enum Operation {
 #[derive(Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ApplyPatchJsonInput {
-    /// The path to the file to modify
-    pub path: String,
-
     /// The text to search for in the source. If empty, operation applies to the
     /// end of the file.
     pub search: String,
@@ -193,6 +191,16 @@ pub struct ApplyPatchJsonInput {
     /// The content to use for the operation (replacement text, text to
     /// prepend/append, or target text for swap operations)
     pub content: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Input {
+    /// The path to the file to modify
+    pub path: String,
+
+    /// List of patch operations to apply in sequence
+    pub patches: Vec<ApplyPatchJsonInput>,
 }
 
 /// Performs a single text operation (prepend, append, replace, swap, delete) on
@@ -225,44 +233,52 @@ fn format_output(path: &str, content: &str, warning: Option<&str>) -> String {
 
 #[async_trait::async_trait]
 impl ExecutableTool for ApplyPatchJson {
-    type Input = ApplyPatchJsonInput;
+    type Input = Input;
 
     async fn call(&self, input: Self::Input) -> anyhow::Result<String> {
         let path = Path::new(&input.path);
         assert_absolute_path(path)?;
 
-        // Read the original content before modification
-        let old_content = fs::read_to_string(path)
+        // Read the original content once
+        let mut current_content = fs::read_to_string(path)
             .await
             .map_err(Error::FileOperation)?;
 
-        // Apply the replacement
-        let modified_content = apply_replacement(
-            old_content.clone(),
-            &input.search,
-            &input.operation,
-            &input.content,
-        )?;
+        // Apply each patch sequentially
+        for patch in input.patches {
+            // Save the old content before modification for diff generation
+            let old_content = current_content.clone();
 
-        // Write modified content to file
-        fs::write(path, &modified_content)
+            // Apply the replacement
+            current_content = apply_replacement(
+                current_content,
+                &patch.search,
+                &patch.operation,
+                &patch.content,
+            )?;
+
+            // Generate diff between old and new content
+            let diff =
+                DiffFormat::format("patch", path.to_path_buf(), &old_content, &current_content);
+            println!("{}", diff);
+        }
+
+        // Write final content to file after all patches are applied
+        fs::write(path, &current_content)
             .await
             .map_err(Error::FileOperation)?;
 
         // Check for syntax errors
-        let warning = syn::validate(path, &modified_content).map(|e| e.to_string());
+        let warning = syn::validate(path, &current_content).map(|e| e.to_string());
 
         // Format the output
         let result = format_output(
             path.to_string_lossy().as_ref(),
-            &modified_content,
+            &current_content,
             warning.as_deref(),
         );
 
-        // Generate diff between old and new content
-        let diff = DiffFormat::format(path.to_path_buf(), &old_content, &modified_content);
-        println!("{}", diff);
-
+        // Return the final result
         Ok(result)
     }
 }

--- a/crates/forge_display/src/diff.rs
+++ b/crates/forge_display/src/diff.rs
@@ -20,13 +20,13 @@ impl fmt::Display for Line {
 pub struct DiffFormat;
 
 impl DiffFormat {
-    pub fn format(path: PathBuf, old: &str, new: &str) -> String {
+    pub fn format(op_name: &str, path: PathBuf, old: &str, new: &str) -> String {
         let diff = TextDiff::from_lines(old, new);
         let ops = diff.grouped_ops(3);
 
         let mut output = format!(
             "{}\n\n",
-            TitleFormat::success("diff").sub_title(path.display().to_string())
+            TitleFormat::success(op_name).sub_title(path.display().to_string())
         );
 
         if ops.is_empty() {
@@ -77,14 +77,14 @@ mod tests {
     fn test_color_output() {
         let old = "Hello World\nThis is a test\nThird line\nFourth line";
         let new = "Hello World\nThis is a modified test\nNew line\nFourth line";
-        let diff = DiffFormat::format("example.txt".into(), old, new);
+        let diff = DiffFormat::format("diff", "example.txt".into(), old, new);
         println!("\nColor Output Test:\n{}", diff);
     }
 
     #[test]
     fn test_diff_printer_no_differences() {
         let content = "line 1\nline 2\nline 3";
-        let diff = DiffFormat::format("xyz.txt".into(), content, content);
+        let diff = DiffFormat::format("diff", "xyz.txt".into(), content, content);
         assert!(diff.contains("No changes applied"));
     }
 
@@ -92,7 +92,7 @@ mod tests {
     fn test_file_source() {
         let old = "line 1\nline 2\nline 3\nline 4\nline 5";
         let new = "line 1\nline 2\nline 3";
-        let diff = DiffFormat::format("xya.txt".into(), old, new);
+        let diff = DiffFormat::format("diff", "xya.txt".into(), old, new);
         let clean_diff = strip_ansi_codes(&diff);
         assert_snapshot!(clean_diff);
     }
@@ -101,7 +101,7 @@ mod tests {
     fn test_diff_printer_simple_diff() {
         let old = "line 1\nline 2\nline 3\nline 5\nline 6\nline 7\nline 8\nline 9";
         let new = "line 1\nmodified line\nline 3\nline 5\nline 6\nline 7\nline 8\nline 9";
-        let diff = DiffFormat::format("abc.txt".into(), old, new);
+        let diff = DiffFormat::format("diff", "abc.txt".into(), old, new);
         let clean_diff = strip_ansi_codes(&diff);
         assert_snapshot!(clean_diff);
     }


### PR DESCRIPTION
## Description

This PR enhances the patching functionality to allow multiple patch operations in a single call.

### Changes

- Added a new Input struct with a patches field to handle multiple patch operations
- Implemented sequential application of patches with individual diff generation for each step
- Modified DiffFormat to include operation type (patch/create/overwrite) in the diff title
- Added better string conversion for Operation enum using AsRefStr

### Testing

All unit tests for the patch functionality are passing. The only failing tests are the API integration tests which are failing due to a tracing initialization issue unrelated to the patch functionality changes.

### Benefits

- Allows for more complex file modifications in a single API call
- Provides clearer diff output with operation-specific titles
- Reduces the number of file read/write operations when multiple changes are needed