### PR TITLE
refactor: migrate from content-based to event-based communication model

### DIFF
--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -1,52 +1,29 @@
 use std::sync::Arc;
 
-use forge_app::{EnvironmentService, Infrastructure};
-use forge_domain::{
-    AgentMessage, App, ChatRequest, ChatResponse, Orchestrator, SystemContext, ToolService,
-};
+use forge_domain::{AgentMessage, App, ChatRequest, ChatResponse, Orchestrator};
 use forge_stream::MpscStream;
-use forge_walker::Walker;
 
 pub struct ForgeExecutorService<F> {
-    infra: Arc<F>,
+    app: Arc<F>,
 }
-impl<F: Infrastructure + App> ForgeExecutorService<F> {
+impl<F: App> ForgeExecutorService<F> {
     pub fn new(infra: Arc<F>) -> Self {
-        Self { infra }
+        Self { app: infra }
     }
 }
 
-impl<F: Infrastructure + App> ForgeExecutorService<F> {
+impl<F: App> ForgeExecutorService<F> {
     pub async fn chat(
         &self,
         request: ChatRequest,
     ) -> anyhow::Result<MpscStream<anyhow::Result<AgentMessage<ChatResponse>>>> {
-        let env = self.infra.environment_service().get_environment();
-        let mut files = Walker::max_all()
-            .max_depth(4)
-            .cwd(env.cwd.clone())
-            .get()
-            .await?
-            .iter()
-            .map(|f| f.path.to_string())
-            .collect::<Vec<_>>();
-
-        // Sort the files alphabetically to ensure consistent ordering
-        files.sort();
-
-        let ctx = SystemContext {
-            env: Some(env),
-            tool_information: Some(self.infra.tool_service().usage_prompt()),
-            tool_supported: Some(true),
-            files,
-        };
-
-        let app = self.infra.clone();
+        let app = self.app.clone();
 
         Ok(MpscStream::spawn(move |tx| async move {
             let tx = Arc::new(tx);
-            let orch = Orchestrator::new(app, request, ctx, Some(tx.clone()));
-            match orch.execute().await {
+            let orch = Orchestrator::new(app, request.conversation_id, Some(tx.clone()));
+
+            match orch.dispatch(&request.event).await {
                 Ok(_) => {}
                 Err(err) => tx.send(Err(err)).await.unwrap(),
             }

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -105,7 +105,7 @@ pub enum Transform {
     },
 
     /// Works on the user prompt by enriching it with additional information
-    User { agent_id: AgentId, output: String },
+    User { agent_id: AgentId, output: String, input: String },
 
     /// Intercepts the context and performs an operation without changing the
     /// context

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -105,7 +105,11 @@ pub enum Transform {
     },
 
     /// Works on the user prompt by enriching it with additional information
-    User { agent_id: AgentId, output: String, input: String },
+    User {
+        agent_id: AgentId,
+        output: String,
+        input: String,
+    },
 
     /// Intercepts the context and performs an operation without changing the
     /// context

--- a/crates/forge_domain/src/chat_request.rs
+++ b/crates/forge_domain/src/chat_request.rs
@@ -1,17 +1,17 @@
 use derive_setters::Setters;
 use serde::{Deserialize, Serialize};
 
-use crate::ConversationId;
+use crate::{ConversationId, Event};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Setters)]
 #[setters(into, strip_option)]
 pub struct ChatRequest {
-    pub content: String,
+    pub event: Event,
     pub conversation_id: ConversationId,
 }
 
 impl ChatRequest {
-    pub fn new(content: impl ToString, conversation_id: ConversationId) -> Self {
-        Self { content: content.to_string(), conversation_id }
+    pub fn new(content: Event, conversation_id: ConversationId) -> Self {
+        Self { event: content, conversation_id }
     }
 }

--- a/crates/forge_domain/src/event.rs
+++ b/crates/forge_domain/src/event.rs
@@ -59,15 +59,4 @@ impl Event {
             timestamp,
         }
     }
-
-    pub fn task_init(value: impl ToString) -> Self {
-        Self::new(Self::USER_TASK_INIT, value)
-    }
-
-    pub fn task_update(value: impl ToString) -> Self {
-        Self::new(Self::USER_TASK_UPDATE, value)
-    }
-
-    pub const USER_TASK_INIT: &'static str = "user_task_init";
-    pub const USER_TASK_UPDATE: &'static str = "user_task_update";
 }

--- a/crates/forge_inte/tests/api_spec.rs
+++ b/crates/forge_inte/tests/api_spec.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::Context;
-use forge_api::{AgentMessage, ChatRequest, ChatResponse, ForgeAPI, ModelId, API};
+use forge_api::{AgentMessage, ChatRequest, ChatResponse, Event, ForgeAPI, ModelId, API};
 use tokio_stream::StreamExt;
 
 const MAX_RETRIES: usize = 5;
@@ -49,7 +49,10 @@ impl Fixture {
         // initialize the conversation by storing the workflow.
         let conversation_id = api.init(workflow).await.unwrap();
         let request = ChatRequest::new(
-            "There is a cat hidden in the codebase. What is its name?",
+            Event::new(
+                "user_task_init",
+                "There is a cat hidden in the codebase. What is its name?",
+            ),
             conversation_id,
         );
 

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -166,13 +166,14 @@ impl<F: API> UI<F> {
             }
         };
 
-        // Determine if this is the first message or an update based on conversation history
+        // Determine if this is the first message or an update based on conversation
+        // history
         let conversation = self.api.conversation(&conversation_id).await?;
 
         // Create a ChatRequest with the appropriate event type
         let event = if conversation
             .as_ref()
-            .map_or(true, |c| c.rfind_event(EVENT_USER_TASK_INIT).is_none())
+            .is_none_or(|c| c.rfind_event(EVENT_USER_TASK_INIT).is_none())
         {
             Self::create_task_init_event(content.clone())
         } else {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use colored::Colorize;
-use forge_api::{AgentMessage, ChatRequest, ChatResponse, ConversationId, Model, Usage, API};
+use forge_api::{
+    AgentMessage, ChatRequest, ChatResponse, ConversationId, Event, Model, Usage, API,
+};
 use forge_display::TitleFormat;
 use forge_tracker::EventKind;
 use lazy_static::lazy_static;
@@ -14,6 +16,11 @@ use crate::console::CONSOLE;
 use crate::info::Info;
 use crate::input::{Console, PromptInput};
 use crate::model::{Command, UserInput};
+
+// Event type constants moved to UI layer
+pub const EVENT_USER_TASK_INIT: &str = "user_task_init";
+pub const EVENT_USER_TASK_UPDATE: &str = "user_task_update";
+pub const EVENT_TITLE: &str = "title";
 
 lazy_static! {
     pub static ref TRACKER: forge_tracker::Tracker = forge_tracker::Tracker::default();
@@ -46,6 +53,15 @@ pub struct UI<F> {
 }
 
 impl<F: API> UI<F> {
+    // Helper functions for creating events with the specific event names
+    fn create_task_init_event(content: impl ToString) -> Event {
+        Event::new(EVENT_USER_TASK_INIT, content)
+    }
+
+    fn create_task_update_event(content: impl ToString) -> Event {
+        Event::new(EVENT_USER_TASK_UPDATE, content)
+    }
+
     pub fn init(cli: Cli, api: Arc<F>) -> Result<Self> {
         // Parse CLI arguments first to get flags
 
@@ -150,9 +166,24 @@ impl<F: API> UI<F> {
             }
         };
 
-        let chat = ChatRequest::new(content.clone(), conversation_id);
+        // Determine if this is the first message or an update based on conversation history
+        let conversation = self.api.conversation(&conversation_id).await?;
+
+        // Create a ChatRequest with the appropriate event type
+        let event = if conversation
+            .as_ref()
+            .map_or(true, |c| c.rfind_event(EVENT_USER_TASK_INIT).is_none())
+        {
+            Self::create_task_init_event(content.clone())
+        } else {
+            Self::create_task_update_event(content.clone())
+        };
+
+        // Create the chat request with the event
+        let chat = ChatRequest::new(event, conversation_id);
 
         tokio::spawn(TRACKER.dispatch(EventKind::Prompt(content)));
+
         match self.api.chat(chat).await {
             Ok(mut stream) => self.handle_chat_stream(&mut stream).await,
             Err(err) => Err(err),
@@ -253,7 +284,7 @@ impl<F: API> UI<F> {
                 }
             }
             ChatResponse::Custom(event) => {
-                if event.name == "title" {
+                if event.name == EVENT_TITLE {
                     self.state.current_title = Some(event.value);
                 }
             }


### PR DESCRIPTION
## Description

This PR refactors the communication model in forge to use explicit events instead of raw content strings. The change makes the event flow more explicit across the system and simplifies the codebase.

## Changes

- Replace ChatRequest.content with Event object
- Simplify ForgeExecutor by removing environment and tool services
- Move event type constants from domain layer to UI layer
- Update Orchestrator to use direct event dispatch
- Add input field to Transform::User for bidirectional communication
- Update tests and integration to use new event-based API

## Testing

Most tests pass, though there are some integration test failures related to tracing initialization which should be addressed separately. These failures are not directly caused by the code changes in this PR.

## Additional Notes

This refactoring is part of a larger effort to simplify the system architecture and make the code more maintainable.