### PR TITLE
Feat/file snapshot system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +790,12 @@ name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv"
@@ -869,6 +896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +915,15 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -896,6 +944,7 @@ dependencies = [
  "derive_setters",
  "forge_api",
  "forge_display",
+ "forge_snapshot",
  "forge_tracker",
  "forge_walker",
  "insta",
@@ -1088,6 +1137,34 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "forge_snapshot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_fs",
+ "async-trait",
+ "chrono",
+ "clap",
+ "colored 3.0.0",
+ "dirs",
+ "filetime",
+ "forge_api",
+ "forge_domain",
+ "predicates",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "similar",
+ "tempfile",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "walkdir",
 ]
 
 [[package]]
@@ -1358,6 +1435,17 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.8.0",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1955,6 +2043,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2200,6 +2289,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -2479,6 +2574,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -3629,6 +3754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3923,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -10,6 +10,7 @@ forge_api = { path = "../forge_api" }
 forge_walker = { path = "../forge_walker" }
 forge_display = { path = "../forge_display" }
 forge_tracker = { path = "../forge_tracker" }
+forge_snapshot = { path = "../forge_snapshot" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1.17"
 colored = "3.0.0"

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -44,4 +44,64 @@ pub struct Cli {
     /// Path to a file containing the workflow to execute.
     #[arg(long, short = 'w')]
     pub workflow: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command_type: Option<Commands>,
+}
+
+#[derive(Parser)]
+pub enum Commands {
+    /// File snapshot management commands
+    Snapshot(SnapshotCommand),
+}
+
+#[derive(Parser, Clone)]
+pub struct SnapshotCommand {
+    #[command(subcommand)]
+    pub action: SnapshotAction,
+}
+
+#[derive(Parser, Clone)]
+pub enum SnapshotAction {
+    /// Create a snapshot of a file
+    Create {
+        /// Path to the file
+        file_path: PathBuf,
+    },
+    /// List snapshots for a file
+    List {
+        /// Path to the file
+        file_path: PathBuf,
+    },
+    /// Restore a file from a snapshot
+    Restore {
+        /// Path to the file
+        file_path: PathBuf,
+        /// Timestamp of the snapshot to restore
+        #[arg(long, conflicts_with_all = ["index", "previous"])]
+        timestamp: Option<u64>,
+        /// Index of the snapshot to restore (0 = newest)
+        #[arg(long, conflicts_with_all = ["timestamp", "previous"])]
+        index: Option<usize>,
+        /// Restore the previous version
+        #[arg(long, conflicts_with_all = ["timestamp", "index"])]
+        previous: bool,
+    },
+    /// Show differences with a snapshot
+    Diff {
+        /// Path to the file
+        file_path: PathBuf,
+        /// Timestamp of the snapshot to compare with
+        #[arg(long, conflicts_with = "previous")]
+        timestamp: Option<u64>,
+        /// Compare with the previous version
+        #[arg(long, conflicts_with = "timestamp")]
+        previous: bool,
+    },
+    /// Purge old snapshots
+    Purge {
+        /// Number of days to keep snapshots for (default: 30)
+        #[arg(long)]
+        older_than: Option<u32>,
+    },
 }

--- a/crates/forge_main/src/lib.rs
+++ b/crates/forge_main/src/lib.rs
@@ -8,7 +8,9 @@ mod input;
 mod model;
 mod normalize;
 mod prompt;
+mod snapshot;
 mod ui;
 
 pub use cli::Cli;
 pub use ui::UI;
+pub use snapshot::handle_snapshot_command;

--- a/crates/forge_main/src/snapshot.rs
+++ b/crates/forge_main/src/snapshot.rs
@@ -24,15 +24,12 @@ pub async fn handle_snapshot_command(cmd: SnapshotCommand) -> Result<()> {
             let snapshots = service.list_snapshots(&file_path).await?;
             println!("INDEX  TIMESTAMP    DATE                SIZE");
             for (i, snapshot) in snapshots.iter().enumerate() {
-                let timestamp_secs = snapshot.timestamp / 1000;
-                let date = DateTime::<Utc>::from_timestamp_millis(snapshot.timestamp as i64)
-                    .unwrap_or(Utc::now())
-                    .with_timezone(&Local);
+                let date = snapshot.date.with_timezone(&Local);
                 
                 println!(
                     "{:<6}  {:<11}  {:<19}  {:.1}K{}",
                     i,
-                    timestamp_secs,
+                    snapshot.timestamp,
                     date.format("%Y-%m-%d %H:%M"),
                     snapshot.size as f64 / 1024.0,
                     if i == 0 { "   (current)" } else { "" }

--- a/crates/forge_main/src/snapshot.rs
+++ b/crates/forge_main/src/snapshot.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use forge_snapshot::{FileSnapshotServiceImpl, FileSnapshotService};
+use chrono::{DateTime, Local, TimeZone, Utc};
+use std::sync::Arc;
+
+use crate::cli::{SnapshotAction, SnapshotCommand};
+use crate::console::CONSOLE;
+
+pub async fn handle_snapshot_command(cmd: SnapshotCommand) -> Result<()> {
+    let service = FileSnapshotServiceImpl::from_env();
+    
+    match cmd.action {
+        SnapshotAction::Create { file_path } => {
+            let snapshot = service.create_snapshot(&file_path).await?;
+            let local_time = Local::now();
+            
+            CONSOLE.writeln(&format!(
+                "Created snapshot at {} ({})",
+                local_time.format("%Y-%m-%d %H:%M:%S"),
+                snapshot.timestamp
+            ))?;
+        },
+        SnapshotAction::List { file_path } => {
+            let snapshots = service.list_snapshots(&file_path).await?;
+            println!("INDEX  TIMESTAMP    DATE                SIZE");
+            for (i, snapshot) in snapshots.iter().enumerate() {
+                let timestamp_secs = snapshot.timestamp / 1000;
+                let date = DateTime::<Utc>::from_timestamp_millis(snapshot.timestamp as i64)
+                    .unwrap_or(Utc::now())
+                    .with_timezone(&Local);
+                
+                println!(
+                    "{:<6}  {:<11}  {:<19}  {:.1}K{}",
+                    i,
+                    timestamp_secs,
+                    date.format("%Y-%m-%d %H:%M"),
+                    snapshot.size as f64 / 1024.0,
+                    if i == 0 { "   (current)" } else { "" }
+                );
+            }
+        },
+        SnapshotAction::Restore { file_path, timestamp, index, previous } => {
+            if previous {
+                service.restore_previous(&file_path).await?;
+            } else if let Some(ts) = timestamp {
+                service.restore_by_timestamp(&file_path, ts).await?;
+            } else if let Some(idx) = index {
+                service.restore_by_index(&file_path, idx).await?;
+            }
+            CONSOLE.writeln("File restored successfully")?;
+        },
+        SnapshotAction::Diff { file_path, timestamp, previous } => {
+            let snapshot = if previous {
+                service.get_snapshot_by_index(&file_path, 1).await?
+            } else if let Some(ts) = timestamp {
+                service.get_snapshot_by_timestamp(&file_path, ts).await?
+            } else {
+                service.get_snapshot_by_index(&file_path, 0).await?
+            };
+            
+            let diff = service.diff_with_snapshot(&file_path, &snapshot).await?;
+            CONSOLE.writeln(&diff)?;
+        },
+        SnapshotAction::Purge { older_than } => {
+            let days = older_than.unwrap_or(30);
+            let count = service.purge_older_than(days).await?;
+            CONSOLE.writeln(&format!("Purged {} snapshots older than {} days", count, days))?;
+        },
+    }
+    
+    Ok(())
+} 

--- a/crates/forge_snapshot/Cargo.toml
+++ b/crates/forge_snapshot/Cargo.toml
@@ -22,13 +22,13 @@ dirs = "6.0"
 forge_domain = { path = "../forge_domain" }
 forge_api = { path = "../forge_api" }
 regex = "1.10.3"
+filetime = "0.2"
 
 [dev-dependencies]
 tempfile = "3.10"
 tokio-test = "0.4"
 assert_fs = "1.1"
 predicates = "3.1"
-filetime = "0.2"
 
 [[bin]]
 name = "forge-snapshot"

--- a/crates/forge_snapshot/Cargo.toml
+++ b/crates/forge_snapshot/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "forge_snapshot"
+version = "0.1.0"
+edition = "2024"
+description = "File snapshot system for automatic versioning and recovery"
+
+[dependencies]
+tokio = { version = "1.36", features = ["full"] }
+anyhow = "1.0"
+thiserror = "2.0"
+sha2 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
+async-trait = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+walkdir = "2.4"
+similar = "2.4"
+colored = "3.0"
+clap = { version = "4.5", features = ["derive", "env"] }
+dirs = "6.0"
+forge_domain = { path = "../forge_domain" }
+forge_api = { path = "../forge_api" }
+regex = "1.10.3"
+
+[dev-dependencies]
+tempfile = "3.10"
+tokio-test = "0.4"
+assert_fs = "1.1"
+predicates = "3.1"
+filetime = "0.2"
+
+[[bin]]
+name = "forge-snapshot"
+path = "src/bin/forge-snapshot.rs"

--- a/crates/forge_snapshot/src/bin/forge-snapshot.rs
+++ b/crates/forge_snapshot/src/bin/forge-snapshot.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use forge_snapshot::SnapshotCli;
+
+#[derive(Parser)]
+#[command(name = "forge-snapshot")]
+#[command(about = "File snapshot system for automatic versioning and recovery")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+
+    #[arg(long, env = "FORGE_SNAPSHOT_DIR")]
+    snapshot_dir: Option<PathBuf>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List snapshots for a file
+    List {
+        /// Path to the file
+        file: PathBuf,
+    },
+
+    /// Restore a file to a previous version
+    Restore {
+        /// Path to the file
+        file: PathBuf,
+
+        /// Timestamp to restore to
+        #[arg(long)]
+        timestamp: Option<u64>,
+
+        /// Index to restore to (0 = newest, 1 = previous version, etc.)
+        #[arg(long)]
+        index: Option<usize>,
+
+        /// Restore to previous version (shorthand for --index=1)
+        #[arg(long)]
+        previous: bool,
+    },
+
+    /// Show differences between versions
+    Diff {
+        /// Path to the file
+        file: PathBuf,
+
+        /// Timestamp to compare with
+        #[arg(long)]
+        timestamp: Option<u64>,
+
+        /// Index to compare with (0 = newest, 1 = previous version, etc.)
+        #[arg(long)]
+        index: Option<usize>,
+
+        /// Compare with previous version (shorthand for --index=1)
+        #[arg(long)]
+        previous: bool,
+    },
+
+    /// Purge old snapshots
+    Purge {
+        /// Purge snapshots older than this many days (default: 30)
+        #[arg(long)]
+        older_than: Option<u32>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let snapshot_dir = cli.snapshot_dir.unwrap_or_else(|| {
+        dirs::data_dir()
+            .expect("Could not determine data directory")
+            .join("forge")
+            .join("snapshots")
+    });
+
+    std::fs::create_dir_all(&snapshot_dir)?;
+    let snapshot_cli = SnapshotCli::new(snapshot_dir);
+
+    match cli.command {
+        Commands::List { file } => {
+            snapshot_cli.list(&file).await?;
+        }
+        Commands::Restore {
+            file,
+            timestamp,
+            index,
+            previous,
+        } => {
+            let index = if previous { Some(1) } else { index };
+            snapshot_cli.restore(&file, timestamp, index).await?;
+        }
+        Commands::Diff {
+            file,
+            timestamp,
+            index,
+            previous,
+        } => {
+            let index = if previous { Some(1) } else { index };
+            snapshot_cli.diff(&file, timestamp, index).await?;
+        }
+        Commands::Purge { older_than } => {
+            snapshot_cli.purge(older_than).await?;
+        }
+    }
+
+    Ok(())
+} 

--- a/crates/forge_snapshot/src/cli.rs
+++ b/crates/forge_snapshot/src/cli.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+use anyhow::Result;
+use crate::service::FileSnapshotServiceImpl;
+use crate::FileSnapshotService;
+
+pub struct SnapshotCli {
+    service: FileSnapshotServiceImpl,
+}
+
+impl SnapshotCli {
+    pub fn new(snapshot_dir: PathBuf) -> Self {
+        Self {
+            service: FileSnapshotServiceImpl::new(snapshot_dir),
+        }
+    }
+
+    pub async fn list(&self, file_path: &Path) -> Result<()> {
+        let snapshots = self.service.list_snapshots(file_path).await?;
+        
+        if snapshots.is_empty() {
+            println!("No snapshots found for {}", file_path.display());
+            return Ok(());
+        }
+
+        println!("INDEX  TIMESTAMP    DATE                    SIZE");
+        println!("-----  ---------    ----                    ----");
+
+        for (i, snapshot) in snapshots.iter().enumerate() {
+            let size = format_size(snapshot.size);
+            println!(
+                "{:5}  {:10}   {}    {:>8}   {}",
+                i,
+                snapshot.timestamp,
+                snapshot.date.format("%Y-%m-%d %H:%M"),
+                size,
+                if i == 0 { "(current)" } else { "" }
+            );
+        }
+
+        Ok(())
+    }
+
+    pub async fn restore(&self, file_path: &Path, timestamp: Option<u64>, index: Option<usize>) -> Result<()> {
+        match (timestamp, index) {
+            (Some(ts), None) => {
+                self.service.restore_by_timestamp(file_path, ts).await?;
+                println!("Restored {} to timestamp {}", file_path.display(), ts);
+            }
+            (None, Some(idx)) => {
+                self.service.restore_by_index(file_path, idx).await?;
+                println!("Restored {} to index {}", file_path.display(), idx);
+            }
+            (None, None) => {
+                self.service.restore_previous(file_path).await?;
+                println!("Restored {} to previous version", file_path.display());
+            }
+            (Some(_), Some(_)) => {
+                anyhow::bail!("Cannot specify both timestamp and index");
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn diff(&self, file_path: &Path, timestamp: Option<u64>, index: Option<usize>) -> Result<()> {
+        let snapshot = match (timestamp, index) {
+            (Some(ts), None) => {
+                self.service.get_snapshot_by_timestamp(file_path, ts).await?
+            }
+            (None, Some(idx)) => {
+                self.service.get_snapshot_by_index(file_path, idx).await?
+            }
+            (None, None) => {
+                let snapshots = self.service.list_snapshots(file_path).await?;
+                if snapshots.len() < 2 {
+                    anyhow::bail!("No previous version found");
+                }
+                self.service.get_snapshot_by_index(file_path, 1).await?
+            }
+            (Some(_), Some(_)) => {
+                anyhow::bail!("Cannot specify both timestamp and index");
+            }
+        };
+
+        let diff = self.service.diff_with_snapshot(file_path, &snapshot).await?;
+        print!("{}", diff);
+        Ok(())
+    }
+
+    pub async fn purge(&self, days: Option<u32>) -> Result<()> {
+        let days = days.unwrap_or(30);
+        let count = self.service.purge_older_than(days).await?;
+        println!("Purged {} snapshots older than {} days", count, days);
+        Ok(())
+    }
+}
+
+fn format_size(size: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if size < KB {
+        format!("{}B", size)
+    } else if size < MB {
+        format!("{:.1}K", size as f64 / KB as f64)
+    } else if size < GB {
+        format!("{:.1}M", size as f64 / MB as f64)
+    } else {
+        format!("{:.1}G", size as f64 / GB as f64)
+    }
+} 

--- a/crates/forge_snapshot/src/cli.rs
+++ b/crates/forge_snapshot/src/cli.rs
@@ -22,15 +22,14 @@ impl SnapshotCli {
             return Ok(());
         }
 
-        println!("INDEX  TIMESTAMP    DATE                    SIZE");
-        println!("-----  ---------    ----                    ----");
-
+        println!("INDEX  TIMESTAMP    DATE                SIZE");
+        
         for (i, snapshot) in snapshots.iter().enumerate() {
             let size = format_size(snapshot.size);
             println!(
-                "{:5}  {:10}   {}    {:>8}   {}",
+                "{:5}  {:10}   {:16}    {:>4}   {}",
                 i,
-                snapshot.timestamp,
+                snapshot.timestamp / 1000,  // Convert milliseconds to seconds
                 snapshot.date.format("%Y-%m-%d %H:%M"),
                 size,
                 if i == 0 { "(current)" } else { "" }

--- a/crates/forge_snapshot/src/lib.rs
+++ b/crates/forge_snapshot/src/lib.rs
@@ -1,0 +1,106 @@
+mod service;
+mod cli;
+
+pub use service::FileSnapshotServiceImpl;
+pub use cli::SnapshotCli;
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTimeError;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SnapshotError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Snapshot not found: {0}")]
+    NotFound(String),
+    #[error("Invalid snapshot path: {0}")]
+    InvalidPath(String),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("System time error: {0}")]
+    SystemTime(#[from] SystemTimeError),
+}
+
+pub type Result<T> = std::result::Result<T, SnapshotError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotInfo {
+    pub timestamp: u64,
+    pub date: DateTime<Utc>,
+    pub size: u64,
+    pub path: PathBuf,
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotMetadata {
+    pub info: SnapshotInfo,
+    pub original_path: PathBuf,
+    pub snapshot_path: PathBuf,
+}
+
+#[async_trait]
+pub trait FileSnapshotService: Send + Sync {
+    fn snapshot_dir(&self) -> PathBuf;
+
+    /// Creates a new snapshot of the given file
+    async fn create_snapshot(&self, file_path: &Path) -> Result<SnapshotInfo>;
+
+    /// Lists all snapshots for a given file
+    async fn list_snapshots(&self, file_path: &Path) -> Result<Vec<SnapshotInfo>>;
+
+    /// Restores a file to a specific timestamp
+    async fn restore_by_timestamp(&self, file_path: &Path, timestamp: u64) -> Result<()>;
+
+    /// Restores a file to a specific index (0 = newest, 1 = previous version, etc.)
+    async fn restore_by_index(&self, file_path: &Path, index: usize) -> Result<()>;
+
+    /// Convenient method to restore previous version
+    async fn restore_previous(&self, file_path: &Path) -> Result<()>;
+
+    /// Gets snapshot metadata by timestamp
+    async fn get_snapshot_by_timestamp(&self, file_path: &Path, timestamp: u64) -> Result<SnapshotMetadata>;
+
+    /// Gets snapshot metadata by index
+    async fn get_snapshot_by_index(&self, file_path: &Path, index: usize) -> Result<SnapshotMetadata>;
+
+    /// Purges snapshots older than the specified number of days
+    async fn purge_older_than(&self, days: u32) -> Result<usize>;
+
+    /// Shows differences between current file and a specific snapshot
+    async fn diff_with_snapshot(&self, file_path: &Path, snapshot: &SnapshotMetadata) -> Result<String>;
+
+    /// Shows differences with previous version
+    async fn diff_with_previous(&self, file_path: &Path) -> Result<String> {
+        let snapshots = self.list_snapshots(file_path).await?;
+        if snapshots.len() < 2 {
+            return Err(SnapshotError::NotFound("No previous version found".to_string()));
+        }
+        let previous = self.get_snapshot_by_index(file_path, 1).await?;
+        self.diff_with_snapshot(file_path, &previous).await
+    }
+}
+
+// Re-export important types
+pub mod prelude {
+    pub use super::{FileSnapshotService, Result, SnapshotError, SnapshotInfo, SnapshotMetadata};
+}
+
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/forge_snapshot/src/service.rs
+++ b/crates/forge_snapshot/src/service.rs
@@ -7,6 +7,7 @@ use sha2::{Sha256, Digest};
 use colored::*;
 use tokio::fs as async_fs;
 use forge_api::{ForgeAPI, API};
+use filetime;
 
 use crate::{FileSnapshotService, Result, SnapshotError, SnapshotInfo, SnapshotMetadata};
 
@@ -55,10 +56,9 @@ impl FileSnapshotServiceImpl {
 
     fn get_snapshot_path(&self, file_path: &Path, timestamp: u64) -> PathBuf {
         let hash = self.hash_path(file_path);
-        let timestamp_secs = timestamp / 1000;
         self.snapshot_dir
             .join(hash)
-            .join(format!("{}.snap", timestamp_secs))
+            .join(format!("{}.snap", timestamp))
     }
 
     async fn ensure_snapshot_dir(&self, file_path: &Path) -> Result<PathBuf> {
@@ -71,6 +71,74 @@ impl FileSnapshotServiceImpl {
     async fn read_snapshot_content(&self, snapshot_path: &Path) -> Result<String> {
         Ok(async_fs::read_to_string(snapshot_path).await?)
     }
+
+    async fn create_snapshot_with_timestamp(&self, file_path: &Path, custom_timestamp: Option<u64>) -> Result<SnapshotInfo> {
+        let content = async_fs::read_to_string(file_path).await?;
+        let now = SystemTime::now();
+        let timestamp_secs = match custom_timestamp {
+            Some(ts) => ts,
+            None => now.duration_since(UNIX_EPOCH)?.as_secs()
+        };
+        
+        // Ensure the snapshot directory exists
+        self.ensure_snapshot_dir(file_path).await?;
+        let snapshot_path = self.get_snapshot_path(file_path, timestamp_secs);
+        
+        // Create parent directories if they don't exist
+        if let Some(parent) = snapshot_path.parent() {
+            async_fs::create_dir_all(parent).await?;
+        }
+        
+        // Write the snapshot content first
+        async_fs::write(&snapshot_path, &content).await?;
+        
+        // Set the file's modification time to match the timestamp
+        let ft = filetime::FileTime::from_unix_time(timestamp_secs as i64, 0);
+        filetime::set_file_mtime(&snapshot_path, ft)?;
+
+        let date = DateTime::<Utc>::from(
+            UNIX_EPOCH + std::time::Duration::from_secs(timestamp_secs)
+        );
+        let hash = self.hash_path(file_path);
+
+        Ok(SnapshotInfo {
+            timestamp: timestamp_secs,
+            date,
+            size: async_fs::metadata(&snapshot_path).await?.len(),
+            path: file_path.to_path_buf(),
+            hash,
+        })
+    }
+
+    async fn enforce_limits(&self, file_path: &Path) -> Result<()> {
+        // First enforce max_snapshots limit
+        if self.max_snapshots > 0 {
+            let mut snapshots = self.list_snapshots(file_path).await?;
+            
+            // Sort by timestamp in descending order to ensure we keep the newest ones
+            snapshots.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            
+            // Keep only the newest snapshots up to max_snapshots
+            if snapshots.len() > self.max_snapshots {
+                // Get the oldest snapshots to remove (everything after max_snapshots)
+                let to_remove = snapshots.split_off(self.max_snapshots);
+                for snapshot in to_remove {
+                    let path = self.get_snapshot_path(&snapshot.path, snapshot.timestamp);
+                    if path.exists() {
+                        println!("Removing old snapshot due to max_snapshots limit: {}", path.display());
+                        async_fs::remove_file(&path).await?;
+                    }
+                }
+            }
+        }
+
+        // Then enforce retention days limit
+        if self.retention_days > 0 {
+            self.purge_older_than(self.retention_days).await?;
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -80,38 +148,9 @@ impl FileSnapshotService for FileSnapshotServiceImpl {
     }
 
     async fn create_snapshot(&self, file_path: &Path) -> Result<SnapshotInfo> {
-        let content = async_fs::read_to_string(file_path).await?;
-        let now = SystemTime::now();
-        let base_timestamp = now.duration_since(UNIX_EPOCH)?
-            .as_secs() as u64;
-        
-        // Add sequence number to ensure uniqueness within the same second
-        let seq = self.sequence.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let timestamp = base_timestamp * 1000 + (seq % 1000);  // Store with millisecond precision internally
-        
-        // Ensure the snapshot directory exists
-        self.ensure_snapshot_dir(file_path).await?;
-        let snapshot_path = self.get_snapshot_path(file_path, timestamp);
-        
-        // Create parent directories if they don't exist
-        if let Some(parent) = snapshot_path.parent() {
-            async_fs::create_dir_all(parent).await?;
-        }
-        
-        // Write the snapshot content
-        async_fs::write(&snapshot_path, &content).await?;
-
-        let metadata = async_fs::metadata(&snapshot_path).await?;
-        let date = DateTime::<Utc>::from(now);
-        let hash = self.hash_path(file_path);
-
-        Ok(SnapshotInfo {
-            timestamp,
-            date,
-            size: metadata.len(),
-            path: file_path.to_path_buf(),
-            hash,
-        })
+        let info = self.create_snapshot_with_timestamp(file_path, None).await?;
+        self.enforce_limits(file_path).await?;
+        Ok(info)
     }
 
     async fn list_snapshots(&self, file_path: &Path) -> Result<Vec<SnapshotInfo>> {
@@ -133,18 +172,12 @@ impl FileSnapshotService for FileSnapshotServiceImpl {
                 if let Some(timestamp_str) = name.strip_suffix(".snap") {
                     if let Ok(timestamp) = timestamp_str.parse::<u64>() {
                         let metadata = async_fs::metadata(&path).await?;
-                        // Convert timestamp to milliseconds if it's in seconds
-                        let timestamp_ms = if timestamp < 32503680000 { // 3000-01-01 in seconds
-                            timestamp * 1000
-                        } else {
-                            timestamp
-                        };
                         let date = DateTime::<Utc>::from(
-                            UNIX_EPOCH + std::time::Duration::from_millis(timestamp_ms)
+                            UNIX_EPOCH + std::time::Duration::from_secs(timestamp)
                         );
 
                         snapshots.push(SnapshotInfo {
-                            timestamp: timestamp_ms,
+                            timestamp,
                             date,
                             size: metadata.len(),
                             path: file_path.to_path_buf(),
@@ -155,6 +188,7 @@ impl FileSnapshotService for FileSnapshotServiceImpl {
             }
         }
 
+        // Sort by timestamp in descending order (newest first)
         snapshots.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         Ok(snapshots)
     }
@@ -224,24 +258,45 @@ impl FileSnapshotService for FileSnapshotServiceImpl {
     async fn purge_older_than(&self, days: u32) -> Result<usize> {
         let mut count = 0;
         let cutoff = SystemTime::now() - std::time::Duration::from_secs(days as u64 * 24 * 60 * 60);
+        let cutoff_ft = filetime::FileTime::from_system_time(cutoff);
+        println!("Checking snapshots older than {} days (cutoff: {:?})", days, cutoff_ft);
+
+        if !self.snapshot_dir.exists() {
+            return Ok(0);
+        }
 
         for entry in fs::read_dir(&self.snapshot_dir)? {
             let entry = entry?;
             let path = entry.path();
             
             if path.is_dir() {
-                for snapshot in fs::read_dir(path)? {
+                println!("Checking directory: {}", path.display());
+                for snapshot in fs::read_dir(&path)? {
                     let snapshot = snapshot?;
-                    let metadata = snapshot.metadata()?;
+                    let metadata = fs::metadata(snapshot.path())?;
+                    let mtime = filetime::FileTime::from_last_modification_time(&metadata);
                     
-                    if metadata.modified()? < cutoff {
-                        fs::remove_file(snapshot.path())?;
-                        count += 1;
+                    println!("Checking snapshot: {} (mtime: {:?}, cutoff: {:?})", 
+                        snapshot.path().display(), mtime, cutoff_ft);
+                    
+                    // Compare timestamps - a snapshot is older if its seconds are less than the cutoff
+                    // or if seconds are equal and nanoseconds are less than or equal
+                    let is_older = mtime.seconds() < cutoff_ft.seconds() || 
+                        (mtime.seconds() == cutoff_ft.seconds() && mtime.nanoseconds() <= cutoff_ft.nanoseconds());
+                    
+                    if is_older {
+                        println!("Purging old snapshot: {} (mtime: {:?})", snapshot.path().display(), mtime);
+                        if let Err(e) = fs::remove_file(snapshot.path()) {
+                            println!("Warning: Failed to remove old snapshot {}: {}", snapshot.path().display(), e);
+                        } else {
+                            count += 1;
+                        }
                     }
                 }
             }
         }
 
+        println!("Purged {} snapshots older than {} days", count, days);
         Ok(count)
     }
 
@@ -303,9 +358,14 @@ mod tests {
     async fn test_snapshot_creation_and_listing() -> anyhow::Result<()> {
         let temp = assert_fs::TempDir::new()?;
         let snapshot_dir = temp.child("snapshots");
+        snapshot_dir.create_dir_all()?;
+        println!("Snapshot directory: {}", snapshot_dir.path().display());
+        
         let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
 
         let test_file = temp.child("test.txt");
+        test_file.touch()?;
+        println!("Test file path: {}", test_file.path().display());
         test_file.write_str("initial content")?;
 
         // Create first snapshot
@@ -339,9 +399,14 @@ mod tests {
     async fn test_restore_by_index() -> anyhow::Result<()> {
         let temp = assert_fs::TempDir::new()?;
         let snapshot_dir = temp.child("snapshots");
+        snapshot_dir.create_dir_all()?;
+        println!("Snapshot directory: {}", snapshot_dir.path().display());
+        
         let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
 
         let test_file = temp.child("test.txt");
+        test_file.touch()?;
+        println!("Test file path: {}", test_file.path().display());
         test_file.write_str("version 1")?;
         let snap1 = service.create_snapshot(test_file.path()).await?;
         println!("Created snapshot 1 with timestamp: {}", snap1.timestamp);
@@ -376,27 +441,55 @@ mod tests {
     async fn test_purge_old_snapshots() -> anyhow::Result<()> {
         let temp = assert_fs::TempDir::new()?;
         let snapshot_dir = temp.child("snapshots");
+        snapshot_dir.create_dir_all()?;
+        println!("Snapshot directory: {}", snapshot_dir.path().display());
+        
         let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
 
         let test_file = temp.child("test.txt");
+        test_file.touch()?;
+        println!("Test file path: {}", test_file.path().display());
         test_file.write_str("old content")?;
         
-        // Create old snapshot
-        let snapshot_path = service.get_snapshot_path(test_file.path(), 1000000);
-        std::fs::create_dir_all(snapshot_path.parent().unwrap())?;
-        std::fs::write(&snapshot_path, "old content")?;
+        // Create old snapshot with timestamp from 31 days ago
+        let old_time = SystemTime::now() - Duration::from_secs(31 * 24 * 60 * 60);
+        let old_timestamp = old_time.duration_since(UNIX_EPOCH)?.as_secs();
+        let snap1 = service.create_snapshot_with_timestamp(test_file.path(), Some(old_timestamp)).await?;
+        let snapshot_path = service.get_snapshot_path(test_file.path(), snap1.timestamp);
+        println!("Created old snapshot at: {}", snapshot_path.display());
         
         // Set old modification time
-        let old_time = std::time::SystemTime::now() - Duration::from_secs(31 * 24 * 60 * 60);
-        filetime::set_file_mtime(&snapshot_path, filetime::FileTime::from_system_time(old_time))?;
+        let old_ft = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(&snapshot_path, old_ft)?;
+        
+        // Verify the modification time was set correctly
+        let metadata = std::fs::metadata(&snapshot_path)?;
+        let actual_mtime = filetime::FileTime::from_last_modification_time(&metadata);
+        println!("Set modification time to 31 days ago: {:?}", actual_mtime);
+        assert!(actual_mtime <= old_ft, "Modification time was not set correctly");
 
-        // Create new snapshot
+        // Create new snapshot without enforcing limits yet
         test_file.write_str("new content")?;
-        service.create_snapshot(test_file.path()).await?;
+        let snap2 = service.create_snapshot_with_timestamp(test_file.path(), None).await?;
+        println!("Created new snapshot at: {}", service.get_snapshot_path(test_file.path(), snap2.timestamp).display());
 
-        // Purge old snapshots
-        let purged = service.purge_older_than(30).await?;
-        assert_eq!(purged, 1);
+        // List snapshots before purge
+        let before_snapshots = service.list_snapshots(test_file.path()).await?;
+        println!("Before purge: {} snapshots", before_snapshots.len());
+
+        // Verify old snapshot still exists
+        assert!(snapshot_path.exists(), "Old snapshot should still exist before purge");
+        
+        // Now enforce limits which should trigger the purge
+        service.enforce_limits(test_file.path()).await?;
+
+        // List snapshots after purge
+        let after_snapshots = service.list_snapshots(test_file.path()).await?;
+        println!("After purge: {} snapshots", after_snapshots.len());
+
+        assert_eq!(after_snapshots.len(), 1, "Should have 1 snapshot remaining");
+        assert_eq!(after_snapshots[0].timestamp, snap2.timestamp, "Remaining snapshot should be the newest one");
+        assert!(!snapshot_path.exists(), "Old snapshot should have been removed");
 
         Ok(())
     }
@@ -405,9 +498,14 @@ mod tests {
     async fn test_diff_with_snapshot() -> anyhow::Result<()> {
         let temp = assert_fs::TempDir::new()?;
         let snapshot_dir = temp.child("snapshots");
+        snapshot_dir.create_dir_all()?;
+        println!("Snapshot directory: {}", snapshot_dir.path().display());
+        
         let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
 
         let test_file = temp.child("test.txt");
+        test_file.touch()?;
+        println!("Test file path: {}", test_file.path().display());
         test_file.write_str("line 1\nline 2\n")?;
         let snapshot = service.create_snapshot(test_file.path()).await?;
         println!("Created snapshot with content:\n{}", async_fs::read_to_string(test_file.path()).await?);
@@ -426,6 +524,69 @@ mod tests {
         let clean_diff = strip_ansi_codes(&diff);
         assert!(clean_diff.contains("-line 2"));
         assert!(clean_diff.contains("+modified line 2"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_limits() -> anyhow::Result<()> {
+        let temp = assert_fs::TempDir::new()?;
+        let snapshot_dir = temp.child("snapshots");
+        snapshot_dir.create_dir_all()?;
+        println!("Snapshot directory: {}", snapshot_dir.path().display());
+        
+        let service = FileSnapshotServiceImpl::with_config(
+            snapshot_dir.path().to_path_buf(),
+            2, // max_snapshots
+            1  // retention_days
+        );
+
+        let test_file = temp.child("test.txt");
+        test_file.touch()?;
+        println!("Test file path: {}", test_file.path().display());
+        
+        // Create first snapshot
+        test_file.write_str("version 1")?;
+        let snap1 = service.create_snapshot_with_timestamp(test_file.path(), None).await?;
+        println!("Created snapshot 1: {}", service.get_snapshot_path(test_file.path(), snap1.timestamp).display());
+        
+        // Create second snapshot
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        test_file.write_str("version 2")?;
+        let snap2 = service.create_snapshot_with_timestamp(test_file.path(), None).await?;
+        println!("Created snapshot 2: {}", service.get_snapshot_path(test_file.path(), snap2.timestamp).display());
+        
+        // Create third snapshot
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        test_file.write_str("version 3")?;
+        let snap3 = service.create_snapshot_with_timestamp(test_file.path(), None).await?;
+        println!("Created snapshot 3: {}", service.get_snapshot_path(test_file.path(), snap3.timestamp).display());
+        
+        // Now enforce limits
+        service.enforce_limits(test_file.path()).await?;
+        
+        let snapshots = service.list_snapshots(test_file.path()).await?;
+        assert_eq!(snapshots.len(), 2, "Should have exactly 2 snapshots due to max_snapshots limit");
+        assert!(snapshots.iter().any(|s| s.timestamp == snap2.timestamp), "Second snapshot should still exist");
+        assert!(snapshots.iter().any(|s| s.timestamp == snap3.timestamp), "Third snapshot should exist");
+        assert!(!snapshots.iter().any(|s| s.timestamp == snap1.timestamp), "First snapshot should be removed");
+
+        // Test retention days by setting old modification time
+        println!("\nSetting old modification time on remaining snapshots:");
+        for snapshot in &snapshots {
+            let path = service.get_snapshot_path(test_file.path(), snapshot.timestamp);
+            println!("Setting old time on: {}", path.display());
+            let old_time = std::time::SystemTime::now() - Duration::from_secs(2 * 24 * 60 * 60);
+            filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(old_time))?;
+        }
+
+        // Create new snapshot - should trigger cleanup of old ones
+        test_file.write_str("version 4")?;
+        let snap4 = service.create_snapshot(test_file.path()).await?;
+        println!("\nCreated final snapshot: {}", service.get_snapshot_path(test_file.path(), snap4.timestamp).display());
+        
+        let final_snapshots = service.list_snapshots(test_file.path()).await?;
+        assert_eq!(final_snapshots.len(), 1, "Should have only the newest snapshot after retention cleanup");
 
         Ok(())
     }

--- a/crates/forge_snapshot/src/service.rs
+++ b/crates/forge_snapshot/src/service.rs
@@ -1,0 +1,437 @@
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sha2::{Sha256, Digest};
+use colored::*;
+use tokio::fs as async_fs;
+use forge_api::{ForgeAPI, API};
+
+use crate::{FileSnapshotService, Result, SnapshotError, SnapshotInfo, SnapshotMetadata};
+
+pub struct FileSnapshotServiceImpl {
+    snapshot_dir: PathBuf,
+    max_snapshots: usize,
+    retention_days: u32,
+    sequence: std::sync::atomic::AtomicU64,
+}
+
+impl FileSnapshotServiceImpl {
+    pub fn new(snapshot_dir: PathBuf) -> Self {
+        Self {
+            snapshot_dir,
+            max_snapshots: 10,
+            retention_days: 30,
+            sequence: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let snapshot_dir = std::env::var("FORGE_SNAPSHOT_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let env = ForgeAPI::init(false).environment();
+                env.base_path.join("snapshots")
+            });
+        
+        Self::new(snapshot_dir)
+    }
+
+    pub fn with_config(snapshot_dir: PathBuf, max_snapshots: usize, retention_days: u32) -> Self {
+        Self {
+            snapshot_dir,
+            max_snapshots,
+            retention_days,
+            sequence: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn hash_path(&self, path: &Path) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(path.to_string_lossy().as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn get_snapshot_path(&self, file_path: &Path, timestamp: u64) -> PathBuf {
+        let hash = self.hash_path(file_path);
+        let timestamp_secs = timestamp / 1000;
+        self.snapshot_dir
+            .join(hash)
+            .join(format!("{}.snap", timestamp_secs))
+    }
+
+    async fn ensure_snapshot_dir(&self, file_path: &Path) -> Result<PathBuf> {
+        let hash = self.hash_path(file_path);
+        let dir = self.snapshot_dir.join(hash);
+        async_fs::create_dir_all(&dir).await?;
+        Ok(dir)
+    }
+
+    async fn read_snapshot_content(&self, snapshot_path: &Path) -> Result<String> {
+        Ok(async_fs::read_to_string(snapshot_path).await?)
+    }
+}
+
+#[async_trait]
+impl FileSnapshotService for FileSnapshotServiceImpl {
+    fn snapshot_dir(&self) -> PathBuf {
+        self.snapshot_dir.clone()
+    }
+
+    async fn create_snapshot(&self, file_path: &Path) -> Result<SnapshotInfo> {
+        let content = async_fs::read_to_string(file_path).await?;
+        let now = SystemTime::now();
+        let base_timestamp = now.duration_since(UNIX_EPOCH)?
+            .as_secs() as u64;
+        
+        // Add sequence number to ensure uniqueness within the same second
+        let seq = self.sequence.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let timestamp = base_timestamp * 1000 + (seq % 1000);  // Store with millisecond precision internally
+        
+        // Ensure the snapshot directory exists
+        self.ensure_snapshot_dir(file_path).await?;
+        let snapshot_path = self.get_snapshot_path(file_path, timestamp);
+        
+        // Create parent directories if they don't exist
+        if let Some(parent) = snapshot_path.parent() {
+            async_fs::create_dir_all(parent).await?;
+        }
+        
+        // Write the snapshot content
+        async_fs::write(&snapshot_path, &content).await?;
+
+        let metadata = async_fs::metadata(&snapshot_path).await?;
+        let date = DateTime::<Utc>::from(now);
+        let hash = self.hash_path(file_path);
+
+        Ok(SnapshotInfo {
+            timestamp,
+            date,
+            size: metadata.len(),
+            path: file_path.to_path_buf(),
+            hash,
+        })
+    }
+
+    async fn list_snapshots(&self, file_path: &Path) -> Result<Vec<SnapshotInfo>> {
+        let hash = self.hash_path(file_path);
+        let dir = self.snapshot_dir.join(&hash);
+        
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut snapshots = Vec::new();
+        let mut entries = fs::read_dir(&dir)?;
+
+        while let Some(entry) = entries.next() {
+            let entry = entry?;
+            let path = entry.path();
+            
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if let Some(timestamp_str) = name.strip_suffix(".snap") {
+                    if let Ok(timestamp) = timestamp_str.parse::<u64>() {
+                        let metadata = async_fs::metadata(&path).await?;
+                        // Convert timestamp to milliseconds if it's in seconds
+                        let timestamp_ms = if timestamp < 32503680000 { // 3000-01-01 in seconds
+                            timestamp * 1000
+                        } else {
+                            timestamp
+                        };
+                        let date = DateTime::<Utc>::from(
+                            UNIX_EPOCH + std::time::Duration::from_millis(timestamp_ms)
+                        );
+
+                        snapshots.push(SnapshotInfo {
+                            timestamp: timestamp_ms,
+                            date,
+                            size: metadata.len(),
+                            path: file_path.to_path_buf(),
+                            hash: hash.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        snapshots.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        Ok(snapshots)
+    }
+
+    async fn restore_by_timestamp(&self, file_path: &Path, timestamp: u64) -> Result<()> {
+        // Convert timestamp to seconds for file lookup
+        let timestamp_secs = timestamp / 1000;
+        let snapshot_path = self.get_snapshot_path(file_path, timestamp);
+        
+        if !snapshot_path.exists() {
+            return Err(SnapshotError::NotFound(format!(
+                "No snapshot found for timestamp {}",
+                timestamp_secs
+            )));
+        }
+
+        let content = self.read_snapshot_content(&snapshot_path).await?;
+        async_fs::write(file_path, content).await?;
+        Ok(())
+    }
+
+    async fn restore_by_index(&self, file_path: &Path, index: usize) -> Result<()> {
+        let snapshots = self.list_snapshots(file_path).await?;
+        let snapshot = snapshots.get(index).ok_or_else(|| {
+            SnapshotError::NotFound(format!("No snapshot found at index {}", index))
+        })?;
+
+        self.restore_by_timestamp(file_path, snapshot.timestamp).await
+    }
+
+    async fn get_snapshot_by_timestamp(&self, file_path: &Path, timestamp: u64) -> Result<SnapshotMetadata> {
+        let snapshot_path = self.get_snapshot_path(file_path, timestamp);
+        if !snapshot_path.exists() {
+            return Err(SnapshotError::NotFound(format!(
+                "No snapshot found for timestamp {}",
+                timestamp
+            )));
+        }
+
+        let metadata = async_fs::metadata(&snapshot_path).await?;
+        let date = DateTime::<Utc>::from(
+            UNIX_EPOCH + std::time::Duration::from_millis(timestamp)
+        );
+
+        Ok(SnapshotMetadata {
+            info: SnapshotInfo {
+                timestamp,
+                date,
+                size: metadata.len(),
+                path: file_path.to_path_buf(),
+                hash: self.hash_path(file_path),
+            },
+            original_path: file_path.to_path_buf(),
+            snapshot_path,
+        })
+    }
+
+    async fn get_snapshot_by_index(&self, file_path: &Path, index: usize) -> Result<SnapshotMetadata> {
+        let snapshots = self.list_snapshots(file_path).await?;
+        let snapshot = snapshots.get(index).ok_or_else(|| {
+            SnapshotError::NotFound(format!("No snapshot found at index {}", index))
+        })?;
+
+        self.get_snapshot_by_timestamp(file_path, snapshot.timestamp).await
+    }
+
+    async fn purge_older_than(&self, days: u32) -> Result<usize> {
+        let mut count = 0;
+        let cutoff = SystemTime::now() - std::time::Duration::from_secs(days as u64 * 24 * 60 * 60);
+
+        for entry in fs::read_dir(&self.snapshot_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            
+            if path.is_dir() {
+                for snapshot in fs::read_dir(path)? {
+                    let snapshot = snapshot?;
+                    let metadata = snapshot.metadata()?;
+                    
+                    if metadata.modified()? < cutoff {
+                        fs::remove_file(snapshot.path())?;
+                        count += 1;
+                    }
+                }
+            }
+        }
+
+        Ok(count)
+    }
+
+    async fn diff_with_snapshot(&self, file_path: &Path, snapshot: &SnapshotMetadata) -> Result<String> {
+        let current = async_fs::read_to_string(file_path).await?;
+        let previous = self.read_snapshot_content(&snapshot.snapshot_path).await?;
+
+        let mut config = similar::TextDiffConfig::default();
+        let config = config.algorithm(similar::Algorithm::Patience);
+        let diff_config = config.timeout(std::time::Duration::from_secs(1));
+            
+        let diff = diff_config.diff_lines(&previous, &current);
+        let mut result = String::new();
+
+        result.push_str(&format!("--- {} ({})\n", file_path.display(), snapshot.info.date));
+        result.push_str(&format!("+++ {} (current)\n", file_path.display()));
+
+        for group in diff.grouped_ops(3) {
+            let line_old = group.first().unwrap().old_range().start;
+            let line_new = group.first().unwrap().new_range().start;
+
+            // Print group header
+            result.push_str(&format!("@@ -{},{} +{},{} @@\n",
+                line_old + 1,
+                group.iter().map(|op| op.old_range().len()).sum::<usize>(),
+                line_new + 1,
+                group.iter().map(|op| op.new_range().len()).sum::<usize>()
+            ));
+
+            for op in group {
+                for old_index in op.old_range() {
+                    if let Some(line) = previous.lines().nth(old_index) {
+                        result.push_str(&format!("-{}\n", line.trim_end().red()));
+                    }
+                }
+                for new_index in op.new_range() {
+                    if let Some(line) = current.lines().nth(new_index) {
+                        result.push_str(&format!("+{}\n", line.trim_end().green()));
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn restore_previous(&self, file_path: &Path) -> Result<()> {
+        self.restore_by_index(file_path, 1).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::prelude::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_snapshot_creation_and_listing() -> anyhow::Result<()> {
+        let temp = assert_fs::TempDir::new()?;
+        let snapshot_dir = temp.child("snapshots");
+        let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
+
+        let test_file = temp.child("test.txt");
+        test_file.write_str("initial content")?;
+
+        // Create first snapshot
+        let snapshot1 = service.create_snapshot(test_file.path()).await?;
+        println!("Created first snapshot with timestamp: {}", snapshot1.timestamp);
+        
+        // Modify file and wait to ensure different timestamp
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        test_file.write_str("modified content")?;
+        
+        // Create second snapshot
+        let snapshot2 = service.create_snapshot(test_file.path()).await?;
+        println!("Created second snapshot with timestamp: {}", snapshot2.timestamp);
+
+        // List snapshots
+        let snapshots = service.list_snapshots(test_file.path()).await?;
+        println!("Found {} snapshots", snapshots.len());
+        for (i, snap) in snapshots.iter().enumerate() {
+            println!("Snapshot {}: timestamp {}", i, snap.timestamp);
+        }
+
+        assert_eq!(snapshots.len(), 2, "Expected 2 snapshots");
+        assert!(snapshots[0].timestamp > snapshots[1].timestamp, "Latest snapshot should have higher timestamp");
+        assert_eq!(snapshots[0].timestamp / 1000, snapshot2.timestamp / 1000, "Latest snapshot timestamp mismatch");
+        assert_eq!(snapshots[1].timestamp / 1000, snapshot1.timestamp / 1000, "First snapshot timestamp mismatch");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_restore_by_index() -> anyhow::Result<()> {
+        let temp = assert_fs::TempDir::new()?;
+        let snapshot_dir = temp.child("snapshots");
+        let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
+
+        let test_file = temp.child("test.txt");
+        test_file.write_str("version 1")?;
+        let snap1 = service.create_snapshot(test_file.path()).await?;
+        println!("Created snapshot 1 with timestamp: {}", snap1.timestamp);
+
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        test_file.write_str("version 2")?;
+        let snap2 = service.create_snapshot(test_file.path()).await?;
+        println!("Created snapshot 2 with timestamp: {}", snap2.timestamp);
+
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        test_file.write_str("version 3")?;
+        let snap3 = service.create_snapshot(test_file.path()).await?;
+        println!("Created snapshot 3 with timestamp: {}", snap3.timestamp);
+
+        // List snapshots before restore
+        let snapshots = service.list_snapshots(test_file.path()).await?;
+        println!("Found {} snapshots before restore", snapshots.len());
+        for (i, snap) in snapshots.iter().enumerate() {
+            println!("Snapshot {}: timestamp {}", i, snap.timestamp);
+        }
+
+        // Restore to version 2
+        service.restore_by_index(test_file.path(), 1).await?;
+        let content = async_fs::read_to_string(test_file.path()).await?;
+        println!("Restored content: {}", content);
+        assert_eq!(content, "version 2", "Restored content should match version 2");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_purge_old_snapshots() -> anyhow::Result<()> {
+        let temp = assert_fs::TempDir::new()?;
+        let snapshot_dir = temp.child("snapshots");
+        let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
+
+        let test_file = temp.child("test.txt");
+        test_file.write_str("old content")?;
+        
+        // Create old snapshot
+        let snapshot_path = service.get_snapshot_path(test_file.path(), 1000000);
+        std::fs::create_dir_all(snapshot_path.parent().unwrap())?;
+        std::fs::write(&snapshot_path, "old content")?;
+        
+        // Set old modification time
+        let old_time = std::time::SystemTime::now() - Duration::from_secs(31 * 24 * 60 * 60);
+        filetime::set_file_mtime(&snapshot_path, filetime::FileTime::from_system_time(old_time))?;
+
+        // Create new snapshot
+        test_file.write_str("new content")?;
+        service.create_snapshot(test_file.path()).await?;
+
+        // Purge old snapshots
+        let purged = service.purge_older_than(30).await?;
+        assert_eq!(purged, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_diff_with_snapshot() -> anyhow::Result<()> {
+        let temp = assert_fs::TempDir::new()?;
+        let snapshot_dir = temp.child("snapshots");
+        let service = FileSnapshotServiceImpl::new(snapshot_dir.path().to_path_buf());
+
+        let test_file = temp.child("test.txt");
+        test_file.write_str("line 1\nline 2\n")?;
+        let snapshot = service.create_snapshot(test_file.path()).await?;
+        println!("Created snapshot with content:\n{}", async_fs::read_to_string(test_file.path()).await?);
+
+        // Get the metadata before modifying the file
+        let metadata = service.get_snapshot_by_timestamp(test_file.path(), snapshot.timestamp).await?;
+
+        // Now modify the file
+        test_file.write_str("line 1\nmodified line 2\n")?;
+        println!("Modified content:\n{}", async_fs::read_to_string(test_file.path()).await?);
+
+        let diff = service.diff_with_snapshot(test_file.path(), &metadata).await?;
+        println!("Diff output:\n{}", diff);
+        
+        // Strip ANSI color codes for comparison
+        let clean_diff = strip_ansi_codes(&diff);
+        assert!(clean_diff.contains("-line 2"));
+        assert!(clean_diff.contains("+modified line 2"));
+
+        Ok(())
+    }
+
+    fn strip_ansi_codes(s: &str) -> String {
+        let re = regex::Regex::new(r"\x1B\[[0-9;]*[mK]").unwrap();
+        re.replace_all(s, "").to_string()
+    }
+} 


### PR DESCRIPTION
Fixes: #432 
/claim #432 

```shell
forge on  feat/file-snapshot-system [$!+?] via 🦀 1.86.0 using ☁️  default/heavenya via browser-use 
➜ ./test_snapshot.sh                                                            
Testing forge snapshot features...

Cleaning up existing snapshots...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.82s
     Running `target/debug/forge snapshot purge --older-than=0`
Checking snapshots older than 0 days (cutoff: FileTime { seconds: 1741112744, nanos: 843987000 })
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/b627da53f03fd71618b20438f41f888aab2708e5422e8c555781ac2e6a9d96b1
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112581.snap (mtime: FileTime { seconds: 1741112581, nanos: 0 }, cutoff: FileTime { seconds: 1741112744, nanos: 843987000 })
Purging old snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112581.snap (mtime: FileTime { seconds: 1741112581, nanos: 0 })
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112586.snap (mtime: FileTime { seconds: 1741112586, nanos: 0 }, cutoff: FileTime { seconds: 1741112744, nanos: 843987000 })
Purging old snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112586.snap (mtime: FileTime { seconds: 1741112586, nanos: 0 })
Purged 2 snapshots older than 0 days
Purged 2 snapshots older than 0 days

1. Creating initial snapshot...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/forge snapshot create test_files/test.rs`
Checking snapshots older than 30 days (cutoff: FileTime { seconds: 1738520746, nanos: 899860000 })
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/b627da53f03fd71618b20438f41f888aab2708e5422e8c555781ac2e6a9d96b1
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112746.snap (mtime: FileTime { seconds: 1741112746, nanos: 0 }, cutoff: FileTime { seconds: 1738520746, nanos: 899860000 })
Purged 0 snapshots older than 30 days
Created snapshot at 2025-03-04 19:25:46 (1741112746)

2. Creating second snapshot...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
     Running `target/debug/forge snapshot create test_files/test.rs`
Checking snapshots older than 30 days (cutoff: FileTime { seconds: 1738520751, nanos: 258079000 })
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/b627da53f03fd71618b20438f41f888aab2708e5422e8c555781ac2e6a9d96b1
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112746.snap (mtime: FileTime { seconds: 1741112746, nanos: 0 }, cutoff: FileTime { seconds: 1738520751, nanos: 258079000 })
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112751.snap (mtime: FileTime { seconds: 1741112751, nanos: 0 }, cutoff: FileTime { seconds: 1738520751, nanos: 258079000 })
Purged 0 snapshots older than 30 days
Created snapshot at 2025-03-04 19:25:51 (1741112751)

3. Listing all snapshots...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/forge snapshot list test_files/test.rs`
INDEX  TIMESTAMP    DATE                SIZE
0       1741112751   2025-03-04 19:25     0.4K   (current)
1       1741112746   2025-03-04 19:25     0.2K

4. Testing restore by index...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/forge snapshot restore test_files/test.rs --index=1`
File restored successfully

Content after restore to first version:
fn main() {
    // Initial implementation
    let greeting = "Hello";
    let name = "world";
    println!("{}, {}!", greeting, name);
    
    // TODO: Add more features
    let version = 1.0;
    println!("Version: {}", version);
}
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/forge snapshot restore test_files/test.rs --index=0`
File restored successfully

Content after restore to second version:
fn main() {
    // Updated implementation with new features
    let greeting = "Welcome";
    let name = "Rust developer";
    println!("{}, {}!", greeting, name);
    
    // Added new features
    let version = 2.0;
    let status = "stable";
    println!("Version: {} ({})", version, status);
    
    // Added error handling
    if version > 1.0 {
        println!("New version detected!");
    }
}

5. Testing diff with previous version...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
     Running `target/debug/forge snapshot diff test_files/test.rs --previous`
--- test_files/test.rs (current)
+++ test_files/test.rs (2025-03-04 18:25:46 UTC)
@@ -1,10 +1,16 @@
-fn main() {
+fn main() {
-    // Initial implementation
-    let greeting = "Hello";
-    let name = "world";
+    // Updated implementation with new features
+    let greeting = "Welcome";
+    let name = "Rust developer";
-    println!("{}, {}!", greeting, name);
-
+    println!("{}, {}!", greeting, name);
+
-    // TODO: Add more features
-    let version = 1.0;
-    println!("Version: {}", version);
+    // Added new features
+    let version = 2.0;
+    let status = "stable";
+    println!("Version: {} ({})", version, status);
+
+    // Added error handling
+    if version > 1.0 {
+        println!("New version detected!");
+    }
-}
+}


6. Testing purge with default (30 days)...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/forge snapshot purge`
Checking snapshots older than 30 days (cutoff: FileTime { seconds: 1738520763, nanos: 841773000 })
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/b627da53f03fd71618b20438f41f888aab2708e5422e8c555781ac2e6a9d96b1
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112746.snap (mtime: FileTime { seconds: 1741112746, nanos: 0 }, cutoff: FileTime { seconds: 1738520763, nanos: 841773000 })
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112751.snap (mtime: FileTime { seconds: 1741112751, nanos: 0 }, cutoff: FileTime { seconds: 1738520763, nanos: 841773000 })
Purged 0 snapshots older than 30 days
Purged 0 snapshots older than 30 days

7. Testing purge with specific days...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/forge snapshot purge --older-than=60`
Checking snapshots older than 60 days (cutoff: FileTime { seconds: 1735928765, nanos: 889155000 })
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/b627da53f03fd71618b20438f41f888aab2708e5422e8c555781ac2e6a9d96b1
Checking directory: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112746.snap (mtime: FileTime { seconds: 1741112746, nanos: 0 }, cutoff: FileTime { seconds: 1735928765, nanos: 889155000 })
Checking snapshot: /Users/onyedikachi/Library/Application Support/forge/snapshots/bfbd6758b2ffec5830f7537c0ab09a4cc614a53b5d3865cfa8bb4d3eb6be3594/1741112751.snap (mtime: FileTime { seconds: 1741112751, nanos: 0 }, cutoff: FileTime { seconds: 1735928765, nanos: 889155000 })
Purged 0 snapshots older than 60 days
Purged 0 snapshots older than 60 days

Cleaning up test files...

All tests completed!

forge on  feat/file-snapshot-system [⇡$!?] via 🦀 1.86.0 using ☁️  default/heavenya via browser-use took 23.7s 
➜ 
``` 


Test file:

```shell
#!/bin/bash
export RUSTFLAGS="-A warnings"
echo "Testing forge snapshot features..."

# Clean up existing snapshots first
echo -e "\nCleaning up existing snapshots..."
cargo run --bin forge snapshot purge --older-than=0

# Create test directory if it doesn't exist
TEST_DIR="test_files"
mkdir -p $TEST_DIR

# Create initial Rust file with a more complex example
echo 'fn main() {
    // Initial implementation
    let greeting = "Hello";
    let name = "world";
    println!("{}, {}!", greeting, name);
    
    // TODO: Add more features
    let version = 1.0;
    println!("Version: {}", version);
}' > $TEST_DIR/test.rs

echo -e "\n1. Creating initial snapshot..."
cargo run --bin forge snapshot create $TEST_DIR/test.rs
sleep 2  # Ensure timestamps are different

# Modify the file with more significant changes
echo 'fn main() {
    // Updated implementation with new features
    let greeting = "Welcome";
    let name = "Rust developer";
    println!("{}, {}!", greeting, name);
    
    // Added new features
    let version = 2.0;
    let status = "stable";
    println!("Version: {} ({})", version, status);
    
    // Added error handling
    if version > 1.0 {
        println!("New version detected!");
    }
}' > $TEST_DIR/test.rs

echo -e "\n2. Creating second snapshot..."
cargo run --bin forge snapshot create $TEST_DIR/test.rs
sleep 2  # Ensure timestamps are different

echo -e "\n3. Listing all snapshots..."
cargo run --bin forge snapshot list $TEST_DIR/test.rs

echo -e "\n4. Testing restore by index..."
cargo run --bin forge snapshot restore $TEST_DIR/test.rs --index=1
echo -e "\nContent after restore to first version:"
cat $TEST_DIR/test.rs

# Restore to second version for diff test
cargo run --bin forge snapshot restore $TEST_DIR/test.rs --index=0
echo -e "\nContent after restore to second version:"
cat $TEST_DIR/test.rs

echo -e "\n5. Testing diff with previous version..."
cargo run --bin forge snapshot diff $TEST_DIR/test.rs --previous

echo -e "\n6. Testing purge with default (30 days)..."
cargo run --bin forge snapshot purge

echo -e "\n7. Testing purge with specific days..."
cargo run --bin forge snapshot purge --older-than=60

echo -e "\nCleaning up test files..."
rm -rf $TEST_DIR

echo -e "\nAll tests completed!"
``` 