### PR TITLE
fix: separate default forge config from user config

### DIFF
--- a/crates/forge_api/src/loader.rs
+++ b/crates/forge_api/src/loader.rs
@@ -6,7 +6,7 @@ use forge_app::{FileReadService, Infrastructure};
 use forge_domain::Workflow;
 
 // Default forge.yaml content embedded in the binary
-const DEFAULT_FORGE_WORKFLOW: &str = include_str!("../../../forge.yaml");
+const DEFAULT_FORGE_WORKFLOW: &str = include_str!("../../../forge.default.yaml");
 
 /// A workflow loader to load the workflow from the given path.
 /// It also resolves the internal paths specified in the workflow.

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -28,7 +28,7 @@ agents:
       - user_task_init
       - user_task_update
     ephemeral: false
-    max_walker_depth: 1024
+    max_walker_depth: 4
     system_prompt: "{{> system-prompt-engineer.hbs }}"
     user_prompt: |
       <task>{{event.value}}</task>


### PR DESCRIPTION
## Changes
- Move default configuration to forge.default.yaml 
- Update loader to reference forge.default.yaml instead of forge.yaml
- Add max_walker_depth parameter to software-engineer agent

This PR separates the default config from the user config, making it easier to manage user-specific configuration without affecting the embedded default configuration.