### PR TITLE
Optimize logging for JSON format

### DIFF
--- a/crates/forge_tracker/src/log.rs
+++ b/crates/forge_tracker/src/log.rs
@@ -6,13 +6,13 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{self};
 
 pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
-    debug!(path = %log_path.display(), "Initializing logging system");
+    debug!(path = %log_path.display(), "Initializing logging system in JSON format");
 
     let append = tracing_appender::rolling::daily(log_path, "forge.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(append);
 
     tracing_subscriber::fmt()
-        .pretty()
+        .json()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_env("FORGE_LOG")
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("forge=debug")),
@@ -27,7 +27,7 @@ pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
         .with_writer(non_blocking)
         .init();
 
-    debug!("Logging system initialized successfully");
+    debug!("JSON logging system initialized successfully");
     Ok(Guard(guard))
 }
 


### PR DESCRIPTION
This PR updates the logging system in forge_tracker to use JSON format instead of pretty-printing. This change makes logs more machine-readable and easier to parse by log analysis tools.\n\nChanges:\n- Replace pretty-print formatter with JSON formatter\n- Update log messages to indicate JSON formatting\n- Maintain all existing log fields and functionality