### PR TITLE
Integrate logs with PostHog

### DIFF
--- a/crates/forge_tracker/src/event.rs
+++ b/crates/forge_tracker/src/event.rs
@@ -47,6 +47,7 @@ pub enum EventKind {
     Start,
     Ping,
     Prompt(String),
+    Log(String),
 }
 
 impl EventKind {
@@ -55,6 +56,7 @@ impl EventKind {
             Self::Start => Name::from("start".to_string()),
             Self::Ping => Name::from("ping".to_string()),
             Self::Prompt(_) => Name::from("prompt".to_string()),
+            Self::Log(_) => Name::from("log".to_string()),
         }
     }
     pub fn value(&self) -> String {
@@ -62,6 +64,7 @@ impl EventKind {
             Self::Start => "".to_string(),
             Self::Ping => "".to_string(),
             Self::Prompt(content) => content.to_string(),
+            Self::Log(content) => content.to_string(),
         }
     }
 }

--- a/crates/forge_tracker/src/lib.rs
+++ b/crates/forge_tracker/src/lib.rs
@@ -4,8 +4,12 @@ mod dispatch;
 mod error;
 mod event;
 mod log;
+mod log_posthog;
+#[cfg(test)]
+mod log_posthog_tests;
 pub use can_track::VERSION;
 pub use dispatch::Tracker;
 use error::Result;
 pub use event::{Event, EventKind};
-pub use log::{init_tracing, Guard};
+pub use log::{init_tracing, init_tracing_with_posthog, Guard};
+pub use log_posthog::PosthogLayer;

--- a/crates/forge_tracker/src/log.rs
+++ b/crates/forge_tracker/src/log.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use tracing::debug;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{self};
 
 pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
@@ -28,6 +30,37 @@ pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
         .init();
 
     debug!("JSON logging system initialized successfully");
+    Ok(Guard(guard))
+}
+
+pub fn init_tracing_with_posthog(log_path: PathBuf, tracker: &'static crate::Tracker) -> anyhow::Result<Guard> {
+    debug!(path = %log_path.display(), "Initializing logging system with PostHog integration");
+
+    let append = tracing_appender::rolling::daily(log_path, "forge.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(append);
+
+    let posthog_layer = crate::PosthogLayer::new(tracker, tracing::Level::INFO);
+
+    tracing_subscriber::registry()
+        .with(posthog_layer)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_timer(tracing_subscriber::fmt::time::uptime())
+                .with_thread_ids(false)
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_ansi(true)
+                .with_writer(non_blocking),
+        )
+        .with(
+            tracing_subscriber::EnvFilter::try_from_env("FORGE_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("forge=debug")),
+        )
+        .init();
+
+    debug!("Logging system with PostHog integration initialized successfully");
     Ok(Guard(guard))
 }
 

--- a/crates/forge_tracker/src/log.rs
+++ b/crates/forge_tracker/src/log.rs
@@ -6,13 +6,13 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{self};
 
 pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
-    debug!(path = %log_path.display(), "Initializing logging system");
+    debug!(path = %log_path.display(), "Initializing logging system in JSON format");
 
     let append = tracing_appender::rolling::daily(log_path, "forge.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(append);
 
     tracing_subscriber::fmt()
-        .pretty()
+        .json()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_env("FORGE_LOG")
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("forge=debug")),
@@ -27,7 +27,7 @@ pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
         .with_writer(non_blocking)
         .init();
 
-    debug!("Logging system initialized successfully");
+    debug!("JSON logging system initialized successfully");
     Ok(Guard(guard))
 }
 

--- a/crates/forge_tracker/src/log.rs
+++ b/crates/forge_tracker/src/log.rs
@@ -33,7 +33,10 @@ pub fn init_tracing(log_path: PathBuf) -> anyhow::Result<Guard> {
     Ok(Guard(guard))
 }
 
-pub fn init_tracing_with_posthog(log_path: PathBuf, tracker: &'static crate::Tracker) -> anyhow::Result<Guard> {
+pub fn init_tracing_with_posthog(
+    log_path: PathBuf,
+    tracker: &'static crate::Tracker,
+) -> anyhow::Result<Guard> {
     debug!(path = %log_path.display(), "Initializing logging system with PostHog integration");
 
     let append = tracing_appender::rolling::daily(log_path, "forge.log");

--- a/crates/forge_tracker/src/log_posthog.rs
+++ b/crates/forge_tracker/src/log_posthog.rs
@@ -1,0 +1,109 @@
+use tracing::{Event, Level, Subscriber};
+use tracing::span::{Attributes, Id, Record};
+use tracing_subscriber::layer::{Context, Layer};
+use crate::{Tracker, EventKind};
+use serde_json::json;
+
+/// A tracing layer that forwards log events to PostHog
+pub struct PosthogLayer {
+    tracker: &'static Tracker,
+    min_level: Level,
+}
+
+impl PosthogLayer {
+    pub fn new(
+        tracker: &'static Tracker, 
+        min_level: Level,
+    ) -> Self {
+        Self { 
+            tracker, 
+            min_level,
+        }
+    }
+}
+
+impl<S> Layer<S> for PosthogLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        // Extract metadata
+        let meta = event.metadata();
+        let level = *meta.level();
+        
+        // Skip events below the minimum level
+        if level < self.min_level {
+            return;
+        }
+
+        // Extract basic information about the event
+        let target = meta.target();
+        let file = meta.file();
+        let line = meta.line();
+        let module_path = meta.module_path();
+
+        // Capture field values
+        let mut visitor = JsonVisitor::default();
+        event.record(&mut visitor);
+        let fields = visitor.fields;
+
+        // Create a JSON representation of the log event
+        let log_data = json!({
+            "level": level.as_str(),
+            "target": target,
+            "file": file,
+            "line": line,
+            "module_path": module_path,
+            "fields": fields,
+        });
+        
+        // Dispatch to PostHog
+        // We're using fire-and-forget since we don't want logging to be blocking
+        let tracker = self.tracker;
+        let log_str = log_data.to_string();
+        tokio::spawn(async move {
+            let _ = tracker.dispatch(EventKind::Log(log_str)).await;
+        });
+    }
+
+    // We don't need to implement span-related methods for basic logging
+    fn on_new_span(&self, _: &Attributes<'_>, _: &Id, _: Context<'_, S>) {}
+    fn on_record(&self, _: &Id, _: &Record<'_>, _: Context<'_, S>) {}
+    fn on_follows_from(&self, _: &Id, _: &Id, _: Context<'_, S>) {}
+    fn on_close(&self, _: Id, _: Context<'_, S>) {}
+    fn on_enter(&self, _: &Id, _: Context<'_, S>) {}
+    fn on_exit(&self, _: &Id, _: Context<'_, S>) {}
+}
+
+/// Custom visitor to collect field values as JSON
+#[derive(Default)]
+struct JsonVisitor {
+    fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl tracing::field::Visit for JsonVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        let value = format!("{:?}", value);
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_error(&mut self, field: &tracing::field::Field, value: &(dyn std::error::Error + 'static)) {
+        self.fields.insert(field.name().to_string(), json!(value.to_string()));
+    }
+}

--- a/crates/forge_tracker/src/log_posthog_tests.rs
+++ b/crates/forge_tracker/src/log_posthog_tests.rs
@@ -1,30 +1,34 @@
 #[cfg(test)]
 mod tests {
-    use crate::{init_tracing_with_posthog, Tracker, EventKind};
-    use tracing::{info, debug, warn, error};
+    use tracing::{debug, error, info, warn};
+
+    use crate::{init_tracing_with_posthog, EventKind, Tracker};
 
     #[tokio::test]
     async fn test_posthog_logging() {
         let tracker = Box::leak(Box::new(Tracker::default()));
-        
+
         // Create a temporary directory for logs
         let log_path = std::env::temp_dir();
-        
+
         // Initialize tracing with PostHog integration
         let _guard = init_tracing_with_posthog(log_path, tracker).unwrap();
-        
+
         // Generate some log events at different levels
         debug!("This is a debug message");
         info!("This is an info message");
         warn!("This is a warning message with data: {}", 42);
         error!("This is an error message: {}", "test error");
-        
+
         // Manually dispatch an event
-        let _ = tracker.dispatch(EventKind::Prompt("test prompt".to_string())).await;
-        
+        let _ = tracker
+            .dispatch(EventKind::Prompt("test prompt".to_string()))
+            .await;
+
         // Sleep briefly to allow async processing
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
-        // We can't easily assert on PostHog events in tests, but this ensures the code paths are exercised
+
+        // We can't easily assert on PostHog events in tests, but this ensures
+        // the code paths are exercised
     }
 }

--- a/crates/forge_tracker/src/log_posthog_tests.rs
+++ b/crates/forge_tracker/src/log_posthog_tests.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod tests {
+    use crate::{init_tracing_with_posthog, Tracker, EventKind};
+    use tracing::{info, debug, warn, error};
+
+    #[tokio::test]
+    async fn test_posthog_logging() {
+        let tracker = Box::leak(Box::new(Tracker::default()));
+        
+        // Create a temporary directory for logs
+        let log_path = std::env::temp_dir();
+        
+        // Initialize tracing with PostHog integration
+        let _guard = init_tracing_with_posthog(log_path, tracker).unwrap();
+        
+        // Generate some log events at different levels
+        debug!("This is a debug message");
+        info!("This is an info message");
+        warn!("This is a warning message with data: {}", 42);
+        error!("This is an error message: {}", "test error");
+        
+        // Manually dispatch an event
+        let _ = tracker.dispatch(EventKind::Prompt("test prompt".to_string())).await;
+        
+        // Sleep briefly to allow async processing
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        
+        // We can't easily assert on PostHog events in tests, but this ensures the code paths are exercised
+    }
+}


### PR DESCRIPTION
This PR integrates the logging system with PostHog, allowing logs to be sent to PostHog for analysis.\n\nChanges:\n- Add a PostHog tracing layer that forwards logs to PostHog\n- Add new EventKind::Log for tracking log events\n- Implement init_tracing_with_posthog function\n- Add tests for PostHog logging integration