### PR TITLE
feat: add help command mode with dedicated help agent

### DIFF
--- a/crates/forge_app/src/template.rs
+++ b/crates/forge_app/src/template.rs
@@ -12,6 +12,9 @@ use tracing::debug;
 
 use crate::{EmbeddingService, EnvironmentService, Infrastructure, VectorIndex};
 
+// Include README.md at compile time
+const README_CONTENT: &str = include_str!("../../../README.md");
+
 #[derive(Embed)]
 #[folder = "../../templates/"]
 struct Templates;
@@ -31,7 +34,11 @@ impl<F, T> ForgeTemplateService<F, T> {
         // Register all partial templates
         hb.register_embed_templates::<Templates>().unwrap();
 
-        Self { hb, infra, tool_service }
+        Self { 
+            hb, 
+            infra, 
+            tool_service,
+        }
     }
 }
 
@@ -61,14 +68,18 @@ impl<F: Infrastructure, T: ToolService> TemplateService for ForgeTemplateService
         // Sort the files alphabetically to ensure consistent ordering
         files.sort();
 
+        // Create the context with README content for all agents
         let ctx = SystemContext {
             env: Some(env),
             tool_information: Some(self.tool_service.usage_prompt()),
             tool_supported: agent.tool_supported,
             files,
+            readme: README_CONTENT.to_string(),
         };
 
-        Ok(self.hb.render_template(prompt.template.as_str(), &ctx)?)
+        // Render the template with the context
+        let result = self.hb.render_template(prompt.template.as_str(), &ctx)?;
+        Ok(result)
     }
 
     async fn render_event(

--- a/crates/forge_app/src/template.rs
+++ b/crates/forge_app/src/template.rs
@@ -34,11 +34,7 @@ impl<F, T> ForgeTemplateService<F, T> {
         // Register all partial templates
         hb.register_embed_templates::<Templates>().unwrap();
 
-        Self { 
-            hb, 
-            infra, 
-            tool_service,
-        }
+        Self { hb, infra, tool_service }
     }
 }
 

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -18,6 +18,7 @@ pub struct SystemContext {
     pub tool_supported: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub files: Vec<String>,
+    pub readme: String,
 }
 
 #[derive(Debug, Display, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -77,6 +77,9 @@ pub enum Command {
     /// Switch to "plan" mode.
     /// This can be triggered with the '/plan' command.
     Plan,
+    /// Switch to "help" mode.
+    /// This can be triggered with the '/help' command.
+    Help,
     /// Dumps the current conversation into a json file
     Dump,
 }
@@ -96,6 +99,7 @@ impl Command {
             "/models".to_string(),
             "/act".to_string(),
             "/plan".to_string(),
+            "/help".to_string(),
             "/dump".to_string(),
         ]
     }
@@ -121,6 +125,7 @@ impl Command {
             "/dump" => Command::Dump,
             "/act" => Command::Act,
             "/plan" => Command::Plan,
+            "/help" => Command::Help,
             text => Command::Message(text.to_string()),
         }
     }

--- a/crates/forge_main/src/state.rs
+++ b/crates/forge_main/src/state.rs
@@ -5,6 +5,7 @@ use crate::input::PromptInput;
 #[derive(Clone, Default)]
 pub enum Mode {
     Plan,
+    Help,
     #[default]
     Act,
 }
@@ -13,6 +14,7 @@ impl std::fmt::Display for Mode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Mode::Plan => write!(f, "PLAN"),
+            Mode::Help => write!(f, "HELP"),
             Mode::Act => write!(f, "ACT"),
         }
     }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -20,7 +20,7 @@ use crate::state::{Mode, UIState};
 // Event type constants moved to UI layer
 pub const EVENT_USER_TASK_INIT: &str = "user_task_init";
 pub const EVENT_USER_TASK_UPDATE: &str = "user_task_update";
-pub const EVENT_HELP_QUERY: &str = "help_query";
+pub const EVENT_USER_HELP_QUERY: &str = "user_help_query";
 pub const EVENT_TITLE: &str = "title";
 
 lazy_static! {
@@ -79,8 +79,8 @@ impl<F: API> UI<F> {
     fn create_task_update_event(content: impl ToString) -> Event {
         Event::new(EVENT_USER_TASK_UPDATE, content)
     }
-    fn create_help_query_event(content: impl ToString) -> Event {
-        Event::new(EVENT_HELP_QUERY, content)
+    fn create_user_help_query_event(content: impl ToString) -> Event {
+        Event::new(EVENT_USER_HELP_QUERY, content)
     }
 
     pub fn init(cli: Cli, api: Arc<F>) -> Result<Self> {
@@ -337,7 +337,7 @@ impl<F: API> UI<F> {
         let conversation_id = self.init_conversation().await?;
 
         // Create a help query event
-        let event = Self::create_help_query_event(content.clone());
+        let event = Self::create_user_help_query_event(content.clone());
 
         // Create the chat request with the help query event
         let chat = ChatRequest::new(event, conversation_id);

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -20,6 +20,7 @@ use crate::state::{Mode, UIState};
 // Event type constants moved to UI layer
 pub const EVENT_USER_TASK_INIT: &str = "user_task_init";
 pub const EVENT_USER_TASK_UPDATE: &str = "user_task_update";
+pub const EVENT_HELP_QUERY: &str = "help_query";
 pub const EVENT_TITLE: &str = "title";
 
 lazy_static! {
@@ -43,7 +44,7 @@ impl<F: API> UI<F> {
         self.state.mode = mode;
 
         // Show message that mode changed
-        let mode = self.state.mode.to_string();
+        let mode_str = self.state.mode.to_string();
 
         // Set the mode variable in the conversation if a conversation exists
         let conversation_id = self.init_conversation().await?;
@@ -51,13 +52,20 @@ impl<F: API> UI<F> {
             .set_variable(
                 &conversation_id,
                 "mode".to_string(),
-                Value::from(mode.as_str()),
+                Value::from(mode_str.as_str()),
             )
             .await?;
 
+        // Print a mode-specific message
+        let mode_message = match self.state.mode {
+            Mode::Act => "mode - executes commands and makes file changes",
+            Mode::Plan => "mode - plans actions without making changes",
+            Mode::Help => "mode - answers questions (type /act or /plan to switch back)",
+        };
+
         CONSOLE.write(
-            TitleFormat::success(&mode)
-                .sub_title("mode activated")
+            TitleFormat::success(&mode_str)
+                .sub_title(mode_message)
                 .format(),
         )?;
 
@@ -70,6 +78,9 @@ impl<F: API> UI<F> {
 
     fn create_task_update_event(content: impl ToString) -> Event {
         Event::new(EVENT_USER_TASK_UPDATE, content)
+    }
+    fn create_help_query_event(content: impl ToString) -> Event {
+        Event::new(EVENT_HELP_QUERY, content)
     }
 
     pub fn init(cli: Cli, api: Arc<F>) -> Result<Self> {
@@ -129,7 +140,10 @@ impl<F: API> UI<F> {
                     continue;
                 }
                 Command::Message(ref content) => {
-                    let chat_result = self.chat(content.clone()).await;
+                    let chat_result = match self.state.mode {
+                        Mode::Help => self.help_chat(content.clone()).await,
+                        _ => self.chat(content.clone()).await,
+                    };
                     if let Err(err) = chat_result {
                         CONSOLE.writeln(TitleFormat::failed(format!("{:?}", err)).format())?;
                     }
@@ -145,6 +159,13 @@ impl<F: API> UI<F> {
                 }
                 Command::Plan => {
                     self.handle_mode_change(Mode::Plan).await?;
+
+                    let prompt_input = Some((&self.state).into());
+                    input = self.console.prompt(prompt_input).await?;
+                    continue;
+                }
+                Command::Help => {
+                    self.handle_mode_change(Mode::Help).await?;
 
                     let prompt_input = Some((&self.state).into());
                     input = self.console.prompt(prompt_input).await?;
@@ -311,5 +332,21 @@ impl<F: API> UI<F> {
             }
         }
         Ok(())
+    } // Handle help chat in HELP mode
+    async fn help_chat(&mut self, content: String) -> Result<()> {
+        let conversation_id = self.init_conversation().await?;
+
+        // Create a help query event
+        let event = Self::create_help_query_event(content.clone());
+
+        // Create the chat request with the help query event
+        let chat = ChatRequest::new(event, conversation_id);
+
+        tokio::spawn(TRACKER.dispatch(EventKind::Prompt(content)));
+
+        match self.api.chat(chat).await {
+            Ok(mut stream) => self.handle_chat_stream(&mut stream).await,
+            Err(err) => Err(err),
+        }
     }
 }

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -16,7 +16,7 @@ agents:
     user_prompt: <technical_content>{{event.value}}</technical_content>
 
   - id: help_agent
-    model: *efficiency_model
+    model: google/gemini-2.0-flash-thinking-exp:free
     tools:
       - tool_forge_event_dispatch
     subscribe:

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -18,7 +18,8 @@ agents:
   - id: help_agent
     model: google/gemini-2.0-flash-thinking-exp:free
     tools:
-      - tool_forge_event_dispatch
+      - tool_forge_fs_read
+      - tool_forge_fs_create
     subscribe:
       - user_help_query
     system_prompt: |

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -15,6 +15,16 @@ agents:
     system_prompt: "{{> system-prompt-title-generator.hbs }}"
     user_prompt: <technical_content>{{event.value}}</technical_content>
 
+  - id: help_agent
+    model: *efficiency_model
+    tools:
+      - tool_forge_event_dispatch
+    subscribe:
+      - user_help_query
+    system_prompt: |
+      {{> system-prompt-help.hbs }}
+    user_prompt: <query>{{event.value}}</query>
+
   - id: software-engineer
     model: *advanced_model
     tool_supported: true

--- a/forge.yaml
+++ b/forge.yaml
@@ -16,7 +16,7 @@ agents:
     user_prompt: <technical_content>{{event.value}}</technical_content>
 
   - id: help_agent
-    model: *efficiency_model
+    model: google/gemini-2.0-flash-thinking-exp:free
     tools:
       - tool_forge_event_dispatch
     subscribe:

--- a/forge.yaml
+++ b/forge.yaml
@@ -18,7 +18,8 @@ agents:
   - id: help_agent
     model: google/gemini-2.0-flash-thinking-exp:free
     tools:
-      - tool_forge_event_dispatch
+      - tool_forge_fs_read
+      - tool_forge_fs_create
     subscribe:
       - user_help_query
     system_prompt: |

--- a/forge.yaml
+++ b/forge.yaml
@@ -15,6 +15,16 @@ agents:
     system_prompt: "{{> system-prompt-title-generator.hbs }}"
     user_prompt: <technical_content>{{event.value}}</technical_content>
 
+  - id: help_agent
+    model: *efficiency_model
+    tools:
+      - tool_forge_event_dispatch
+    subscribe:
+      - user_help_query
+    system_prompt: |
+      {{> system-prompt-help.hbs }}
+    user_prompt: <user_query>{{event.value}}</user_query>
+
   - id: software-engineer
     model: *advanced_model
     tool_supported: true

--- a/templates/system-prompt-help.hbs
+++ b/templates/system-prompt-help.hbs
@@ -63,6 +63,6 @@ EXAMPLE USAGE
 
 ADDITIONAL TIPS
 
-[Optional: Any extra advice or best practices]
+[Optional: Suggest a related feature that can help]
 
 Remember to keep your responses concise and CLI-optimized while maintaining accuracy and helpfulness.

--- a/templates/system-prompt-help.hbs
+++ b/templates/system-prompt-help.hbs
@@ -36,16 +36,9 @@ SECTION TITLE
 - For numbered lists, use "1.", "2.", etc. with two spaces after the period.
 - Format command examples with proper spacing and indentation.
 
-RESPONSE PROCESS:
+RESPONSE PROCESS
 
-1. Wrap your analysis in <query_breakdown> tags:
-   - Break down the user's question
-   - List and quote relevant sections from the Forge documentation
-   - Identify key concepts and terms related to the query
-   - Outline a structure for your response
-
-2. Provide your response using this structure:
-
+Provide your response using this structure:
 
 SUMMARY
 
@@ -55,7 +48,6 @@ SUMMARY
 DETAILED EXPLANATION
 
 [Main content of your response, broken into subsections if needed]
-
 
 EXAMPLE USAGE
 

--- a/templates/system-prompt-help.hbs
+++ b/templates/system-prompt-help.hbs
@@ -1,0 +1,68 @@
+
+
+You are a specialized assistant for the Forge CLI tool, designed to help users become better at using Forge. Your responses should be concise, accurate, and optimized for command-line interface (CLI) environments.
+
+<forge_documentation>
+{{readme}}    
+</forge_documentation>
+
+Here's some system information that may be relevant to your responses:
+
+<system_info>
+<operating_system>{{env.os}}</operating_system>
+<current_working_directory>{{env.cwd}}</current_working_directory>
+<default_shell>{{env.shell}}</default_shell>
+<home_directory>{{env.home}}</home_directory>
+</system_info>
+
+INSTRUCTIONS:
+
+1. Analyze the user's query wrapped in `<user_query>` about Forge CLI.
+2. Provide accurate information based strictly on the `<forge_documentation>`.
+3. Explain concepts clearly and concisely, optimized for terminal reading.
+4. Include practical, realistic examples of Forge commands.
+5. Only answer questions about Forge CLI. Politely redirect unrelated queries.
+6. Provide context on why Forge features are useful and when to use them.
+
+OUTPUT FORMATTING:
+
+- Keep line lengths under 80 characters when possible.
+- Use plain text formatting only (no Markdown).
+- Format section headers with full-width dashed lines and ALL CAPS:
+
+SECTION TITLE
+
+- Use "*" for bullet points with two spaces of indentation.
+- For numbered lists, use "1.", "2.", etc. with two spaces after the period.
+- Format command examples with proper spacing and indentation.
+
+RESPONSE PROCESS:
+
+1. Wrap your analysis in <query_breakdown> tags:
+   - Break down the user's question
+   - List and quote relevant sections from the Forge documentation
+   - Identify key concepts and terms related to the query
+   - Outline a structure for your response
+
+2. Provide your response using this structure:
+
+
+SUMMARY
+
+[Brief, 1-2 sentence overview of the answer]
+
+
+DETAILED EXPLANATION
+
+[Main content of your response, broken into subsections if needed]
+
+
+EXAMPLE USAGE
+
+[Practical example(s) of using Forge CLI for the discussed topic]
+
+ADDITIONAL TIPS
+
+[Optional: Any extra advice or best practices]
+
+Remember to keep your responses concise and CLI-optimized while maintaining accuracy and helpfulness.


### PR DESCRIPTION
## Overview
This PR implements a dedicated help command mode for the Forge CLI application that allows users to get assistance and documentation directly from the CLI.

## Features
- Added a new '/help' command to switch to help mode
- Created a help agent with a specialized system prompt template
- Integrated README content into templates to provide documentation context
- Added event handling for user help queries
- Updated the agent model to use google/gemini-2.0-flash-thinking-exp for better response quality
- Enhanced the UI to display mode-specific messages

## Implementation Details
- Added new SystemContext.readme field to include README content in prompts
- Created a system-prompt-help.hbs template with specific instructions for help responses
- Updated the state handling to include the new HELP mode
- Configured the help_agent in forge.yaml with appropriate tools and subscriptions
- Enhanced UI messaging to indicate current mode with descriptive text

## Testing
The help mode has been tested by:
- Switching to help mode using the /help command
- Asking various questions about Forge CLI functionality
- Verifying that responses include content from the README
- Confirming proper mode switching behavior

## Screenshots
(Add screenshots if available)

## Related Issues
Closes #[issue_number]