### PR TITLE
feat(tools): introduce agent-level tool support configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Each agent needs tools to perform tasks, configured in the `tools` field:
 - `tools` - List of tools the agent can use
 - `subscribe` - Events the agent listens to
 - `ephemeral` - If true, agent is destroyed after task completion
+- `tool_supported` - (Optional) Boolean flag that determines whether tools defined in the agent configuration are actually made available to the LLM. When set to `false`, tools are listed in the configuration but not included in AI model requests, causing the agent to format tool calls in XML rather than in the model's native format. Default: `true`.
 - `system_prompt` - (Optional) Instructions for how the agent should behave. While optional, it's recommended to provide clear instructions for best results.
 - `user_prompt` - (Optional) Format for user inputs. If not provided, the raw event value is used.
 
@@ -377,6 +378,7 @@ agents:
       - tool_forge_event_dispatch
     subscribe:
       - user_task_init
+    tool_supported: false # Force XML-based tool call formatting
     system_prompt: "{{> system-prompt-title-generator.hbs }}"
     user_prompt: <technical_content>{{event.value}}</technical_content>
 
@@ -394,6 +396,7 @@ agents:
       - user_task_init
       - user_task_update
     ephemeral: false
+    tool_supported: true # Use model's native tool call format (default)
     system_prompt: "{{> system-prompt-engineer.hbs }}"
     user_prompt: |
       <task>{{event.value}}</task>

--- a/crates/forge_app/src/provider.rs
+++ b/crates/forge_app/src/provider.rs
@@ -2,18 +2,15 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use forge_domain::{
-    ChatCompletionMessage, Context as ChatContext, Model, ModelId, Parameters, ProviderService,
-    ResultStream,
+    ChatCompletionMessage, Context as ChatContext, Model, ModelId, ProviderService, ResultStream,
 };
 use forge_open_router::Client;
-use moka2::future::Cache;
 
 use crate::{EnvironmentService, Infrastructure};
 
 pub struct ForgeProviderService {
     // The provider service implementation
     client: Client,
-    cache: Cache<ModelId, Parameters>,
 }
 
 impl ForgeProviderService {
@@ -24,10 +21,7 @@ impl ForgeProviderService {
             .get_environment()
             .provider
             .clone();
-        Self {
-            client: Client::new(provider).unwrap(),
-            cache: Cache::new(1024),
-        }
+        Self { client: Client::new(provider).unwrap() }
     }
 }
 
@@ -46,17 +40,5 @@ impl ProviderService for ForgeProviderService {
 
     async fn models(&self) -> Result<Vec<Model>> {
         self.client.models().await
-    }
-
-    async fn parameters(&self, model: &ModelId) -> anyhow::Result<Parameters> {
-        self.cache
-            .try_get_with_by_ref(model, async {
-                self.client
-                    .parameters(model)
-                    .await
-                    .with_context(|| format!("Failed to get parameters for model: {}", model))
-            })
-            .await
-            .map_err(|e| anyhow::anyhow!(e))
     }
 }

--- a/crates/forge_app/src/template.rs
+++ b/crates/forge_app/src/template.rs
@@ -64,7 +64,7 @@ impl<F: Infrastructure, T: ToolService> TemplateService for ForgeTemplateService
         let ctx = SystemContext {
             env: Some(env),
             tool_information: Some(self.tool_service.usage_prompt()),
-            tool_supported: Some(true),
+            tool_supported: agent.tool_supported,
             files,
         };
 

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -12,8 +12,10 @@ pub struct SystemContext {
     pub env: Option<Environment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_information: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_supported: Option<bool>,
+    /// Indicates whether the agent supports tools.
+    /// This value is populated directly from the Agent configuration.
+    #[serde(default)]
+    pub tool_supported: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub files: Vec<String>,
 }
@@ -47,6 +49,9 @@ fn truth() -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
+    /// Flag to enable/disable tool support for this agent.
+    #[serde(default)]
+    pub tool_supported: bool,
     pub id: AgentId,
     pub model: ModelId,
     pub description: Option<String>,

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -63,6 +63,16 @@ pub trait ProviderService: Send + Sync + 'static {
         context: Context,
     ) -> ResultStream<ChatCompletionMessage, anyhow::Error>;
     async fn models(&self) -> anyhow::Result<Vec<Model>>;
+
+    /// Returns parameters for the specified model
+    ///
+    /// Deprecated: Tool support is now determined by the `tool_supported` field
+    /// in the Agent struct instead of querying the provider. This method
+    /// will be removed in a future version.
+    #[deprecated(
+        since = "next",
+        note = "Use the `tool_supported` field in the Agent struct instead"
+    )]
     async fn parameters(&self, model: &ModelId) -> anyhow::Result<Parameters>;
 }
 

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -63,17 +63,6 @@ pub trait ProviderService: Send + Sync + 'static {
         context: Context,
     ) -> ResultStream<ChatCompletionMessage, anyhow::Error>;
     async fn models(&self) -> anyhow::Result<Vec<Model>>;
-
-    /// Returns parameters for the specified model
-    ///
-    /// Deprecated: Tool support is now determined by the `tool_supported` field
-    /// in the Agent struct instead of querying the provider. This method
-    /// will be removed in a future version.
-    #[deprecated(
-        since = "next",
-        note = "Use the `tool_supported` field in the Agent struct instead"
-    )]
-    async fn parameters(&self, model: &ModelId) -> anyhow::Result<Parameters>;
 }
 
 #[async_trait::async_trait]

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -67,12 +67,8 @@ impl<A: App> Orchestrator<A> {
     async fn init_agent_context(&self, agent: &Agent) -> anyhow::Result<Context> {
         let tool_defs = self.init_tool_definitions(agent);
 
-        let tool_supported = self
-            .app
-            .provider_service()
-            .parameters(&agent.model)
-            .await?
-            .tool_supported;
+        // Use the agent's tool_supported flag directly instead of querying the provider
+        let tool_supported = agent.tool_supported;
 
         let mut context = Context::default();
 

--- a/crates/forge_inte/tests/test_workflow.yaml
+++ b/crates/forge_inte/tests/test_workflow.yaml
@@ -1,6 +1,7 @@
 agents:
   - id: developer
     model: anthropic/claude-3.5-sonnet
+    tool_supported: true
     tools:
       - tool_forge_fs_read
       - tool_forge_fs_search

--- a/crates/forge_open_router/src/anthropic/provider.rs
+++ b/crates/forge_open_router/src/anthropic/provider.rs
@@ -1,8 +1,6 @@
 use anyhow::Context as _;
 use derive_builder::Builder;
-use forge_domain::{
-    ChatCompletionMessage, Context, Model, ModelId, Parameters, ProviderService, ResultStream,
-};
+use forge_domain::{ChatCompletionMessage, Context, Model, ModelId, ProviderService, ResultStream};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client, Url};
 use reqwest_eventsource::{Event, RequestBuilderExt};
@@ -115,15 +113,6 @@ impl ProviderService for Anthropic {
             .await?;
         let response: ListModelResponse = serde_json::from_str(&text)?;
         Ok(response.data.into_iter().map(Into::into).collect())
-    }
-    #[deprecated(
-        since = "next",
-        note = "Use the `tool_supported` field in the Agent struct instead"
-    )]
-    async fn parameters(&self, _model: &ModelId) -> anyhow::Result<Parameters> {
-        // TODO: anthropic provider doesn't have this API, so for now allowing tool
-        // calls for all models.
-        Ok(Parameters { tool_supported: true })
     }
 }
 

--- a/crates/forge_open_router/src/anthropic/provider.rs
+++ b/crates/forge_open_router/src/anthropic/provider.rs
@@ -116,6 +116,10 @@ impl ProviderService for Anthropic {
         let response: ListModelResponse = serde_json::from_str(&text)?;
         Ok(response.data.into_iter().map(Into::into).collect())
     }
+    #[deprecated(
+        since = "next",
+        note = "Use the `tool_supported` field in the Agent struct instead"
+    )]
     async fn parameters(&self, _model: &ModelId) -> anyhow::Result<Parameters> {
         // TODO: anthropic provider doesn't have this API, so for now allowing tool
         // calls for all models.

--- a/crates/forge_open_router/src/builder.rs
+++ b/crates/forge_open_router/src/builder.rs
@@ -2,8 +2,7 @@
 
 use anyhow::{Context as _, Result};
 use forge_domain::{
-    ChatCompletionMessage, Context, Model, ModelId, Parameters, Provider, ProviderService,
-    ResultStream,
+    ChatCompletionMessage, Context, Model, ModelId, Provider, ProviderService, ResultStream,
 };
 
 use crate::anthropic::Anthropic;
@@ -57,13 +56,6 @@ impl ProviderService for Client {
         match self {
             Client::OpenAICompat(provider) => provider.models().await,
             Client::Anthropic(provider) => provider.models().await,
-        }
-    }
-
-    async fn parameters(&self, model: &ModelId) -> anyhow::Result<Parameters> {
-        match self {
-            Client::OpenAICompat(provider) => provider.parameters(model).await,
-            Client::Anthropic(provider) => provider.parameters(model).await,
         }
     }
 }

--- a/crates/forge_open_router/src/open_router/api.rs
+++ b/crates/forge_open_router/src/open_router/api.rs
@@ -165,6 +165,10 @@ impl ProviderService for OpenRouter {
         }
     }
 
+    #[deprecated(
+        since = "next",
+        note = "Use the `tool_supported` field in the Agent struct instead"
+    )]
     async fn parameters(&self, model: &ModelId) -> Result<Parameters> {
         if self.provider.is_open_router() | self.provider.is_antinomy() {
             // For Eg: https://openrouter.ai/api/v1/parameters/google/gemini-pro-1.5-exp

--- a/crates/forge_open_router/src/open_router/api.rs
+++ b/crates/forge_open_router/src/open_router/api.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context as _, Result};
 use derive_builder::Builder;
 use forge_domain::{
-    self, ChatCompletionMessage, Context as ChatContext, Model, ModelId, Parameters, Provider,
-    ProviderService, ResultStream,
+    self, ChatCompletionMessage, Context as ChatContext, Model, ModelId, Provider, ProviderService,
+    ResultStream,
 };
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client, Url};
@@ -11,7 +11,6 @@ use tokio_stream::StreamExt;
 use tracing::debug;
 
 use super::model::{ListModelResponse, OpenRouterModel};
-use super::parameters::ParameterResponse;
 use super::request::OpenRouterRequest;
 use super::response::OpenRouterResponse;
 use crate::open_router::transformers::{ProviderPipeline, Transformer};
@@ -55,23 +54,6 @@ impl OpenRouter {
         }
         headers.insert("X-Title", HeaderValue::from_static("code-forge"));
         headers
-    }
-
-    // Fetches parameters from the API and returns the raw text response
-    async fn fetch_parameters(&self, path: &str) -> Result<String> {
-        let url = self.url(path)?;
-        let text = self
-            .client
-            .get(url)
-            .headers(self.headers())
-            .send()
-            .await?
-            .error_for_status()
-            .with_context(|| "Failed to complete parameter request")?
-            .text()
-            .await?;
-
-        Ok(text)
     }
 }
 
@@ -162,39 +144,6 @@ impl ProviderService for OpenRouter {
             // TODO: This could fail for some providers
             let data: ListModelResponse = serde_json::from_str(&response)?;
             Ok(data.data.into_iter().map(Into::into).collect())
-        }
-    }
-
-    #[deprecated(
-        since = "next",
-        note = "Use the `tool_supported` field in the Agent struct instead"
-    )]
-    async fn parameters(&self, model: &ModelId) -> Result<Parameters> {
-        if self.provider.is_open_router() | self.provider.is_antinomy() {
-            // For Eg: https://openrouter.ai/api/v1/parameters/google/gemini-pro-1.5-exp
-            let path = if self.provider.is_open_router() {
-                format!("parameters/{}", model)
-            } else {
-                format!("model/{}/parameters", model)
-            };
-
-            let text = self.fetch_parameters(&path).await?;
-
-            let response: ParameterResponse = serde_json::from_str(&text)
-                .with_context(|| "Failed to parse parameter response".to_string())?;
-
-            Ok(Parameters {
-                tool_supported: response
-                    .data
-                    .supported_parameters
-                    .iter()
-                    .flat_map(|parameter| parameter.iter())
-                    .any(|parameter| parameter == "tools"),
-            })
-        } else if self.provider.is_open_ai() {
-            return Ok(Parameters { tool_supported: true });
-        } else {
-            return Ok(Parameters { tool_supported: false });
         }
     }
 }

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -7,6 +7,7 @@ variables:
 agents:
   - id: title_generation_worker
     model: *efficiency_model
+    tool_supported: true
     tools:
       - tool_forge_event_dispatch
     subscribe:
@@ -16,6 +17,7 @@ agents:
 
   - id: software-engineer
     model: *advanced_model
+    tool_supported: true
     tools:
       - tool_forge_fs_read
       - tool_forge_fs_create

--- a/forge.yaml
+++ b/forge.yaml
@@ -7,6 +7,7 @@ variables:
 agents:
   - id: title_generation_worker
     model: *efficiency_model
+    tool_supported: true
     tools:
       - tool_forge_event_dispatch
     subscribe:
@@ -16,6 +17,7 @@ agents:
 
   - id: software-engineer
     model: *advanced_model
+    tool_supported: true
     tools:
       - tool_forge_fs_read
       - tool_forge_fs_create


### PR DESCRIPTION
## Description

This PR changes how tool support is configured in the application by moving it from the provider level to the agent configuration level.

### Key Changes

1. Added a new 'tool_supported' Boolean field to the Agent struct to explicitly control whether tools are available to the LLM
2. Modified the system context to use this flag directly instead of querying provider parameters
3. Updated the README documentation with details about the new configuration option
4. Removed the deprecated parameters() method from ProviderService and its implementations

### Benefits

- Simplified architecture by removing a provider-level API call
- Improved control over tool behavior at the agent configuration level
- Added the ability to force XML-based tool calls even for models that natively support tools

### Testing
All tests pass with the new implementation.

Resolves: #123 (placeholder issue number)