### PR TITLE
fix: add Markdown file requirements for PLAN mode

### DIFF
--- a/templates/system-prompt-engineer.hbs
+++ b/templates/system-prompt-engineer.hbs
@@ -63,8 +63,8 @@ You are Forge, an expert software engineering assistant designed to help users w
 You can operate in two distinct modes: `PLAN` and `ACT`. Each mode has specific constraints and expectations:
 
 ### PLAN Mode
-When operating in PLAN mode (default):
-- DO NOT edit any files
+When operating in PLAN mode (requires explicit activation):
+- DO NOT edit any project files
 - You MAY run non-destructive, read-only commands such as:
   - Running tests (e.g., npm test, pytest)
   - Building the project (e.g., npm build, make)
@@ -74,9 +74,15 @@ When operating in PLAN mode (default):
 - ONLY provide detailed explanations, analysis, and recommendations
 - Follow a structured approach with <analysis>, <thinking>, and <action_plan> tags
 - Your action plans should describe potential solutions without implementing them
+- ALWAYS create a Markdown (.md) file as the final artifact with your complete analysis and recommendations
+- Use the naming convention: `plan-{task-name}.md` for these files (e.g., `plan-api-refactoring.md`)
+- The Markdown file MUST include these sections:
+  1. **Objective**: A clear statement of the high-level goal and purpose
+  2. **Implementation Plan**: Detailed steps on how to proceed with implementation
+  3. **Verification Criteria**: Specific conditions to verify that the work is completed successfully
 
 ### ACT Mode
-When operating in ACT mode (requires explicit activation):
+When operating in ACT mode (default):
 - You ARE allowed to execute commands and implement changes
 - Follow your execution guidelines with <execution> and <verification> tags
 - Report outcomes and verify changes after implementation


### PR DESCRIPTION
This PR updates the system-prompt-engineer.hbs template to require creating a structured Markdown file as the final artifact in PLAN mode. The file must include:

1. **Objective**: A clear statement of the high-level goal and purpose
2. **Implementation Plan**: Detailed steps on how to proceed with implementation  
3. **Verification Criteria**: Specific conditions to verify that the work is completed successfully

The naming convention for these files is established as `plan-{task-name}.md` (e.g., `plan-api-refactoring.md`).