### PR TITLE
fix: simplify title generation event logic

### DIFF
--- a/crates/forge_main/src/state.rs
+++ b/crates/forge_main/src/state.rs
@@ -21,12 +21,24 @@ impl std::fmt::Display for Mode {
 }
 
 /// State information for the UI
-#[derive(Default)]
 pub struct UIState {
     pub current_title: Option<String>,
     pub conversation_id: Option<ConversationId>,
     pub usage: Usage,
     pub mode: Mode,
+    pub is_first: bool,
+}
+
+impl Default for UIState {
+    fn default() -> Self {
+        Self {
+            current_title: Default::default(),
+            conversation_id: Default::default(),
+            usage: Default::default(),
+            mode: Default::default(),
+            is_first: true,
+        }
+    }
 }
 
 impl From<&UIState> for PromptInput {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -274,15 +274,9 @@ impl<F: API> UI<F> {
     async fn chat(&mut self, content: String) -> Result<()> {
         let conversation_id = self.init_conversation().await?;
 
-        // Determine if this is the first message or an update based on conversation
-        // history
-        let conversation = self.api.conversation(&conversation_id).await?;
-
         // Create a ChatRequest with the appropriate event type
-        let event = if conversation
-            .as_ref()
-            .is_none_or(|c| c.rfind_event(EVENT_USER_TASK_INIT).is_none())
-        {
+        let event = if self.state.is_first {
+            self.state.is_first = false;
             Self::create_task_init_event(content.clone())
         } else {
             Self::create_task_update_event(content.clone())


### PR DESCRIPTION
## Description

This PR improves the way we track whether a message is the first one in a conversation by:

1. Adding an `is_first` boolean flag to the `UIState` struct
2. Creating a custom `Default` implementation for `UIState` where `is_first` is initialized to `true`
3. Replacing the complex conversation history check with this simple boolean flag

## Motivation

The previous approach required querying the conversation history to determine if a message was the first one, which was more complex and potentially less reliable. This change simplifies the logic and makes it more deterministic.

## Changes

- Added `is_first: bool` field to `UIState` struct
- Implemented custom `Default` for `UIState` 
- Updated the `chat` method to use this flag instead of querying conversation history