### PR TITLE
feat: add npm package publishing to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,5 +288,23 @@ jobs:
         ref: main
         token: ${{ secrets.HOMEBREW_ACCESS }}
     - run: GITHUB_TOKEN="${{ secrets.HOMEBREW_ACCESS }}" ./update-formula.sh ${{needs.draft_release.outputs.create_release_name }}
+  npm_release:
+    needs:
+    - draft_release
+    - build-release
+    - semantic_release
+    if: (startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')) && (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    name: npm_release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: antinomyhq/npm-code-forge
+        ref: main
+        token: ${{ secrets.NPM_ACCESS }}
+    - run: NPM_TOKEN="${{ secrets.NPM_TOKEN }}" ./update-package.sh ${{needs.draft_release.outputs.create_release_name}}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,10 @@ jobs:
         repository: antinomyhq/npm-code-forge
         ref: main
         token: ${{ secrets.NPM_ACCESS }}
-    - run: NPM_TOKEN="${{ secrets.NPM_TOKEN }}" ./update-package.sh ${{needs.draft_release.outputs.create_release_name}}
+    - run: ./update-package.sh ${{needs.draft_release.outputs.create_release_name}}
+      env:
+        AUTO_PUSH: 'true'
+        CI: 'true'
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/forge_ci/tests/ci.rs
+++ b/crates/forge_ci/tests/ci.rs
@@ -259,7 +259,7 @@ fn generate() {
                 Step::run("GITHUB_TOKEN=\"${{ secrets.HOMEBREW_ACCESS }}\" ./update-formula.sh ${{needs.draft_release.outputs.create_release_name }}"),
             ),
     );
-    
+
     // npm release job
     workflow = workflow.add_job(
         "npm_release",

--- a/crates/forge_ci/tests/ci.rs
+++ b/crates/forge_ci/tests/ci.rs
@@ -282,7 +282,10 @@ fn generate() {
             )
             // Make script executable and run it with token
             .add_step(
-                Step::run("NPM_TOKEN=\"${{ secrets.NPM_TOKEN }}\" ./update-package.sh ${{needs.draft_release.outputs.create_release_name}}"),
+                Step::run("./update-package.sh ${{needs.draft_release.outputs.create_release_name}}")
+                .add_env(("AUTO_PUSH", "true"))
+                .add_env(("CI", "true"))
+                .add_env(("NPM_TOKEN", "${{ secrets.NPM_TOKEN }}")),
             ),
     );
 


### PR DESCRIPTION
This PR adds an npm package publishing step to the CI workflow, similar to the existing Homebrew release step.

## Changes
- Added npm_release job to CI workflow in forge_ci/tests/ci.rs
- The job runs after the semantic release
- Uses same dependencies and conditions as the homebrew_release job
- Checks out npm-code-forge repository and runs update-package.sh script

## Related
- Resolves #528

## Required Secrets
- NPM_ACCESS - GitHub token with repository access permissions
- NPM_TOKEN - NPM authentication token for package publishing

This implementation assumes a separate npm-code-forge repository will be created as described in issue #528.
NPM packacge repo link https://github.com/antinomyhq/npm-code-forge