### PR TITLE
fix: enhance `PLAN` mode guidelines to prohibit code snippets in favor of conceptual descriptions

### DIFF
--- a/templates/system-prompt-engineer.hbs
+++ b/templates/system-prompt-engineer.hbs
@@ -63,6 +63,8 @@ When operating in PLAN mode (requires explicit activation):
 - ONLY provide detailed explanations, analysis, and recommendations
 - Follow a structured approach with <analysis>, <thinking>, and <action_plan> tags
 - Your action plans should describe potential solutions without implementing them
+- NEVER include any code snippets or code examples in your plan documentation
+- Describe code changes conceptually without showing actual code implementation
 - ALWAYS create a Markdown (.md) file as the final artifact with your complete analysis and recommendations
 - Use the naming convention: `plan-{task-name}.md` for these files (e.g., `plan-api-refactoring.md`)
 - The Markdown file MUST include these sections:


### PR DESCRIPTION
## Overview
Update the system prompt engineer template to explicitly prohibit code snippets in plan documentation and require conceptual descriptions of solutions instead.

## Purpose
This change improves the planning process by focusing on high-level concepts and architectural decisions before jumping into implementation details. By prohibiting code snippets in planning documents, we encourage more thoughtful design consideration and prevent premature optimization or implementation bias.

## Implementation
Added two new guidelines to the PLAN mode instructions in the system prompt engineer template:
1. "NEVER include any code snippets or code examples in your plan documentation"
2. "Describe code changes conceptually without showing actual code implementation"

These changes ensure that planning outputs focus on the problem space and solution approach rather than specific implementation details that might constrain thinking.

## Testing
The updated template has been tested manually by generating plan documents and verifying that they follow the new guidelines, focusing on conceptual descriptions without code snippets.

## Related Issues
No directly related issues, but this change addresses feedback from team members about wanting more architectural guidance from the planning process.

## Changelog
- Added explicit instruction to never include code snippets or examples in plan documentation
- Added instruction to describe code changes conceptually without implementation details

## Suggested Reviewers
- Team members who frequently use the planning functionality
- UX/documentation specialists who can evaluate the clarity of the new guidelines