### PR TITLE
chore(ci): JSON parsing error with special characters in comments

### DIFF
--- a/.github/workflows/forge-automation.yml
+++ b/.github/workflows/forge-automation.yml
@@ -101,7 +101,7 @@ jobs:
 
           .
     - name: Run Forge to revise plan based on feedback
-      run: 'forge --event=''{"name": "revise_plan", "value": "${{ github.event.issue.number }}|${{ github.event.comment.body }}"}'''
+      run: 'forge --event=''{"name": "revise_plan", "value": "${{ github.event.issue.number }}|${{ toJSON(github.event.comment.body) }}"}'''
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         FORGE_KEY: ${{ secrets.FORGE_KEY }}

--- a/crates/forge_ci/tests/forge_automation.rs
+++ b/crates/forge_ci/tests/forge_automation.rs
@@ -10,11 +10,18 @@ fn generate_comment_body(emoji: &str, title: &str, message: &str) -> String {
     )
 }
 
-/// Generate a forge event JSON string
+/// Generate a forge event JSON string with proper escaping
 fn forge_event_json(event_name: &str, value_expr: &str) -> String {
+    let escaped_value = value_expr
+        .replace('\\', "\\\\")  // Escape backslashes first
+        .replace('"', "\\\"")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t");
+
     format!(
-        "forge --event='{{\"{}\": \"{}\", \"value\": \"{}\"}}\'",
-        "name", event_name, value_expr
+        "forge --event='{{\"name\": \"{}\", \"value\": \"{}\"}}'",
+        event_name, escaped_value
     )
 }
 
@@ -156,7 +163,7 @@ fn test_forge_automation() {
                 ))),
         )
         .add_step(
-            Step::run(forge_event_json("revise_plan", "${{ github.event.issue.number }}|${{ github.event.comment.body }}"))
+            Step::run("forge --event='{\"name\": \"revise_plan\", \"value\": \"${{ github.event.issue.number }}|${{ toJSON(github.event.comment.body) }}\"}'")
                 .name("Run Forge to revise plan based on feedback")
                 .add_env(("GITHUB_TOKEN", "${{ steps.generate-token.outputs.token }}"))
                 .add_env(("FORGE_KEY", "${{ secrets.FORGE_KEY }}")),
@@ -294,5 +301,14 @@ mod tests {
         let condition = issue_comment_condition("test-label", "/test-command");
         assert!(condition.contains("test-label"));
         assert!(condition.contains("/test-command"));
+    }
+    
+    #[test]
+    fn test_forge_event_json_with_special_chars() {
+        let json = forge_event_json("test_event", "test_value\r\nwith\tspecial\"chars");
+        assert_eq!(
+            json,
+            "forge --event='{\"name\": \"test_event\", \"value\": \"test_value\\r\\nwith\\tspecial\\\"chars\"}'"
+        );
     }
 }

--- a/crates/forge_ci/tests/forge_automation.rs
+++ b/crates/forge_ci/tests/forge_automation.rs
@@ -13,7 +13,7 @@ fn generate_comment_body(emoji: &str, title: &str, message: &str) -> String {
 /// Generate a forge event JSON string with proper escaping
 fn forge_event_json(event_name: &str, value_expr: &str) -> String {
     let escaped_value = value_expr
-        .replace('\\', "\\\\")  // Escape backslashes first
+        .replace('\\', "\\\\") // Escape backslashes first
         .replace('"', "\\\"")
         .replace('\r', "\\r")
         .replace('\n', "\\n")
@@ -302,7 +302,7 @@ mod tests {
         assert!(condition.contains("test-label"));
         assert!(condition.contains("/test-command"));
     }
-    
+
     #[test]
     fn test_forge_event_json_with_special_chars() {
         let json = forge_event_json("test_event", "test_value\r\nwith\tspecial\"chars");


### PR DESCRIPTION
This PR fixes the issue with JSON parsing errors when comments contain special characters like carriage returns and newlines.

## Changes:
- Modified the workflow to use GitHub Actions' built-in toJSON() function to properly escape comment bodies
- Improved the forge_event_json function to properly handle escape sequences
- Added a unit test to verify special characters are properly escaped

Fixes the CI error in PR #545 where control characters in comments were breaking JSON parsing.