### PR TITLE
fix(#561): Redesign conversation state management to address agent persistence after interruptions

### DIFF
--- a/crates/forge_api/src/api.rs
+++ b/crates/forge_api/src/api.rs
@@ -76,7 +76,7 @@ impl<F: App + Infrastructure> API for ForgeAPI<F> {
         &self,
         conversation_id: &ConversationId,
     ) -> anyhow::Result<Option<Conversation>> {
-        self.app.conversation_service().get(conversation_id).await
+        self.app.conversation_service().find(conversation_id).await
     }
 
     async fn get_variable(

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -30,7 +30,6 @@ impl<F: App> ForgeExecutorService<F> {
         Ok(MpscStream::spawn(move |tx| async move {
             let tx = Arc::new(tx);
 
-        
             let orch = Orchestrator::new(app, conversation, Some(tx.clone()));
 
             match orch.dispatch(request.event).await {

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -25,7 +25,7 @@ impl<F: App> ForgeExecutorService<F> {
             let tx = Arc::new(tx);
             let mut conversation = app
                 .conversation_service()
-                .get(&request.conversation_id)
+                .find(&request.conversation_id)
                 .await
                 .unwrap_or_default()
                 .expect("conversation for the request should've been created");

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -29,9 +29,9 @@ impl<F: App> ForgeExecutorService<F> {
                 .await
                 .unwrap_or_default()
                 .expect("conversation for the request should've been created");
+
+            // since this is a new request, we clear the queue
             conversation.state.values_mut().for_each(|state| {
-                // since this is a new request, we clear the queue and start fresh with new
-                // events.
                 state.queue.clear();
             });
 

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -23,6 +23,7 @@ impl<F: App> ForgeExecutorService<F> {
 
         Ok(MpscStream::spawn(move |tx| async move {
             let tx = Arc::new(tx);
+            // ideally, conversation should've been created at this point.
             let conversation = app
                 .conversation_service()
                 .get(&request.conversation_id)

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use forge_domain::{AgentMessage, App, ChatRequest, ChatResponse, Orchestrator};
+use forge_domain::{
+    AgentMessage, App, ChatRequest, ChatResponse, ConversationService, Orchestrator,
+};
 use forge_stream::MpscStream;
 
 pub struct ForgeExecutorService<F> {
@@ -21,7 +23,13 @@ impl<F: App> ForgeExecutorService<F> {
 
         Ok(MpscStream::spawn(move |tx| async move {
             let tx = Arc::new(tx);
-            let orch = Orchestrator::new(app, request.conversation_id, Some(tx.clone()));
+            let conversation = app
+                .conversation_service()
+                .get(&request.conversation_id)
+                .await
+                .unwrap_or_default()
+                .unwrap();
+            let orch = Orchestrator::new(app, conversation, Some(tx.clone()));
 
             match orch.dispatch(request.event).await {
                 Ok(_) => {}

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -23,13 +23,12 @@ impl<F: App> ForgeExecutorService<F> {
 
         Ok(MpscStream::spawn(move |tx| async move {
             let tx = Arc::new(tx);
-            // ideally, conversation should've been created at this point.
             let mut conversation = app
                 .conversation_service()
                 .get(&request.conversation_id)
                 .await
                 .unwrap_or_default()
-                .unwrap();
+                .expect("conversation for the request should've been created");
             conversation.state.values_mut().for_each(|state| {
                 // since this is a new request, we clear the queue and start fresh with new events.
                 state.queue.clear();

--- a/crates/forge_api/src/executor.rs
+++ b/crates/forge_api/src/executor.rs
@@ -30,7 +30,8 @@ impl<F: App> ForgeExecutorService<F> {
                 .unwrap_or_default()
                 .expect("conversation for the request should've been created");
             conversation.state.values_mut().for_each(|state| {
-                // since this is a new request, we clear the queue and start fresh with new events.
+                // since this is a new request, we clear the queue and start fresh with new
+                // events.
                 state.queue.clear();
             });
 

--- a/crates/forge_app/src/conversation.rs
+++ b/crates/forge_app/src/conversation.rs
@@ -38,6 +38,11 @@ impl ConversationService for ForgeConversationService {
         Ok(self.workflows.lock().await.get(id).cloned())
     }
 
+    async fn set(&self, id: &ConversationId, conversation: Conversation) -> Result<()> {
+        self.workflows.lock().await.insert(id.clone(), conversation);
+        Ok(())
+    }
+
     async fn create(&self, workflow: Workflow) -> Result<ConversationId> {
         let id = ConversationId::generate();
         let conversation = Conversation::new(id.clone(), workflow);
@@ -78,4 +83,5 @@ impl ConversationService for ForgeConversationService {
     async fn delete_variable(&self, id: &ConversationId, key: &str) -> Result<bool> {
         self.update(id, |c| c.delete_variable(key)).await
     }
+
 }

--- a/crates/forge_app/src/conversation.rs
+++ b/crates/forge_app/src/conversation.rs
@@ -34,11 +34,11 @@ impl ConversationService for ForgeConversationService {
         Ok(f(conversation))
     }
 
-    async fn get(&self, id: &ConversationId) -> Result<Option<Conversation>> {
+    async fn find(&self, id: &ConversationId) -> Result<Option<Conversation>> {
         Ok(self.workflows.lock().await.get(id).cloned())
     }
 
-    async fn set(&self, id: &ConversationId, conversation: Conversation) -> Result<()> {
+    async fn upsert(&self, id: &ConversationId, conversation: Conversation) -> Result<()> {
         self.workflows.lock().await.insert(id.clone(), conversation);
         Ok(())
     }

--- a/crates/forge_app/src/conversation.rs
+++ b/crates/forge_app/src/conversation.rs
@@ -38,8 +38,11 @@ impl ConversationService for ForgeConversationService {
         Ok(self.workflows.lock().await.get(id).cloned())
     }
 
-    async fn upsert(&self, id: &ConversationId, conversation: Conversation) -> Result<()> {
-        self.workflows.lock().await.insert(id.clone(), conversation);
+    async fn upsert(&self, conversation: Conversation) -> Result<()> {
+        self.workflows
+            .lock()
+            .await
+            .insert(conversation.id.clone(), conversation);
         Ok(())
     }
 

--- a/crates/forge_app/src/conversation.rs
+++ b/crates/forge_app/src/conversation.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context as AnyhowContext, Result};
-use forge_domain::{AgentId, Context, Conversation, ConversationId, ConversationService, Workflow};
+use forge_domain::{Conversation, ConversationId, ConversationService, Workflow};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
@@ -50,25 +50,6 @@ impl ConversationService for ForgeConversationService {
         Ok(id)
     }
 
-    async fn inc_turn(&self, id: &ConversationId, agent: &AgentId) -> Result<()> {
-        self.update(id, |c| {
-            c.state.entry(agent.clone()).or_default().turn_count += 1;
-        })
-        .await
-    }
-
-    async fn set_context(
-        &self,
-        id: &ConversationId,
-        agent: &AgentId,
-        context: Context,
-    ) -> Result<()> {
-        self.update(id, |c| {
-            c.state.entry(agent.clone()).or_default().context = Some(context);
-        })
-        .await
-    }
-
     async fn get_variable(&self, id: &ConversationId, key: &str) -> Result<Option<Value>> {
         self.update(id, |c| c.get_variable(key).cloned()).await
     }
@@ -83,5 +64,4 @@ impl ConversationService for ForgeConversationService {
     async fn delete_variable(&self, id: &ConversationId, key: &str) -> Result<bool> {
         self.update(id, |c| c.delete_variable(key)).await
     }
-
 }

--- a/crates/forge_domain/src/conversation.rs
+++ b/crates/forge_domain/src/conversation.rs
@@ -181,7 +181,7 @@ impl Conversation {
             })
             .collect::<Vec<_>>();
 
-        self.insert_event(event.clone());
+        self.insert_event(event);
 
         inactive_agents
     }

--- a/crates/forge_domain/src/conversation.rs
+++ b/crates/forge_domain/src/conversation.rs
@@ -45,8 +45,6 @@ pub struct AgentState {
     pub context: Option<Context>,
     /// holds the events that are waiting to be processed
     pub queue: VecDeque<Event>,
-    /// indicates if the agent is currently processing events
-    pub is_active: bool,
 }
 
 impl Conversation {
@@ -148,8 +146,6 @@ impl Conversation {
             if let Some(event) = agent.queue.pop_front() {
                 return Some(event);
             }
-            // since no event is present, set the agent as inactive
-            agent.is_active = false;
         }
         None
     }
@@ -177,12 +173,9 @@ impl Conversation {
                 let is_inactive = self
                     .state
                     .get(&agent.id)
-                    .is_none_or(|state| !state.is_active);
-
+                    .map(|state| state.queue.is_empty())
+                    .unwrap_or(true);
                 if is_inactive {
-                    // Mark agent as active by setting is_active to true in the agent's state
-                    self.state.entry(agent.id.clone()).or_default().is_active = true;
-
                     Some(agent.id.clone())
                 } else {
                     None

--- a/crates/forge_domain/src/conversation.rs
+++ b/crates/forge_domain/src/conversation.rs
@@ -163,11 +163,9 @@ impl Conversation {
     /// now activated
     pub fn dispatch_event(&mut self, event: Event) -> Vec<AgentId> {
         let name = event.name.as_str();
-        self.insert_event(event.clone());
-
         let mut agents = self.subscriptions(name);
 
-        agents
+        let inactive_agents = agents
             .iter_mut()
             .filter_map(|agent| {
                 let is_inactive = self
@@ -181,6 +179,10 @@ impl Conversation {
                     None
                 }
             })
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+
+        self.insert_event(event.clone());
+
+        inactive_agents
     }
 }

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -80,6 +80,8 @@ pub trait ToolService: Send + Sync {
 pub trait ConversationService: Send + Sync {
     async fn get(&self, id: &ConversationId) -> anyhow::Result<Option<Conversation>>;
 
+    async fn set(&self, id: &ConversationId, conversation: Conversation) -> anyhow::Result<()>;
+
     async fn create(&self, workflow: Workflow) -> anyhow::Result<ConversationId>;
 
     async fn inc_turn(&self, id: &ConversationId, agent: &AgentId) -> anyhow::Result<()>;

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -84,15 +84,6 @@ pub trait ConversationService: Send + Sync {
 
     async fn create(&self, workflow: Workflow) -> anyhow::Result<ConversationId>;
 
-    async fn inc_turn(&self, id: &ConversationId, agent: &AgentId) -> anyhow::Result<()>;
-
-    async fn set_context(
-        &self,
-        id: &ConversationId,
-        agent: &AgentId,
-        context: Context,
-    ) -> anyhow::Result<()>;
-
     async fn get_variable(&self, id: &ConversationId, key: &str) -> anyhow::Result<Option<Value>>;
 
     async fn set_variable(

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -80,7 +80,7 @@ pub trait ToolService: Send + Sync {
 pub trait ConversationService: Send + Sync {
     async fn find(&self, id: &ConversationId) -> anyhow::Result<Option<Conversation>>;
 
-    async fn upsert(&self, id: &ConversationId, conversation: Conversation) -> anyhow::Result<()>;
+    async fn upsert(&self, conversation: Conversation) -> anyhow::Result<()>;
 
     async fn create(&self, workflow: Workflow) -> anyhow::Result<ConversationId>;
 

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -78,9 +78,9 @@ pub trait ToolService: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait ConversationService: Send + Sync {
-    async fn get(&self, id: &ConversationId) -> anyhow::Result<Option<Conversation>>;
+    async fn find(&self, id: &ConversationId) -> anyhow::Result<Option<Conversation>>;
 
-    async fn set(&self, id: &ConversationId, conversation: Conversation) -> anyhow::Result<()>;
+    async fn upsert(&self, id: &ConversationId, conversation: Conversation) -> anyhow::Result<()>;
 
     async fn create(&self, workflow: Workflow) -> anyhow::Result<ConversationId>;
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -410,7 +410,10 @@ impl<A: App> Orchestrator<A> {
     }
 
     async fn init_agent(&self, agent_id: &AgentId) -> anyhow::Result<()> {
-        while let Some(event) = self.conversation.write().await.poll_event(agent_id) {
+        while let Some(event) = {
+            let mut conversation = self.conversation.write().await;
+            conversation.poll_event(agent_id)
+        } {
             self.init_agent_with_event(agent_id, &event).await?;
         }
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -268,10 +268,7 @@ impl<A: App> Orchestrator<A> {
 
     async fn sync_conversation(&self) -> anyhow::Result<()> {
         let conversation = self.conversation.read().await.clone();
-        self.app
-            .conversation_service()
-            .upsert(&conversation.id.clone(), conversation)
-            .await?;
+        self.app.conversation_service().upsert(conversation).await?;
         Ok(())
     }
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -52,7 +52,12 @@ impl<A: App> Orchestrator<A> {
         Ok(tool_results)
     }
 
-    pub fn new(svc: Arc<A>, conversation: Conversation, sender: Option<ArcSender>) -> Self {
+    pub fn new(svc: Arc<A>, mut conversation: Conversation, sender: Option<ArcSender>) -> Self {
+        // since this is a new request, we clear the queue
+        conversation.state.values_mut().for_each(|state| {
+            state.queue.clear();
+        });
+
         Self {
             app: svc,
             sender,

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -426,9 +426,7 @@ impl<A: App> Orchestrator<A> {
 
     async fn init_agent(&self, agent_id: &AgentId) -> anyhow::Result<()> {
         loop {
-            let mut conversation = self.conversation.write().await;
-            if let Some(event) = conversation.poll_event(agent_id) {
-                drop(conversation);
+            if let Some(event) = self.conversation.write().await.poll_event(agent_id) {
                 self.init_agent_with_event(agent_id, &event).await?;
             } else {
                 break;

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -184,7 +184,7 @@ impl<A: App> Orchestrator<A> {
                 event_value = %event.value,
                 "Dispatching event"
             );
-            conversation.dispatch_event(event.clone())
+            conversation.dispatch_event(event)
         };
 
         // Execute all initialization futures in parallel
@@ -276,8 +276,7 @@ impl<A: App> Orchestrator<A> {
     }
 
     async fn get_last_event(&self, name: &str) -> anyhow::Result<Option<Event>> {
-        let conversation = self.conversation.read().await;
-        Ok(conversation.rfind_event(name).cloned())
+        Ok(self.conversation.read().await.rfind_event(name).cloned())
     }
 
     async fn get_conversation(&self) -> anyhow::Result<Conversation> {
@@ -300,7 +299,7 @@ impl<A: App> Orchestrator<A> {
             .state
             .entry(agent_id.clone())
             .or_default()
-            .context = Some(context.clone());
+            .context = Some(context);
         Ok(())
     }
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -5,6 +5,7 @@ use anyhow::Context as AnyhowContext;
 use async_recursion::async_recursion;
 use futures::future::join_all;
 use futures::{Stream, StreamExt};
+use tokio::sync::RwLock;
 use tracing::debug;
 
 use crate::*;
@@ -21,7 +22,7 @@ pub struct AgentMessage<T> {
 pub struct Orchestrator<App> {
     app: Arc<App>,
     sender: Option<ArcSender>,
-    conversation_id: ConversationId,
+    conversation: Arc<RwLock<Conversation>>,
 }
 
 struct ChatCompletionResult {
@@ -51,8 +52,12 @@ impl<A: App> Orchestrator<A> {
         Ok(tool_results)
     }
 
-    pub fn new(svc: Arc<A>, conversation_id: ConversationId, sender: Option<ArcSender>) -> Self {
-        Self { app: svc, sender, conversation_id }
+    pub fn new(svc: Arc<A>, conversation: Conversation, sender: Option<ArcSender>) -> Self {
+        Self {
+            app: svc,
+            sender,
+            conversation: Arc::new(RwLock::new(conversation)),
+        }
     }
 
     async fn send_message(&self, agent: &Agent, message: ChatResponse) -> anyhow::Result<()> {
@@ -174,23 +179,27 @@ impl<A: App> Orchestrator<A> {
     }
 
     pub async fn dispatch(&self, event: Event) -> anyhow::Result<()> {
+        let mut conversation = self.conversation.write().await;
         debug!(
-            conversation_id = %self.conversation_id,
+            conversation_id = %conversation.id,
             event_name = %event.name,
             event_value = %event.value,
             "Dispatching event"
         );
 
-        let agents = self
-            .app
-            .conversation_service()
-            .update(&self.conversation_id, |conversation| {
-                conversation.dispatch_event(event)
-            })
-            .await?;
+        // get the in-active agents.
+        let inactive_agents = conversation
+            .state
+            .iter()
+            .filter(|(_, state)| state.queue.is_empty())
+            .map(|(agent_id, _)| agent_id.clone())
+            .collect::<Vec<_>>();
+
+        // insert the event into the agents which have subscribed to the event.
+        conversation.insert_event(event.clone());
 
         // Execute all initialization futures in parallel
-        join_all(agents.iter().map(|id| self.init_agent(id)))
+        join_all(inactive_agents.iter().map(|id| self.init_agent(id)))
             .await
             .into_iter()
             .collect::<anyhow::Result<Vec<()>>>()?;
@@ -270,40 +279,42 @@ impl<A: App> Orchestrator<A> {
     }
 
     async fn get_last_event(&self, name: &str) -> anyhow::Result<Option<Event>> {
-        Ok(self.get_conversation().await?.rfind_event(name).cloned())
+        let conversation = self.conversation.read().await;
+        Ok(conversation.rfind_event(name).cloned())
     }
 
     async fn get_conversation(&self) -> anyhow::Result<Conversation> {
-        Ok(self
-            .app
-            .conversation_service()
-            .get(&self.conversation_id)
-            .await?
-            .ok_or(Error::ConversationNotFound(self.conversation_id.clone()))?)
+        Ok(self.conversation.read().await.clone())
     }
 
     async fn complete_turn(&self, agent_id: &AgentId) -> anyhow::Result<()> {
-        self.app
-            .conversation_service()
-            .inc_turn(&self.conversation_id, agent_id)
-            .await
+        let mut conversation = self.conversation.write().await;
+        conversation
+            .state
+            .entry(agent_id.clone())
+            .or_default()
+            .turn_count += 1;
+        Ok(())
     }
 
     async fn set_context(&self, agent_id: &AgentId, context: Context) -> anyhow::Result<()> {
-        self.app
-            .conversation_service()
-            .set_context(&self.conversation_id, agent_id, context)
-            .await
+        let mut conversation = self.conversation.write().await;
+        conversation
+            .state
+            .entry(agent_id.clone())
+            .or_default()
+            .context = Some(context.clone());
+        Ok(())
     }
 
     async fn init_agent_with_event(&self, agent_id: &AgentId, event: &Event) -> anyhow::Result<()> {
+        let conversation = self.get_conversation().await?;
         debug!(
-            conversation_id = %self.conversation_id,
+            conversation_id = %conversation.id,
             agent = %agent_id,
             event = ?event,
             "Initializing agent"
         );
-        let conversation = self.get_conversation().await?;
         let agent = conversation.workflow.get_agent(agent_id)?;
 
         let mut context = if agent.ephemeral.unwrap_or_default() {
@@ -389,24 +400,36 @@ impl<A: App> Orchestrator<A> {
 
             self.set_context(&agent.id, context.clone()).await?;
 
+            // sync the conversation service with the updated conversation
+            self.app
+                .conversation_service()
+                .set(&conversation.id, self.conversation.read().await.clone())
+                .await?;
+
             if tool_results.is_empty() {
                 break;
             }
         }
 
         self.complete_turn(&agent.id).await?;
+        // sync the conversation service with the updated conversation
+        self.app
+            .conversation_service()
+            .set(&conversation.id, self.conversation.read().await.clone())
+            .await?;
 
         Ok(())
     }
 
     async fn init_agent(&self, agent_id: &AgentId) -> anyhow::Result<()> {
-        let conversation_service = self.app.conversation_service();
-
-        while let Some(event) = conversation_service
-            .update(&self.conversation_id, |c| c.poll_event(agent_id))
-            .await?
-        {
-            self.init_agent_with_event(agent_id, &event).await?;
+        loop {
+            let mut conversation = self.conversation.write().await;
+            if let Some(event) = conversation.poll_event(agent_id) {
+                drop(conversation);
+                self.init_agent_with_event(agent_id, &event).await?;
+            } else {
+                break;
+            }
         }
 
         Ok(())

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -270,7 +270,7 @@ impl<A: App> Orchestrator<A> {
         let conversation = self.conversation.read().await.clone();
         self.app
             .conversation_service()
-            .set(&conversation.id.clone(), conversation)
+            .upsert(&conversation.id.clone(), conversation)
             .await?;
         Ok(())
     }

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -425,12 +425,8 @@ impl<A: App> Orchestrator<A> {
     }
 
     async fn init_agent(&self, agent_id: &AgentId) -> anyhow::Result<()> {
-        loop {
-            if let Some(event) = self.conversation.write().await.poll_event(agent_id) {
-                self.init_agent_with_event(agent_id, &event).await?;
-            } else {
-                break;
-            }
+        while let Some(event) = self.conversation.write().await.poll_event(agent_id) {
+            self.init_agent_with_event(agent_id, &event).await?;
         }
 
         Ok(())


### PR DESCRIPTION
## Overview
This PR refactors the conversation state management system to fix an issue where agent states incorrectly remain marked as active after Ctrl+C interruptions, leading to potential state corruption in subsequent interactions.

## Purpose
When users interrupt a conversation with Ctrl+C, the `is_active` flags on agents remained set to `true`, causing incorrect behavior if the conversation was resumed later. This refactoring removes the problematic flag entirely and fundamentally redesigns how agent activity is tracked and synchronized.

## Implementation
The implementation takes a three-pronged approach:

1. **Architecture Change**: The `Orchestrator` now maintains the conversation in memory with proper synchronization using `RwLock`, rather than repeatedly fetching it from storage.

2. **State Management**: Removed the `is_active` flag from `AgentState` and instead determine agent activity dynamically by checking if its event queue is empty.

3. **API Improvements**: Renamed methods in `ConversationService` to be more intuitive:
   - `get` → `find` (more explicit about possible absence)
   - Added `upsert` method for clear responsibility
   - Removed redundant methods by moving their functionality to the `Orchestrator`

4. **Synchronization**: Added explicit conversation state synchronization to ensure persistence after state changes.

## Testing
To test these changes:

1. Start a conversation with a multi-agent system
2. Interrupt with Ctrl+C during agent processing
3. Resume the conversation
4. Verify that agents properly respond to new events

This fix ensures that conversation state is properly maintained across interruptions without corruption.

## Related Issues
Fixes #561: "bug: Agent states remain active after Ctrl+C interruption"

## Changelog

### Changed in `conversation.rs`
- Removed `is_active` flag from `AgentState`
- Reworked `dispatch_event` to track activity based on queue emptiness
- Improved event handling to reduce cloning

### Changed in `lib.rs`
- Simplified `ConversationService` trait interface
- Renamed methods for clarity: `get` → `find` and added `upsert`
- Moved agent-specific operations to the `Orchestrator`

### Changed in `orch.rs`
- Redesigned `Orchestrator` to store conversation with `RwLock`
- Added conversation synchronization after state changes
- Improved event polling for better error handling
- Added queue clearing logic during initialization

### Changed in `api.rs` and `executor.rs`
- Updated to use new method names and patterns
- Improved conversation retrieval in executor service

## Suggested Reviewers
- @laststylebender14 - Owner of the related issue
- Team members familiar with the conversation system architecture