### PR TITLE
fix: preserve coloured output for sbt tests

### DIFF
--- a/crates/forge_services/src/tools/shell/executor.rs
+++ b/crates/forge_services/src/tools/shell/executor.rs
@@ -29,8 +29,7 @@ impl CommandExecutor {
         self.command.env("CLICOLOR_FORCE", "1");
 
         // Add Java-specific color options for SBT
-        self.command
-            .env("JAVA_OPTS", "-Dsbt.color=always");
+        self.command.env("JAVA_OPTS", "-Dsbt.color=always");
 
         self
     }

--- a/crates/forge_services/src/tools/shell/executor.rs
+++ b/crates/forge_services/src/tools/shell/executor.rs
@@ -30,7 +30,7 @@ impl CommandExecutor {
 
         // Add Java-specific color options for SBT
         self.command
-            .env("JAVA_OPTS", "-Dsbt.color=always -Dsbt.log.noformat=false");
+            .env("JAVA_OPTS", "-Dsbt.color=always");
 
         self
     }

--- a/crates/forge_services/src/tools/shell/executor.rs
+++ b/crates/forge_services/src/tools/shell/executor.rs
@@ -24,13 +24,23 @@ impl CommandExecutor {
 
     /// Enable colored output for the command. By default it's disabled.
     pub fn colored(mut self) -> Self {
-        // Force color output even through pipes or when not directly
-        // connected to a terminal (non-TTY environments)
+        // Core color settings for general commands
         self.command
             .env("CLICOLOR_FORCE", "1")
             .env("FORCE_COLOR", "true")
-            .env("SBT_OPTS", "-Dsbt.color=always")
             .env_remove("NO_COLOR");
+
+        // Language/program specific color settings
+        self.command
+            .env("SBT_OPTS", "-Dsbt.color=always")
+            .env("JAVA_OPTS", "-Dsbt.color=always");
+
+        // enabled Git colors
+        self.command
+            .env("GIT_CONFIG_PARAMETERS", "'color.ui=always'");
+
+        // Other common tools
+        self.command.env("GREP_OPTIONS", "--color=always"); // GNU grep
 
         self
     }

--- a/crates/forge_services/src/tools/shell/executor.rs
+++ b/crates/forge_services/src/tools/shell/executor.rs
@@ -22,9 +22,16 @@ impl CommandExecutor {
         Self { command }
     }
 
-    /// Enable colored output for the command. bydefault it's disabled.
+    /// Enable colored output for the command. By default it's disabled.
     pub fn colored(mut self) -> Self {
+        // Force color output even through pipes or when not directly
+        // connected to a terminal (non-TTY environments)
         self.command.env("CLICOLOR_FORCE", "1");
+
+        // Add Java-specific color options for SBT
+        self.command
+            .env("JAVA_OPTS", "-Dsbt.color=always -Dsbt.log.noformat=false");
+
         self
     }
 

--- a/crates/forge_services/src/tools/shell/executor.rs
+++ b/crates/forge_services/src/tools/shell/executor.rs
@@ -26,10 +26,11 @@ impl CommandExecutor {
     pub fn colored(mut self) -> Self {
         // Force color output even through pipes or when not directly
         // connected to a terminal (non-TTY environments)
-        self.command.env("CLICOLOR_FORCE", "1");
-
-        // Add Java-specific color options for SBT
-        self.command.env("JAVA_OPTS", "-Dsbt.color=always");
+        self.command
+            .env("CLICOLOR_FORCE", "1")
+            .env("FORCE_COLOR", "true")
+            .env("SBT_OPTS", "-Dsbt.color=always")
+            .env_remove("NO_COLOR");
 
         self
     }


### PR DESCRIPTION
fixes: #603

![image](https://github.com/user-attachments/assets/7caa9ba2-0699-48ec-a594-25f219697ce8)
