### PR TITLE
refactor: simplify command output formatting in shell execution

### DIFF
--- a/crates/forge_services/src/tools/shell/shell_tool.rs
+++ b/crates/forge_services/src/tools/shell/shell_tool.rs
@@ -101,11 +101,10 @@ impl ExecutableTool for Shell {
 
             println!(
                 "\n{}",
-                TitleFormat::execute(format!(
-                    "{} {} {}",
-                    self.env.shell, parameter, &input.command
-                ))
-                .format()
+                // parameter, &input.command
+                TitleFormat::execute(&input.command)
+                    .sub_title(format!("(using {})", self.env.shell.as_str()))
+                    .format()
             );
         }
 


### PR DESCRIPTION
**BEFORE**
<img width="453" alt="Screenshot 2025-04-05 at 9 39 23 AM" src="https://github.com/user-attachments/assets/0e446f05-75bf-402c-ae92-87195f9033da" />


**AFTER**
<img width="509" alt="Screenshot 2025-04-05 at 9 39 36 AM" src="https://github.com/user-attachments/assets/cb412ea7-f8e6-4c77-89fb-4e5c7abbcebd" />



fixes #602