### PR TITLE
fix(compaction): move decision logic to orchestrator for better separation of concerns

### DIFF
--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -291,6 +291,15 @@ impl Agent {
         Ok(ToolDefinition::new(self.id.as_str().to_string())
             .description(self.description.clone().unwrap()))
     }
+    /// Checks if compaction should be applied
+    pub fn should_compact(&self, context: &Context, prompt_tokens: Option<usize>) -> bool {
+        // Return false if compaction is not configured
+        if let Some(compact) = &self.compact {
+            compact.should_compact(context, prompt_tokens)
+        } else {
+            false
+        }
+    }
 }
 
 impl Key for Agent {

--- a/crates/forge_domain/src/services.rs
+++ b/crates/forge_domain/src/services.rs
@@ -28,12 +28,7 @@ pub trait ToolService: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait CompactionService: Send + Sync {
-    async fn compact_context(
-        &self,
-        agent: &Agent,
-        context: Context,
-        prompt_tokens: Option<usize>,
-    ) -> anyhow::Result<Context>;
+    async fn compact_context(&self, agent: &Agent, context: Context) -> anyhow::Result<Context>;
 }
 
 #[async_trait::async_trait]

--- a/crates/forge_services/src/conversation.rs
+++ b/crates/forge_services/src/conversation.rs
@@ -99,7 +99,7 @@ impl<C: CompactionService> ConversationService for ForgeConversationService<C> {
         // Perform compaction
         let new_context = self
             .compaction_service
-            .compact_context(agent, context.clone(), None)
+            .compact_context(agent, context.clone())
             .await?;
 
         // Compute compacted metrics


### PR DESCRIPTION
## Refactoring Context Compaction Logic

This PR moves the compaction decision logic from the compaction service to the orchestrator, improving separation of concerns. The orchestrator now determines when compaction should occur while the compaction service focuses solely on applying the compaction.

### Key Improvements

- **Better Separation of Concerns:** Orchestrator makes decisions, services perform actions
- **Simplified API:** CompactionService now has a cleaner interface focused only on its core responsibility
- **Improved Code Organization:** Added a helper method to Agent for determining if compaction is needed
- **Guaranteed Compaction Command:** Ensures the /compact command will always compress the context regardless of thresholds

### Implementation Details

1. Added 'should_compact' method to the Agent struct that reuses the existing logic from Compact
2. Simplified the CompactionService trait to remove decision-making responsibility
3. Updated the Orchestrator to check compaction conditions before calling the service
4. Removed unnecessary decision logic from the compaction service implementation
5. Updated all call sites to use the new interfaces

These changes ensure that the orchestrator, which has context about the overall conversation state, is responsible for determining when compaction should occur, while the compaction service focuses on the technical implementation of how to compact. Additionally, the /compact command will now always perform compaction when explicitly requested, regardless of whether the normal compaction thresholds are met.