### PR TITLE
feat(cli): enhance  command output and refactor formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "derive_setters",
  "forge_api",
  "forge_display",
+ "forge_domain",
  "forge_fs",
  "forge_snaps",
  "forge_spinner",

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 clap.workspace = true
 forge_api.workspace = true
+forge_domain.workspace = true
 forge_walker.workspace = true
 forge_display.workspace = true
 forge_tracker.workspace = true

--- a/crates/forge_main/src/lib.rs
+++ b/crates/forge_main/src/lib.rs
@@ -8,6 +8,7 @@ mod input;
 mod model;
 mod prompt;
 mod state;
+mod tools_display;
 mod ui;
 
 pub use auto_update::update_forge;

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -180,6 +180,7 @@ impl ForgeCommandManager {
             "/plan" => Ok(Command::Plan),
             "/help" => Ok(Command::Help),
             "/model" => Ok(Command::Model),
+            "/tools" => Ok(Command::Tools),
             text => {
                 let parts = text.split_ascii_whitespace().collect::<Vec<&str>>();
 
@@ -248,6 +249,10 @@ pub enum Command {
     /// This can be triggered with the '/model' command.
     #[strum(props(usage = "Switch to a different model"))]
     Model,
+    /// List all available tools with their descriptions and schema
+    /// This can be triggered with the '/tools' command.
+    #[strum(props(usage = "List all available tools with their descriptions and schema"))]
+    Tools,
     /// Handles custom command defined in workflow file.
     Custom(PartialEvent),
     /// Executes a native shell command.
@@ -269,6 +274,7 @@ impl Command {
             Command::Help => "/help",
             Command::Dump(_) => "/dump",
             Command::Model => "/model",
+            Command::Tools => "/tools",
             Command::Custom(event) => &event.name,
             Command::Shell(_) => "!shell",
         }

--- a/crates/forge_main/src/tools_display.rs
+++ b/crates/forge_main/src/tools_display.rs
@@ -18,7 +18,7 @@ pub fn format_tools(tools: &[ToolDefinition]) -> String {
         let schema = format!("{}", schema_json.dimmed());
 
         if i > 0 {
-            out.push_str("\n");
+            out.push('\n');
         }
 
         out.push_str(&format!("{}\n{}\n{}\n", name, description, schema));

--- a/crates/forge_main/src/tools_display.rs
+++ b/crates/forge_main/src/tools_display.rs
@@ -1,0 +1,28 @@
+use colored::Colorize;
+use forge_api::ToolDefinition;
+use serde_json::to_string_pretty;
+
+/// Formats the list of tools for display in the shell UI, following these
+/// rules:
+/// - Name: blue bold
+/// - Description: default
+/// - Input json schema: dimmed, pretty-printed, multi-line
+/// - Blank line between each tool
+pub fn format_tools(tools: &[ToolDefinition]) -> String {
+    let mut out = String::new();
+
+    for (i, tool) in tools.iter().enumerate() {
+        let name = tool.name.as_str().blue().bold();
+        let description = &tool.description;
+        let schema_json = to_string_pretty(&tool.input_schema).unwrap_or_else(|_| "{}".to_string());
+        let schema = format!("{}", schema_json.dimmed());
+
+        if i > 0 {
+            out.push_str("\n");
+        }
+
+        out.push_str(&format!("{}\n{}\n{}\n", name, description, schema));
+    }
+
+    out
+}

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -206,6 +206,12 @@ impl<F: API> UI<F> {
                     let info = Info::from(self.command.as_ref());
                     println!("{}", info);
                 }
+                Command::Tools => {
+                    use crate::tools_display::format_tools;
+                    let tools = self.api.tools().await;
+                    let output = format_tools(&tools);
+                    println!("{}", output);
+                }
                 Command::Exit => {
                     update_forge().await;
 


### PR DESCRIPTION
Adds a dedicated formatter for  command output and refactors tool display logic out of the Info struct. Provides a clearer and more structured listing of available tools within the Forge CLI.\n\n- Implements a new  function in a dedicated module () for consistent tool information display.\n- Formats tool name as blue and bold, description with default styling, and input JSON schema as dimmed multi-line text.\n- Removes redundant tool formatting logic from the  struct to centralize display concerns.\n- Updates the  command handler in the UI to utilize the new formatting function.