### PR TITLE
feat(display): add plain text diff output to patch tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "console",
  "derive_more 2.0.1",
  "derive_setters",
  "dissimilar",

--- a/crates/forge_domain/src/conversation_html.rs
+++ b/crates/forge_domain/src/conversation_html.rs
@@ -232,9 +232,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                                         .append(Element::new("strong").text("Tool Result: "))
                                         .append(Element::span(tool_result.name.as_str())),
                                 )
-                                .append(Element::new("pre").text(
-                                    to_string_pretty(&tool_result.content).unwrap_or_default(),
-                                ))
+                                .append(Element::new("pre").text(&tool_result.content))
                         }
                         ContextMessage::Image(url) => {
                             // Image message

--- a/crates/forge_domain/src/tool_call_parser.rs
+++ b/crates/forge_domain/src/tool_call_parser.rs
@@ -448,7 +448,7 @@ mod tests {
     fn test_unrecognized_closing_tags() {
         let input = "<tool_call><foo><p></abc></p></tool_call>";
 
-        let action = parse(&input).unwrap();
+        let action = parse(input).unwrap();
         let expected = vec![ToolCallFull {
             name: ToolName::new("foo"),
             call_id: None,

--- a/crates/forge_domain/src/tool_call_parser.rs
+++ b/crates/forge_domain/src/tool_call_parser.rs
@@ -58,9 +58,6 @@ fn parse_tool_call(input: &str) -> IResult<&str, ToolCallParsed> {
     // Match all the arguments with whitespace
     let (input, args) = parse_args(input)?;
 
-    // Ignore everything until the closing tag
-    let (input, _) = take_until("</tool_call>").parse(input)?;
-
     Ok((
         input,
         ToolCallParsed {
@@ -434,6 +431,19 @@ mod tests {
     #[test]
     fn test_parse_missing_closing() {
         let input = "<tool_call><foo><p>abc</p></tool_call>";
+
+        let action = parse(input).unwrap();
+        let expected = vec![ToolCallFull {
+            name: ToolName::new("foo"),
+            call_id: None,
+            arguments: serde_json::from_str(r#"{"p":"abc"}"#).unwrap(),
+        }];
+        assert_eq!(action, expected);
+    }
+
+    #[test]
+    fn test_parse_missing_closing_outer() {
+        let input = "<tool_call><foo><p>abc</p></foo>";
 
         let action = parse(input).unwrap();
         let expected = vec![ToolCallFull {

--- a/crates/forge_domain/src/tool_call_parser.rs
+++ b/crates/forge_domain/src/tool_call_parser.rs
@@ -436,7 +436,7 @@ mod tests {
     fn test_parse_missing_closing() {
         let input = "<tool_call><foo><p>abc</p></tool_call>";
 
-        let action = parse(&input).unwrap();
+        let action = parse(input).unwrap();
         let expected = vec![ToolCallFull {
             name: ToolName::new("foo"),
             call_id: None,

--- a/crates/forge_provider/src/open_router/provider.rs
+++ b/crates/forge_provider/src/open_router/provider.rs
@@ -81,16 +81,15 @@ impl OpenRouter {
         request = ProviderPipeline::new(&self.provider).transform(request);
 
         let url = self.url("chat/completions")?;
-        let cache_breakpoints: usize = request
-            .messages
-            .iter()
-            .flatten()
-            .flat_map(|msg| msg.content.as_ref())
-            .map(|msg| msg.count_cache_parts())
-            .sum();
-        
-        debug!(url = %url, model = %model, cache_breakpoints = %cache_breakpoints, "Connecting Upstream");
-        
+
+        debug!(
+            url = %url,
+            model = %model,
+            message_count = %request.message_count(),
+            message_cache_count = %request.message_cache_count(),
+            "Connecting Upstream"
+        );
+
         let mut es = self
             .client
             .post(url.clone())

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -60,22 +60,6 @@ impl MessageContent {
             _ => self,
         }
     }
-
-    pub fn count_cache_parts(&self) -> usize {
-        match self {
-            MessageContent::Text(_) => 0,
-            MessageContent::Parts(parts) => parts
-                .iter()
-                .filter(|part| {
-                    if let ContentPart::Text { cache_control, .. } = part {
-                        cache_control.is_some()
-                    } else {
-                        false
-                    }
-                })
-                .count(),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -1,3 +1,5 @@
+use std::usize;
+
 use derive_more::derive::Display;
 use derive_setters::Setters;
 use forge_domain::{
@@ -56,6 +58,22 @@ impl MessageContent {
                 cache_control: Some(CacheControl { type_: CacheControlType::Ephemeral }),
             }]),
             _ => self,
+        }
+    }
+
+    pub fn count_cache_parts(&self) -> usize {
+        match self {
+            MessageContent::Text(_) => 0,
+            MessageContent::Parts(parts) => parts
+                .iter()
+                .filter(|part| {
+                    if let ContentPart::Text { cache_control, .. } = part {
+                        cache_control.is_some()
+                    } else {
+                        false
+                    }
+                })
+                .count(),
         }
     }
 }

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -60,6 +60,20 @@ impl MessageContent {
             _ => self,
         }
     }
+
+    #[cfg(test)]
+    pub fn is_cached(&self) -> bool {
+        match self {
+            MessageContent::Text(_) => false,
+            MessageContent::Parts(parts) => parts.iter().any(|part| {
+                if let ContentPart::Text { cache_control, .. } = part {
+                    cache_control.is_some()
+                } else {
+                    false
+                }
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -190,6 +190,26 @@ pub struct OpenRouterRequest {
     pub parallel_tool_calls: Option<bool>,
 }
 
+impl OpenRouterRequest {
+    pub fn message_count(&self) -> usize {
+        self.messages
+            .as_ref()
+            .map(|messages| messages.len())
+            .unwrap_or(0)
+    }
+
+    pub fn message_cache_count(&self) -> usize {
+        self.messages
+            .iter()
+            .flatten()
+            .flat_map(|a| a.content.as_ref())
+            .enumerate()
+            .map(|(i, _)| i)
+            .max()
+            .unwrap_or(0)
+    }
+}
+
 /// ref: https://openrouter.ai/docs/transforms
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub enum Transform {

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 use derive_more::derive::Display;
 use derive_setters::Setters;
 use forge_domain::{

--- a/crates/forge_provider/src/open_router/request.rs
+++ b/crates/forge_provider/src/open_router/request.rs
@@ -258,7 +258,7 @@ impl From<Context> for OpenRouterRequest {
             min_p: Default::default(),
             top_a: Default::default(),
             prediction: Default::default(),
-            transforms: Some(vec![Transform::default()]),
+            transforms: Default::default(),
             models: Default::default(),
             route: Default::default(),
             provider: Default::default(),

--- a/crates/forge_provider/src/open_router/transformers/set_cache.rs
+++ b/crates/forge_provider/src/open_router/transformers/set_cache.rs
@@ -15,9 +15,10 @@ impl Transformer for SetCache {
                         cache_positions.push(i);
                     }
                     last_was_user = true;
-                } else if message.role == OpenRouterRole::Assistant
-                    || message.role == OpenRouterRole::System
-                {
+                } else if message.role == OpenRouterRole::Assistant {
+                    last_was_user = false;
+                } else if message.role == OpenRouterRole::System {
+                    cache_positions.push(i);
                     last_was_user = false;
                 }
             }
@@ -110,15 +111,15 @@ mod tests {
         assert_eq!(actual, expected);
 
         let actual = create_test_context("suuau");
-        let expected = "suuau";
+        let expected = "[suuau";
         assert_eq!(actual, expected);
 
         let actual = create_test_context("suuauu");
-        let expected = "suuauu";
+        let expected = "[suuauu";
         assert_eq!(actual, expected);
 
         let actual = create_test_context("suuauuaaau");
-        let expected = "s[uuauuaaau";
+        let expected = "[s[uuauuaaau";
         assert_eq!(actual, expected);
 
         let actual = create_test_context("suuauuaaauauau");

--- a/crates/forge_provider/src/open_router/transformers/set_cache.rs
+++ b/crates/forge_provider/src/open_router/transformers/set_cache.rs
@@ -92,7 +92,7 @@ mod tests {
 
         for (i, c) in message.to_string().chars().enumerate() {
             if sequences.contains(&i) {
-                output.push_str("[");
+                output.push('[');
             }
             output.push_str(c.to_string().as_str())
         }

--- a/crates/forge_provider/src/open_router/transformers/set_cache.rs
+++ b/crates/forge_provider/src/open_router/transformers/set_cache.rs
@@ -38,16 +38,15 @@ impl Transformer for SetCache {
 #[cfg(test)]
 mod tests {
     use forge_domain::{ContentMessage, Context, ContextMessage, Role};
+    use pretty_assertions::assert_eq;
 
     use super::*;
-    use pretty_assertions::assert_eq;
 
     fn create_test_context(message: impl ToString) -> Vec<usize> {
         let context = Context {
             messages: message
                 .to_string()
                 .chars()
-                .into_iter()
                 .map(|c| match c {
                     's' => ContextMessage::ContentMessage(ContentMessage {
                         role: Role::System,

--- a/crates/forge_provider/src/open_router/transformers/set_cache.rs
+++ b/crates/forge_provider/src/open_router/transformers/set_cache.rs
@@ -6,53 +6,108 @@ pub struct SetCache;
 
 impl Transformer for SetCache {
     fn transform(&self, mut request: OpenRouterRequest) -> OpenRouterRequest {
-        if let (Some(mut messages), Some(model)) = (request.messages.take(), request.model.take()) {
-            if let Some(msg) = messages
-                .iter_mut()
-                .rev()
-                .find(|msg| matches!(msg.role, OpenRouterRole::System | OpenRouterRole::User))
-            {
-                msg.content = msg.content.take().map(|content| content.cached());
+        if let Some(messages) = request.messages.as_mut() {
+            let mut last_was_user = false;
+            let mut cache_positions = Vec::new();
+            for (i, message) in messages.iter().enumerate() {
+                if message.role == OpenRouterRole::User {
+                    if !last_was_user {
+                        cache_positions.push(i);
+                    }
+                    last_was_user = true;
+                } else if message.role == OpenRouterRole::Assistant
+                    || message.role == OpenRouterRole::System
+                {
+                    last_was_user = false;
+                }
             }
 
-            request.messages = Some(messages);
-            request.model = Some(model);
+            for pos in cache_positions.into_iter().rev().take(2) {
+                if let Some(ref content) = messages[pos].content {
+                    messages[pos].content = Some(content.clone().cached());
+                }
+            }
+
+            request
+        } else {
+            request
         }
-        request
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use forge_domain::{ContentMessage, Context, ContextMessage, ModelId, Role};
+    use forge_domain::{ContentMessage, Context, ContextMessage, Role};
 
     use super::*;
-    use crate::open_router::request::MessageContent;
+    use pretty_assertions::assert_eq;
 
-    #[test]
-    fn test_sonnet_transformer_caching() {
+    fn create_test_context(message: impl ToString) -> Vec<usize> {
         let context = Context {
-            messages: vec![ContextMessage::ContentMessage(ContentMessage {
-                role: Role::User,
-                content: "test message".to_string(),
-                tool_calls: None,
-            })],
+            messages: message
+                .to_string()
+                .chars()
+                .into_iter()
+                .map(|c| match c {
+                    's' => ContextMessage::ContentMessage(ContentMessage {
+                        role: Role::System,
+                        content: c.to_string(),
+                        tool_calls: None,
+                    }),
+                    'u' => ContextMessage::ContentMessage(ContentMessage {
+                        role: Role::User,
+                        content: c.to_string(),
+                        tool_calls: None,
+                    }),
+                    'a' => ContextMessage::ContentMessage(ContentMessage {
+                        role: Role::Assistant,
+                        content: c.to_string(),
+                        tool_calls: None,
+                    }),
+                    _ => {
+                        panic!("Invalid character in test message");
+                    }
+                })
+                .collect::<Vec<_>>(),
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
             temperature: None,
         };
 
-        let request =
-            OpenRouterRequest::from(context).model(ModelId::new("anthropic/claude-3.5-sonnet"));
+        let request = OpenRouterRequest::from(context);
+        let request = SetCache.transform(request);
+        request
+            .messages
+            .into_iter()
+            .flatten()
+            .flat_map(|m| m.content)
+            .enumerate()
+            .filter(|(_, m)| m.is_cached())
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>()
+    }
 
-        let transformer = SetCache;
-        let transformed = transformer.transform(request);
+    #[test]
+    fn test_transformation() {
+        let actual = create_test_context("suu");
+        let expected = vec![1];
+        assert_eq!(actual, expected);
 
-        let messages = transformed.messages.unwrap();
-        assert!(matches!(
-            messages[0].content,
-            Some(MessageContent::Parts(_))
-        ));
+        let actual = create_test_context("suua");
+        let expected = vec![1];
+        assert_eq!(actual, expected);
+
+        let actual = create_test_context("suuau");
+        let expected = vec![1, 4];
+        assert_eq!(actual, expected);
+
+        let actual = create_test_context("suuauu");
+        let expected = vec![1, 4];
+        assert_eq!(actual, expected);
+
+        let actual = create_test_context("suuauuaaau");
+        let expected = vec![4, 9];
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/forge_provider/src/open_router/transformers/transformer.rs
+++ b/crates/forge_provider/src/open_router/transformers/transformer.rs
@@ -93,11 +93,11 @@ mod tests {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
         let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
-        
+
         // Apply transformation with condition that should match
         let conditional = transformer.when_model_matches_condition("claude", true);
         let actual = conditional.transform(request);
-        
+
         // Expected: model name should be prefixed
         assert_eq!(actual.model.unwrap().as_str(), "prefix-anthropic/claude-3");
     }
@@ -107,11 +107,11 @@ mod tests {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
         let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
-        
+
         // Apply transformation with condition that should not match
         let conditional = transformer.when_model_matches_condition("claude", false);
         let actual = conditional.transform(request);
-        
+
         // Expected: model name should remain unchanged
         assert_eq!(actual.model.unwrap().as_str(), "anthropic/claude-3");
     }
@@ -121,11 +121,11 @@ mod tests {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
         let request = OpenRouterRequest::default().model(ModelId::new("openai/gpt-4"));
-        
+
         // Apply transformation with condition that should not match
         let conditional = transformer.when_model_matches_condition("claude", true);
         let actual = conditional.transform(request);
-        
+
         // Expected: model name should remain unchanged
         assert_eq!(actual.model.unwrap().as_str(), "openai/gpt-4");
     }
@@ -135,11 +135,11 @@ mod tests {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
         let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
-        
+
         // Apply transformation with when_model
         let conditional = transformer.when_model("claude");
         let actual = conditional.transform(request);
-        
+
         // Expected: model name should be prefixed
         assert_eq!(actual.model.unwrap().as_str(), "prefix-anthropic/claude-3");
     }
@@ -148,21 +148,23 @@ mod tests {
     fn test_except_when_model() {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
-        
+
         // Test with a model that should be excluded
         let request1 = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
         let conditional = transformer.except_when_model("claude");
         let actual1 = conditional.transform(request1);
-        // Expected: model name should remain unchanged (because it matches the pattern and matches=false)
+        // Expected: model name should remain unchanged (because it matches the pattern
+        // and matches=false)
         assert_eq!(actual1.model.unwrap().as_str(), "anthropic/claude-3");
-        
+
         // Create a new transformer since the previous one was consumed
         let transformer2 = TestTransformer { prefix: "prefix-".to_string() };
         // Test with a model that should not be excluded
         let request2 = OpenRouterRequest::default().model(ModelId::new("openai/gpt-4"));
         let conditional2 = transformer2.except_when_model("claude");
         let actual2 = conditional2.transform(request2);
-        // Expected: model name should be prefixed (because it doesn't match the pattern)
+        // Expected: model name should be prefixed (because it doesn't match the
+        // pattern)
         assert_eq!(actual2.model.unwrap().as_str(), "prefix-openai/gpt-4");
     }
 
@@ -172,11 +174,11 @@ mod tests {
         let transformer1 = TestTransformer { prefix: "prefix1-".to_string() };
         let transformer2 = TestTransformer { prefix: "prefix2-".to_string() };
         let request = OpenRouterRequest::default().model(ModelId::new("model"));
-        
+
         // Apply combined transformations
         let combined = transformer1.combine(transformer2);
         let actual = combined.transform(request);
-        
+
         // Expected: both prefixes should be applied (in the correct order)
         assert_eq!(actual.model.unwrap().as_str(), "prefix1-prefix2-model");
     }
@@ -186,19 +188,23 @@ mod tests {
         // Fixture for first test
         let transformer1 = TestTransformer { prefix: "prefix-".to_string() };
         let request1 = OpenRouterRequest::default().model(ModelId::new("model"));
-        
+
         // Test with a condition that should match
         let conditional1 = transformer1.when(|req| req.model.is_some());
         let actual1 = conditional1.transform(request1);
         // Expected: model name should be prefixed
         assert_eq!(actual1.model.unwrap().as_str(), "prefix-model");
-        
+
         // Fixture for second test (need a new transformer since when takes ownership)
         let transformer2 = TestTransformer { prefix: "prefix-".to_string() };
         let request2 = OpenRouterRequest::default().model(ModelId::new("model"));
-        
+
         // Test with a condition that should not match
-        let conditional2 = transformer2.when(|req| req.model.as_ref().map_or(false, |m| m.as_str().contains("other")));
+        let conditional2 = transformer2.when(|req| {
+            req.model
+                .as_ref()
+                .is_some_and(|m| m.as_str().contains("other"))
+        });
         let actual2 = conditional2.transform(request2);
         // Expected: model name should remain unchanged
         assert_eq!(actual2.model.unwrap().as_str(), "model");
@@ -209,11 +215,11 @@ mod tests {
         // Fixture
         let transformer = TestTransformer { prefix: "prefix-".to_string() };
         let request = OpenRouterRequest::default(); // No model set
-        
+
         // Apply transformation with when_model
         let conditional = transformer.when_model("claude");
         let actual = conditional.transform(request);
-        
+
         // Expected: request should remain unchanged
         assert!(actual.model.is_none());
     }
@@ -223,11 +229,14 @@ mod tests {
         // Fixture
         let transformer = Identity;
         let request = OpenRouterRequest::default().model(ModelId::new("model"));
-        
+
         // Apply identity transformation
         let actual = transformer.transform(request.clone());
-        
+
         // Expected: request should remain unchanged
-        assert_eq!(actual.model.unwrap().as_str(), request.model.unwrap().as_str());
+        assert_eq!(
+            actual.model.unwrap().as_str(),
+            request.model.unwrap().as_str()
+        );
     }
 }

--- a/crates/forge_provider/src/open_router/transformers/transformer.rs
+++ b/crates/forge_provider/src/open_router/transformers/transformer.rs
@@ -24,7 +24,7 @@ pub trait Transformer {
         self.when(move |req| {
             req.model
                 .as_ref()
-                .map(|name| regex.is_match(name.as_str()) && matches)
+                .map(|name| regex.is_match(name.as_str()) == matches)
                 .unwrap_or(true)
         })
     }
@@ -62,5 +62,172 @@ pub trait Transformer {
         Self: Sized,
     {
         When(self, condition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use forge_domain::ModelId;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::open_router::transformers::identity::Identity;
+
+    // A simple test transformer that adds a prefix to the model name
+    struct TestTransformer {
+        prefix: String,
+    }
+
+    impl Transformer for TestTransformer {
+        fn transform(&self, mut request: OpenRouterRequest) -> OpenRouterRequest {
+            if let Some(model) = request.model.as_mut() {
+                let new_model = format!("{}{}", self.prefix, model.as_str());
+                *model = ModelId::new(&new_model);
+            }
+            request
+        }
+    }
+
+    #[test]
+    fn test_when_model_matches_condition_true() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
+        
+        // Apply transformation with condition that should match
+        let conditional = transformer.when_model_matches_condition("claude", true);
+        let actual = conditional.transform(request);
+        
+        // Expected: model name should be prefixed
+        assert_eq!(actual.model.unwrap().as_str(), "prefix-anthropic/claude-3");
+    }
+
+    #[test]
+    fn test_when_model_matches_condition_false() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
+        
+        // Apply transformation with condition that should not match
+        let conditional = transformer.when_model_matches_condition("claude", false);
+        let actual = conditional.transform(request);
+        
+        // Expected: model name should remain unchanged
+        assert_eq!(actual.model.unwrap().as_str(), "anthropic/claude-3");
+    }
+
+    #[test]
+    fn test_when_model_matches_condition_no_match() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        let request = OpenRouterRequest::default().model(ModelId::new("openai/gpt-4"));
+        
+        // Apply transformation with condition that should not match
+        let conditional = transformer.when_model_matches_condition("claude", true);
+        let actual = conditional.transform(request);
+        
+        // Expected: model name should remain unchanged
+        assert_eq!(actual.model.unwrap().as_str(), "openai/gpt-4");
+    }
+
+    #[test]
+    fn test_when_model() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        let request = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
+        
+        // Apply transformation with when_model
+        let conditional = transformer.when_model("claude");
+        let actual = conditional.transform(request);
+        
+        // Expected: model name should be prefixed
+        assert_eq!(actual.model.unwrap().as_str(), "prefix-anthropic/claude-3");
+    }
+
+    #[test]
+    fn test_except_when_model() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        
+        // Test with a model that should be excluded
+        let request1 = OpenRouterRequest::default().model(ModelId::new("anthropic/claude-3"));
+        let conditional = transformer.except_when_model("claude");
+        let actual1 = conditional.transform(request1);
+        // Expected: model name should remain unchanged (because it matches the pattern and matches=false)
+        assert_eq!(actual1.model.unwrap().as_str(), "anthropic/claude-3");
+        
+        // Create a new transformer since the previous one was consumed
+        let transformer2 = TestTransformer { prefix: "prefix-".to_string() };
+        // Test with a model that should not be excluded
+        let request2 = OpenRouterRequest::default().model(ModelId::new("openai/gpt-4"));
+        let conditional2 = transformer2.except_when_model("claude");
+        let actual2 = conditional2.transform(request2);
+        // Expected: model name should be prefixed (because it doesn't match the pattern)
+        assert_eq!(actual2.model.unwrap().as_str(), "prefix-openai/gpt-4");
+    }
+
+    #[test]
+    fn test_combine() {
+        // Fixture
+        let transformer1 = TestTransformer { prefix: "prefix1-".to_string() };
+        let transformer2 = TestTransformer { prefix: "prefix2-".to_string() };
+        let request = OpenRouterRequest::default().model(ModelId::new("model"));
+        
+        // Apply combined transformations
+        let combined = transformer1.combine(transformer2);
+        let actual = combined.transform(request);
+        
+        // Expected: both prefixes should be applied (in the correct order)
+        assert_eq!(actual.model.unwrap().as_str(), "prefix1-prefix2-model");
+    }
+
+    #[test]
+    fn test_when() {
+        // Fixture for first test
+        let transformer1 = TestTransformer { prefix: "prefix-".to_string() };
+        let request1 = OpenRouterRequest::default().model(ModelId::new("model"));
+        
+        // Test with a condition that should match
+        let conditional1 = transformer1.when(|req| req.model.is_some());
+        let actual1 = conditional1.transform(request1);
+        // Expected: model name should be prefixed
+        assert_eq!(actual1.model.unwrap().as_str(), "prefix-model");
+        
+        // Fixture for second test (need a new transformer since when takes ownership)
+        let transformer2 = TestTransformer { prefix: "prefix-".to_string() };
+        let request2 = OpenRouterRequest::default().model(ModelId::new("model"));
+        
+        // Test with a condition that should not match
+        let conditional2 = transformer2.when(|req| req.model.as_ref().map_or(false, |m| m.as_str().contains("other")));
+        let actual2 = conditional2.transform(request2);
+        // Expected: model name should remain unchanged
+        assert_eq!(actual2.model.unwrap().as_str(), "model");
+    }
+
+    #[test]
+    fn test_when_model_no_model() {
+        // Fixture
+        let transformer = TestTransformer { prefix: "prefix-".to_string() };
+        let request = OpenRouterRequest::default(); // No model set
+        
+        // Apply transformation with when_model
+        let conditional = transformer.when_model("claude");
+        let actual = conditional.transform(request);
+        
+        // Expected: request should remain unchanged
+        assert!(actual.model.is_none());
+    }
+
+    #[test]
+    fn test_identity_transformer() {
+        // Fixture
+        let transformer = Identity;
+        let request = OpenRouterRequest::default().model(ModelId::new("model"));
+        
+        // Apply identity transformation
+        let actual = transformer.transform(request.clone());
+        
+        // Expected: request should remain unchanged
+        assert_eq!(actual.model.unwrap().as_str(), request.model.unwrap().as_str());
     }
 }

--- a/crates/forge_services/Cargo.toml
+++ b/crates/forge_services/Cargo.toml
@@ -48,6 +48,7 @@ base64.workspace = true
 strum_macros.workspace = true
 strum.workspace = true
 bytes.workspace = true
+console.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_services/src/tools/fs/fs_undo.rs
+++ b/crates/forge_services/src/tools/fs/fs_undo.rs
@@ -70,7 +70,7 @@ impl<F: Infrastructure> ExecutableTool for FsUndo<F> {
         let display_path = self.format_display_path(path)?;
 
         // Display a message about the file being undone
-        let message = TitleFormat::new("undo").title(display_path.clone());
+        let message = TitleFormat::new("undo").sub_title(display_path.clone());
         context.send_text(message.format()).await?;
 
         Ok(format!(

--- a/crates/forge_services/src/tools/patch.rs
+++ b/crates/forge_services/src/tools/patch.rs
@@ -288,9 +288,6 @@ impl<F: Infrastructure> ExecutableTool for ApplyPatchJson<F> {
             &current_content,
         );
 
-        // Output diff either to sender or println
-        context.send_text(diff).await?;
-
         // Write final content to file after all patches are applied
         self.0
             .file_write_service()
@@ -303,9 +300,12 @@ impl<F: Infrastructure> ExecutableTool for ApplyPatchJson<F> {
         // Format the output
         let result = format_output(
             path.to_string_lossy().as_ref(),
-            &current_content,
+            console::strip_ansi_codes(&diff).as_ref(),
             warning.as_deref(),
         );
+
+        // Output diff either to sender or println
+        context.send_text(diff).await?;
 
         // Return the final result
         Ok(result)

--- a/forge.yaml
+++ b/forge.yaml
@@ -12,6 +12,7 @@ commands:
       - Top-level summary should contain 2-3 lines about the core functionality improvements
 max_walker_depth: 1024
 tool_supported: false
+temperature: 0
 custom_rules: |-
   Handling Errors:
 

--- a/templates/partial-system-info.hbs
+++ b/templates/partial-system-info.hbs
@@ -1,7 +1,6 @@
 ```
 <system_info>
 <operating_system>{{env.os}}</operating_system>
-<current_time>{{current_time}}</current_time>
 <current_working_directory>{{env.cwd}}</current_working_directory>
 <default_shell>{{env.shell}}</default_shell>
 <home_directory>{{env.home}}</home_directory>

--- a/templates/partial-tool-information.hbs
+++ b/templates/partial-tool-information.hbs
@@ -25,23 +25,36 @@ Here's a correct example structure:
 
 Example of correct multi-step tool usage:
 
-First message:
 ```
+First message to read file_a:
 <tool_call>
 <tool_forge_fs_read>
-<path>/path/to/file</path>
+<path>/path/to/file_a</path>
 </tool_forge_fs_read>
 </tool_call>
-```
 
-After receiving response from the user, second message:
-```
+User response for the first message:
+<tool_result>
+<tool_forge_fs_create>  
+<success>[success message]</success>
+</tool_forge_fs_create>
+<tool_result>
+
+
+Second request to read file_b:
 <tool_call>
 <tool_forge_fs_create>
-<path>/path/to/file</path>
+<path>/path/to/file_b</path>
 <content>New content</content>
 </tool_forge_fs_create>
 </tool_call>
+
+User response for the second message:
+<tool_result>
+<tool_forge_fs_create>  
+<success>[success message]</success>
+</tool_forge_fs_create>
+<tool_result>
 ```
 
 Important:
@@ -50,6 +63,8 @@ Important:
 - Do NOT use JSON format (e.g., `tool_name({"param": "value"})`)
 - Do NOT mix formats in the same message
 - If you need to make multiple tool calls, send them in separate messages
+- Tool results will be wrapped in a `tool_result` tag by the user
+- Do not assume a tool call succeeded without a tool_result
 
 Before using a tool, ensure all required parameters are available. 
 If any required parameters are missing, do not attempt to use the tool.


### PR DESCRIPTION
## Summary
Enhances the patch tool to return a plain text diff as the final output instead of XML content. The implementation maintains colored diffs for the interactive display while ensuring that the final output uses text-only formatting without ANSI color codes.

## Changes
- Added `format_plain` and `format_with_options` methods to `DiffFormat` in forge_display
- Modified the `format_output` function in patch.rs to return plain text diffs
- Maintained backward compatibility with tests
- Added a new test to verify plain text output has no ANSI codes

## Testing
All tests pass with the new implementation. Added a specific test for the plain text output.
