### PR TITLE
Refactor: Simplify ForgeTemplateService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "derive_setters",
  "forge_stream",
  "forge_template",
+ "forge_walker",
  "futures",
  "insta",
  "merge",

--- a/crates/forge_domain/Cargo.toml
+++ b/crates/forge_domain/Cargo.toml
@@ -29,6 +29,7 @@ merge.workspace = true
 tokio-retry = { workspace = true }
 serde_yml.workspace = true
 forge_template.workspace = true
+forge_walker.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_domain/src/services.rs
+++ b/crates/forge_domain/src/services.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
 use serde_json::Value;
 
 use crate::{
-    Agent, Attachment, ChatCompletionMessage, Compact, CompactionResult, Context, Conversation,
-    ConversationId, Environment, Event, EventContext, Model, ModelId, ResultStream, SystemContext,
-    Template, ToolCallContext, ToolCallFull, ToolDefinition, ToolResult, Workflow,
+    Agent, Attachment, ChatCompletionMessage, CompactionResult, Context, Conversation,
+    ConversationId, Environment, Model, ModelId, ResultStream
+    , ToolCallContext, ToolCallFull, ToolDefinition, ToolResult, Workflow,
 };
 
 #[async_trait::async_trait]
@@ -63,29 +61,10 @@ pub trait ConversationService: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait TemplateService: Send + Sync {
-    async fn render_system(
+    fn render(
         &self,
-        agent: &Agent,
-        prompt: &Template<SystemContext>,
-        variables: &HashMap<String, Value>,
-    ) -> anyhow::Result<String>;
-
-    async fn render_event(
-        &self,
-        agent: &Agent,
-        prompt: &Template<EventContext>,
-        event: &Event,
-        variables: &HashMap<String, Value>,
-    ) -> anyhow::Result<String>;
-
-    /// Renders a custom summarization prompt for context compaction
-    /// This takes a raw string template and renders it with information about
-    /// the compaction and the original context (which allows for more
-    /// sophisticated compaction templates)
-    async fn render_summarization(
-        &self,
-        compaction: &Compact,
-        context: &Context,
+        template: impl ToString,
+        object: &impl serde::Serialize,
     ) -> anyhow::Result<String>;
 }
 

--- a/crates/forge_domain/src/system_context.rs
+++ b/crates/forge_domain/src/system_context.rs
@@ -29,9 +29,6 @@ pub struct SystemContext {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub files: Vec<String>,
 
-    // README content to provide project context to the agent
-    pub readme: String,
-
     #[serde(skip_serializing_if = "String::is_empty")]
     pub custom_rules: String,
 

--- a/crates/forge_services/src/forge_services.rs
+++ b/crates/forge_services/src/forge_services.rs
@@ -23,23 +23,20 @@ pub struct ForgeServices<F> {
     provider_service: Arc<ForgeProviderService>,
     conversation_service: Arc<
         ForgeConversationService<
-            ForgeCompactionService<ForgeTemplateService<F, ForgeToolService>, ForgeProviderService>,
+            ForgeCompactionService<ForgeTemplateService, ForgeProviderService>,
         >,
     >,
-    template_service: Arc<ForgeTemplateService<F, ForgeToolService>>,
+    template_service: Arc<ForgeTemplateService>,
     attachment_service: Arc<ForgeChatRequest<F>>,
     compaction_service: Arc<
-        ForgeCompactionService<ForgeTemplateService<F, ForgeToolService>, ForgeProviderService>,
+        ForgeCompactionService<ForgeTemplateService, ForgeProviderService>,
     >,
 }
 
 impl<F: Infrastructure> ForgeServices<F> {
     pub fn new(infra: Arc<F>) -> Self {
         let tool_service = Arc::new(ForgeToolService::new(infra.clone()));
-        let template_service = Arc::new(ForgeTemplateService::new(
-            infra.clone(),
-            tool_service.clone(),
-        ));
+        let template_service = Arc::new(ForgeTemplateService::new());
         let provider_service = Arc::new(ForgeProviderService::new(infra.clone()));
         let attachment_service = Arc::new(ForgeChatRequest::new(infra.clone()));
         let compaction_service = Arc::new(ForgeCompactionService::new(
@@ -65,7 +62,7 @@ impl<F: Infrastructure> Services for ForgeServices<F> {
     type ToolService = ForgeToolService;
     type ProviderService = ForgeProviderService;
     type ConversationService = ForgeConversationService<Self::CompactionService>;
-    type TemplateService = ForgeTemplateService<F, Self::ToolService>;
+    type TemplateService = ForgeTemplateService;
     type AttachmentService = ForgeChatRequest<F>;
     type EnvironmentService = F::EnvironmentService;
     type CompactionService = ForgeCompactionService<Self::TemplateService, Self::ProviderService>;

--- a/crates/forge_services/src/template.rs
+++ b/crates/forge_services/src/template.rs
@@ -1,35 +1,24 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use chrono::Local;
-use forge_domain::{
-    Agent, Compact, Context, EnvironmentService, Event, EventContext, SystemContext, Template,
-    TemplateService, ToolService,
-};
-use forge_walker::Walker;
+use forge_domain::TemplateService;
 use handlebars::Handlebars;
 use rust_embed::Embed;
-use serde_json::Value;
-use tracing::debug;
-
-use crate::Infrastructure;
-
-// Include README.md at compile time
-const README_CONTENT: &str = include_str!("../../../README.md");
 
 #[derive(Embed)]
 #[folder = "../../templates/"]
 struct Templates;
 
 #[derive(Clone)]
-pub struct ForgeTemplateService<F, T> {
+pub struct ForgeTemplateService {
     hb: Handlebars<'static>,
-    infra: Arc<F>,
-    tool_service: Arc<T>,
 }
 
-impl<F, T> ForgeTemplateService<F, T> {
-    pub fn new(infra: Arc<F>, tool_service: Arc<T>) -> Self {
+impl Default for ForgeTemplateService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForgeTemplateService {
+    pub fn new() -> Self {
         let mut hb = Handlebars::new();
         hb.set_strict_mode(true);
         hb.register_escape_fn(|str| str.to_string());
@@ -37,98 +26,19 @@ impl<F, T> ForgeTemplateService<F, T> {
         // Register all partial templates
         hb.register_embed_templates::<Templates>().unwrap();
 
-        Self { hb, infra, tool_service }
+        Self { hb }
     }
 }
 
 #[async_trait::async_trait]
-impl<F: Infrastructure, T: ToolService> TemplateService for ForgeTemplateService<F, T> {
-    async fn render_system(
+impl TemplateService for ForgeTemplateService {
+    fn render(
         &self,
-        _agent: &Agent,
-        prompt: &Template<SystemContext>,
-        variables: &HashMap<String, Value>,
+        template: impl ToString,
+        object: &impl serde::Serialize,
     ) -> anyhow::Result<String> {
-        let env = self.infra.environment_service().get_environment();
-
-        // Build the walker, only setting max_depth if a value was provided
-        let mut walker = Walker::max_all();
-
-        // Only set max_depth if the value is provided
-        // Create maximum depth for file walker, defaulting to 1 if not specified
-        walker = walker.max_depth(_agent.max_walker_depth.unwrap_or(1));
-
-        let mut files = walker
-            .cwd(env.cwd.clone())
-            .get()
-            .await?
-            .iter()
-            .map(|f| f.path.to_string())
-            .collect::<Vec<_>>();
-
-        // Sort the files alphabetically to ensure consistent ordering
-        files.sort();
-
-        // Get current date and time with timezone
-        let current_time = Local::now().format("%Y-%m-%d %H:%M:%S %:z").to_string();
-
-        // Create the context with README content for all agents
-        let ctx = SystemContext {
-            current_time,
-            env: Some(env),
-            tool_information: Some(self.tool_service.usage_prompt()),
-            tool_supported: _agent.tool_supported.unwrap_or_default(),
-            files,
-            readme: README_CONTENT.to_string(),
-            custom_rules: _agent.custom_rules.as_ref().cloned().unwrap_or_default(),
-            variables: variables.clone(),
-        };
-
-        // Render the template with the context
-        let result = self.hb.render_template(prompt.template.as_str(), &ctx)?;
-        Ok(result)
-    }
-
-    async fn render_event(
-        &self,
-        _agent: &Agent,
-        prompt: &Template<EventContext>,
-        event: &Event,
-        variables: &HashMap<String, Value>,
-    ) -> anyhow::Result<String> {
-        // Create an EventContext with the provided event
-        let mut event_context = EventContext::new(event.clone());
-
-        // Add variables to the context
-        event_context = event_context.variables(variables.clone());
-
-        debug!(event_context = ?event_context, "Event context");
-
-        // Render the template with the event context
-        Ok(self
-            .hb
-            .render_template(prompt.template.as_str(), &event_context)?)
-    }
-
-    async fn render_summarization(
-        &self,
-        compaction: &Compact,
-        context: &Context,
-    ) -> anyhow::Result<String> {
-        let summary_tag = compaction.summary_tag.as_ref().cloned().unwrap_or_default();
-        let ctx = serde_json::json!({
-            "context": context.to_text(),
-            "summary_tag": summary_tag
-        });
-
-        // Render the template with the context
-        let result = self.hb.render_template(
-            compaction
-                .prompt
-                .as_deref()
-                .unwrap_or("{{> system-prompt-context-summarizer.hbs}}"),
-            &ctx,
-        )?;
-        Ok(result)
+        let template = template.to_string();
+        let rendered = self.hb.render(&template, object)?;
+        Ok(rendered)
     }
 }


### PR DESCRIPTION
Removes unnecessary generics from ForgeTemplateService and simplifies the template service API by replacing multiple render methods with a single generic render method.