### PR TITLE
fix: refactor string formatting to use new syntax

### DIFF
--- a/crates/forge_ci/tests/ci.rs
+++ b/crates/forge_ci/tests/ci.rs
@@ -15,7 +15,7 @@ fn apt_get_install(packages: &[&str]) -> String {
         "sudo apt-get update && \\\nsudo apt-get install -y \\\n{}",
         packages
             .iter()
-            .map(|pkg| format!("  {}", pkg))
+            .map(|pkg| format!("  {pkg}"))
             .collect::<Vec<_>>()
             .join(" \\\n")
     )

--- a/crates/forge_ci/tests/forge_automation.rs
+++ b/crates/forge_ci/tests/forge_automation.rs
@@ -19,9 +19,7 @@ fn forge_event_json(event_name: &str, value_expr: &str) -> String {
         .replace('\n', "\\n")
         .replace('\t', "\\t");
 
-    format!(
-        "forge --event='{{\"name\": \"{event_name}\", \"value\": \"{escaped_value}\"}}'"
-    )
+    format!("forge --event='{{\"name\": \"{event_name}\", \"value\": \"{escaped_value}\"}}'")
 }
 
 /// Get the appropriate issue/PR number based on event context

--- a/crates/forge_ci/tests/forge_automation.rs
+++ b/crates/forge_ci/tests/forge_automation.rs
@@ -20,8 +20,7 @@ fn forge_event_json(event_name: &str, value_expr: &str) -> String {
         .replace('\t', "\\t");
 
     format!(
-        "forge --event='{{\"name\": \"{}\", \"value\": \"{}\"}}'",
-        event_name, escaped_value
+        "forge --event='{{\"name\": \"{event_name}\", \"value\": \"{escaped_value}\"}}'"
     )
 }
 
@@ -54,8 +53,7 @@ fn add_forge_cli_installation(job: Job) -> Job {
 /// Generate condition for issue_comment with label and comment prefix
 fn issue_comment_condition(label: &str, comment_prefix: &str) -> String {
     format!(
-        "github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.issue.labels.*.name, '{}') && startsWith(github.event.comment.body, '{}')",
-        label, comment_prefix
+        "github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.issue.labels.*.name, '{label}') && startsWith(github.event.comment.body, '{comment_prefix}')"
     )
 }
 
@@ -63,12 +61,11 @@ fn issue_comment_condition(label: &str, comment_prefix: &str) -> String {
 fn add_pr_checkout_steps(job: Job, pr_number_expr: &str) -> Job {
     job.add_step(
         Step::run(format!(
-            "git fetch origin pull/{}/head:pr-{}",
-            pr_number_expr, pr_number_expr
+            "git fetch origin pull/{pr_number_expr}/head:pr-{pr_number_expr}"
         ))
         .name("Fetch PR branch"),
     )
-    .add_step(Step::run(format!("git checkout pr-{}", pr_number_expr)).name("Checkout PR branch"))
+    .add_step(Step::run(format!("git checkout pr-{pr_number_expr}")).name("Checkout PR branch"))
 }
 
 #[test]

--- a/crates/forge_display/src/diff.rs
+++ b/crates/forge_display/src/diff.rs
@@ -78,7 +78,7 @@ mod tests {
         let old = "Hello World\nThis is a test\nThird line\nFourth line";
         let new = "Hello World\nThis is a modified test\nNew line\nFourth line";
         let diff = DiffFormat::format("diff", "example.txt".into(), old, new);
-        println!("\nColor Output Test:\n{}", diff);
+        println!("\nColor Output Test:\n{diff}");
     }
 
     #[test]

--- a/crates/forge_display/src/grep.rs
+++ b/crates/forge_display/src/grep.rs
@@ -81,7 +81,7 @@ impl GrepFormat {
 
     /// Format a single line with colorization and consistent padding
     fn format_line(&self, num: &str, content: &str, padding: usize) -> String {
-        let num = style(format!("{:>padding$}: ", num, padding = padding)).dim();
+        let num = style(format!("{num:>padding$}: ")).dim();
 
         // Format the content with highlighting if regex is available
         let line = match self.regex {
@@ -99,7 +99,7 @@ impl GrepFormat {
             None => content.to_string(),
         };
 
-        format!("{}{}\n", num, line)
+        format!("{num}{line}\n")
     }
 
     /// Format a group of lines for a single file
@@ -114,7 +114,7 @@ impl GrepFormat {
             .into_iter()
             .map(|(num, content)| self.format_line(num, content, max_num_width))
             .collect::<String>();
-        format!("{}\n{}", file_header, formatted_lines)
+        format!("{file_header}\n{formatted_lines}")
     }
 
     /// Handle raw file paths (entries without line:content format)
@@ -216,7 +216,7 @@ mod tests {
     impl Display for GrepSuite {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             for spec in &self.0 {
-                writeln!(f, "{}", spec)?;
+                writeln!(f, "{spec}")?;
             }
             Ok(())
         }

--- a/crates/forge_display/src/title.rs
+++ b/crates/forge_display/src/title.rs
@@ -54,14 +54,14 @@ impl TitleFormat {
             title = title.red().bold();
         }
 
-        buf.push_str(&format!("{}", title));
+        buf.push_str(&format!("{title}"));
 
         if let Some(ref sub_title) = self.sub_title {
             buf.push_str(&format!(" {}", sub_title.dimmed()).to_string());
         }
 
         if let Some(ref error) = self.error {
-            buf.push_str(&format!(" {}", error).to_string());
+            buf.push_str(&format!(" {error}").to_string());
         }
 
         buf

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -500,8 +500,7 @@ mod tests {
             let agent: std::result::Result<Agent, serde_json::Error> = serde_json::from_value(json);
             assert!(
                 agent.is_ok(),
-                "Valid temperature {} should deserialize",
-                temp
+                "Valid temperature {temp} should deserialize"
             );
             assert_eq!(agent.unwrap().temperature.unwrap().value(), temp);
         }
@@ -517,14 +516,12 @@ mod tests {
             let agent: std::result::Result<Agent, serde_json::Error> = serde_json::from_value(json);
             assert!(
                 agent.is_err(),
-                "Invalid temperature {} should fail deserialization",
-                temp
+                "Invalid temperature {temp} should fail deserialization"
             );
             let err = agent.unwrap_err().to_string();
             assert!(
                 err.contains("temperature must be between 0.0 and 2.0"),
-                "Error should mention valid range: {}",
-                err
+                "Error should mention valid range: {err}"
             );
         }
 

--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -498,10 +498,7 @@ mod tests {
             });
 
             let agent: std::result::Result<Agent, serde_json::Error> = serde_json::from_value(json);
-            assert!(
-                agent.is_ok(),
-                "Valid temperature {temp} should deserialize"
-            );
+            assert!(agent.is_ok(), "Valid temperature {temp} should deserialize");
             assert_eq!(agent.unwrap().temperature.unwrap().value(), temp);
         }
 

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -196,12 +196,12 @@ impl Context {
                     lines.push_str("</message>");
                 }
                 ContextMessage::Image(url) => {
-                    lines.push_str(format!("<file_attachment path=\"{}\">", url).as_str());
+                    lines.push_str(format!("<file_attachment path=\"{url}\">").as_str());
                 }
             }
         }
 
-        format!("<chat_history>{}</chat_history>", lines)
+        format!("<chat_history>{lines}</chat_history>")
     }
 
     /// Estimates the token count for this context using a simple approximation

--- a/crates/forge_domain/src/conversation_html.rs
+++ b/crates/forge_domain/src/conversation_html.rs
@@ -76,7 +76,7 @@ fn create_agents_section(conversation: &Conversation) -> Element {
                 agent
                     .model
                     .as_ref()
-                    .map(|model| Element::new("span").text(format!("Model: {}", model))),
+                    .map(|model| Element::new("span").text(format!("Model: {model}"))),
             );
 
         let mut agent_div = Element::new("div.agent").append(agent_header);
@@ -118,19 +118,18 @@ fn create_agents_section(conversation: &Conversation) -> Element {
         // Add temperature if available
         if let Some(temperature) = &agent.temperature {
             agent_div =
-                agent_div.append(Element::new("p").text(format!("Temperature: {}", temperature)));
+                agent_div.append(Element::new("p").text(format!("Temperature: {temperature}")));
         }
 
         // Add max turns if available
         if let Some(max_turns) = agent.max_turns {
-            agent_div =
-                agent_div.append(Element::new("p").text(format!("Max Turns: {}", max_turns)));
+            agent_div = agent_div.append(Element::new("p").text(format!("Max Turns: {max_turns}")));
         }
 
         // Add max walker depth if available
         if let Some(max_walker_depth) = agent.max_walker_depth {
             agent_div = agent_div
-                .append(Element::new("p").text(format!("Max Walker Depth: {}", max_walker_depth)));
+                .append(Element::new("p").text(format!("Max Walker Depth: {max_walker_depth}")));
         }
 
         section.append(agent_div)
@@ -180,8 +179,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                             let role_lowercase = content_message.role.to_string().to_lowercase();
 
                             let message_div = Element::new(format!(
-                                "details.message-card.message-{}",
-                                role_lowercase
+                                "details.message-card.message-{role_lowercase}"
                             ))
                             .append(
                                 Element::new("summary")
@@ -238,7 +236,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                             // Image message
                             Element::new("div.message-card.message-user")
                                 .append(Element::new("strong").text("Image Attachment"))
-                                .append(Element::new("p").text(format!("URL: {}", url)))
+                                .append(Element::new("p").text(format!("URL: {url}")))
                         }
                     }),
                 );
@@ -269,7 +267,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                             .append(tool.output_schema.as_ref().map(|schema| {
                                 Element::new("pre").append(
                                     Element::new("strong")
-                                        .text(format!("Output Schema: {:?}", schema)),
+                                        .text(format!("Output Schema: {schema:?}")),
                                 )
                             }))
                             .append(tool.output_schema.as_ref().map(|schema| {
@@ -297,7 +295,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                     context_with_tool_choice.append(
                         Element::new("p")
                             .append(Element::new("strong").text("Max Tokens: "))
-                            .text(format!("{}", max_tokens)),
+                            .text(format!("{max_tokens}")),
                     )
                 } else {
                     context_with_tool_choice
@@ -308,7 +306,7 @@ fn create_agent_states_section(conversation: &Conversation) -> Element {
                     context_with_max_tokens.append(
                         Element::new("p")
                             .append(Element::new("strong").text("Temperature: "))
-                            .text(format!("{}", temperature)),
+                            .text(format!("{temperature}")),
                     )
                 } else {
                     context_with_max_tokens

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -245,7 +245,7 @@ impl<A: Services> Orchestrator<A> {
 
         // Process partial tool calls
         let partial_tool_calls = ToolCallFull::try_from_parts(&tool_call_parts)
-            .with_context(|| format!("Failed to parse tool call: {:?}", tool_call_parts))?;
+            .with_context(|| format!("Failed to parse tool call: {tool_call_parts:?}"))?;
 
         // Process XML tool calls
         let xml_tool_calls = ToolCallFull::try_from_xml(&content)?;

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -16,7 +16,7 @@ impl Provider {
                 if url.ends_with("/") {
                     *set_url = Url::parse(&url).unwrap();
                 } else {
-                    *set_url = Url::parse(&format!("{}/", url)).unwrap();
+                    *set_url = Url::parse(&format!("{url}/")).unwrap();
                 }
             }
             Provider::Anthropic { .. } => {}
@@ -30,7 +30,7 @@ impl Provider {
                 if url.ends_with("/") {
                     *set_url = Url::parse(&url).unwrap();
                 } else {
-                    *set_url = Url::parse(&format!("{}/", url)).unwrap();
+                    *set_url = Url::parse(&format!("{url}/")).unwrap();
                 }
             }
             Provider::OpenAI { .. } => {}

--- a/crates/forge_domain/src/temperature.rs
+++ b/crates/forge_domain/src/temperature.rs
@@ -22,8 +22,7 @@ impl Temperature {
             Ok(Self(value))
         } else {
             Err(format!(
-                "temperature must be between 0.0 and 2.0, got {}",
-                value
+                "temperature must be between 0.0 and 2.0, got {value}"
             ))
         }
     }
@@ -33,7 +32,7 @@ impl Temperature {
     /// # Safety
     /// This function should only be used when the value is known to be valid
     pub fn new_unchecked(value: f32) -> Self {
-        debug_assert!(Self::is_valid(value), "invalid temperature: {}", value);
+        debug_assert!(Self::is_valid(value), "invalid temperature: {value}");
         Self(value)
     }
 
@@ -93,8 +92,7 @@ impl<'de> Deserialize<'de> for Temperature {
             Ok(Self(value))
         } else {
             Err(Error::custom(format!(
-                "temperature must be between 0.0 and 2.0, got {}",
-                value
+                "temperature must be between 0.0 and 2.0, got {value}"
             )))
         }
     }
@@ -113,7 +111,7 @@ mod tests {
         let valid_temps = [0.0, 0.5, 1.0, 1.5, 2.0];
         for temp in valid_temps {
             let result = Temperature::new(temp);
-            assert!(result.is_ok(), "Temperature {} should be valid", temp);
+            assert!(result.is_ok(), "Temperature {temp} should be valid");
             assert_eq!(result.unwrap().value(), temp);
         }
 
@@ -121,7 +119,7 @@ mod tests {
         let invalid_temps = [-0.1, 2.1, 3.0, -1.0, 10.0];
         for temp in invalid_temps {
             let result = Temperature::new(temp);
-            assert!(result.is_err(), "Temperature {} should be invalid", temp);
+            assert!(result.is_err(), "Temperature {temp} should be invalid");
             assert!(
                 result
                     .unwrap_err()
@@ -142,11 +140,10 @@ mod tests {
             let float_val = num.as_f64().unwrap();
             assert!(
                 (float_val - 0.7).abs() < 0.001,
-                "Expected approximately 0.7, got {}",
-                float_val
+                "Expected approximately 0.7, got {float_val}"
             );
         } else {
-            panic!("Expected a number, got {:?}", json);
+            panic!("Expected a number, got {json:?}");
         }
     }
 
@@ -159,8 +156,7 @@ mod tests {
             let temp: Result<Temperature, _> = serde_json::from_value(json);
             assert!(
                 temp.is_ok(),
-                "Valid temperature {} should deserialize",
-                temp_value
+                "Valid temperature {temp_value} should deserialize"
             );
             assert_eq!(temp.unwrap().value(), temp_value);
         }
@@ -172,14 +168,12 @@ mod tests {
             let temp: Result<Temperature, _> = serde_json::from_value(json);
             assert!(
                 temp.is_err(),
-                "Invalid temperature {} should fail deserialization",
-                temp_value
+                "Invalid temperature {temp_value} should fail deserialization"
             );
             let err = temp.unwrap_err().to_string();
             assert!(
                 err.contains("temperature must be between 0.0 and 2.0"),
-                "Error should mention valid range: {}",
-                err
+                "Error should mention valid range: {err}"
             );
         }
     }
@@ -208,8 +202,7 @@ mod tests {
         let err = test_struct.unwrap_err().to_string();
         assert!(
             err.contains("temperature must be between 0.0 and 2.0"),
-            "Error should mention valid range: {}",
-            err
+            "Error should mention valid range: {err}"
         );
     }
 }

--- a/crates/forge_domain/src/text_utils.rs
+++ b/crates/forge_domain/src/text_utils.rs
@@ -19,8 +19,8 @@
 /// assert_eq!(extracted, Some("This is the important part"));
 /// ```
 pub fn extract_tag_content<'a>(text: &'a str, tag_name: &str) -> Option<&'a str> {
-    let opening_tag = format!("<{}>", tag_name);
-    let closing_tag = format!("</{}>", tag_name);
+    let opening_tag = format!("<{tag_name}>",);
+    let closing_tag = format!("</{tag_name}>");
 
     if let Some(start_idx) = text.find(&opening_tag) {
         if let Some(end_idx) = text.find(&closing_tag) {
@@ -39,7 +39,7 @@ pub fn remove_tag_content(text: &str, tag_names: &[&str]) -> String {
     let mut result = text.to_string();
 
     for tag_name in tag_names {
-        let pattern = format!("<{}>[\\s\\S]*?</{}>", tag_name, tag_name);
+        let pattern = format!("<{tag_name}>[\\s\\S]*?</{tag_name}>");
 
         // Create regex to match tag content including nested tags
         if let Ok(regex) = regex::Regex::new(&pattern) {

--- a/crates/forge_domain/src/tool_call_record.rs
+++ b/crates/forge_domain/src/tool_call_record.rs
@@ -18,12 +18,12 @@ pub struct ToolCallRecord {
 impl Display for ToolCallRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let tool_name = self.tool_call.name.as_str();
-        write!(f, "<tool_result tool=\"{}\">", tool_name)?;
+        write!(f, "<tool_result tool=\"{tool_name}\">")?;
 
         if let Some(object) = self.tool_call.arguments.as_object() {
             write!(f, "<arguments>")?;
             for (key, value) in object.iter() {
-                write!(f, "<{0}>{1}</{0}>", key, value)?;
+                write!(f, "<{key}>{value}</{key}>")?;
             }
             write!(f, "</arguments>")?;
         }

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -35,7 +35,7 @@ impl ToolResult {
         output.push_str("\nERROR:\n");
 
         for cause in err.chain() {
-            output.push_str(&format!("Caused by: {}\n", cause));
+            output.push_str(&format!("Caused by: {cause}\n"));
         }
 
         self.content = output;
@@ -61,9 +61,9 @@ impl std::fmt::Display for ToolResult {
         write!(f, "<tool_name>{}</tool_name>", self.name.as_str())?;
         let content = format!("<![CDATA[{}]]>", self.content);
         if self.is_error {
-            write!(f, "<error>{}</error>", content)?;
+            write!(f, "<error>{content}</error>")?;
         } else {
-            write!(f, "<success>{}</success>", content)?;
+            write!(f, "<success>{content}</success>")?;
         }
 
         write!(f, "</tool_result>")

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -66,7 +66,7 @@ impl ForgeEnvironmentService {
                     provider
                 })
             })
-            .unwrap_or_else(|| panic!("No API key found. Please set one of: {}", env_variables))
+            .unwrap_or_else(|| panic!("No API key found. Please set one of: {env_variables}"))
     }
 
     /// Resolves retry configuration from environment variables or returns

--- a/crates/forge_main/build.rs
+++ b/crates/forge_main/build.rs
@@ -13,7 +13,7 @@ fn main() {
         .unwrap_or_else(|_| "0.0.0-dev".to_string());
 
     // Make version available to the application
-    println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version);
+    println!("cargo:rustc-env=CARGO_PKG_VERSION={version}");
 
     // Make version available to the application
     println!("cargo:rustc-env=CARGO_PKG_NAME=forge");

--- a/crates/forge_main/src/auto_update.rs
+++ b/crates/forge_main/src/auto_update.rs
@@ -18,7 +18,7 @@ pub async fn update_forge() {
     if let Err(err) = perform_update().await {
         // Send an event to the tracker on failure
         // We don't need to handle this result since we're failing silently
-        let _ = send_update_failure_event(&format!("Auto update failed: {}", err)).await;
+        let _ = send_update_failure_event(&format!("Auto update failed: {err}")).await;
     }
 }
 

--- a/crates/forge_main/src/banner.rs
+++ b/crates/forge_main/src/banner.rs
@@ -23,13 +23,13 @@ pub fn display() -> io::Result<()> {
         banner.push_str(
             format!(
                 "\n{}{}",
-                format!("{:>width$} ", key, width = max_width).dimmed(),
+                format!("{key:>max_width$} ").dimmed(),
                 value.cyan()
             )
             .as_str(),
         );
     }
 
-    println!("{}\n", banner);
+    println!("{banner}\n");
     Ok(())
 }

--- a/crates/forge_main/src/completer/search_term.rs
+++ b/crates/forge_main/src/completer/search_term.rs
@@ -60,7 +60,7 @@ mod tests {
                     let (a, b) = line.split_at(i);
                     TermSpec {
                         pos: i,
-                        input: format!("{}[{}", a, b),
+                        input: format!("{a}[{b}"),
                         output: output.as_ref().map(|term| term.term.to_string()),
                         span_start: output.as_ref().map(|term| term.span.start),
                         span_end: output.as_ref().map(|term| term.span.end),

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -118,7 +118,7 @@ impl fmt::Display for Info {
                     if let Some(value) = value {
                         writeln!(f, "{}: {}", key.bright_cyan().bold(), value)?;
                     } else {
-                        writeln!(f, "{}", key)?;
+                        writeln!(f, "{key}")?;
                     }
                 }
             }

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -13,7 +13,7 @@ fn humanize_context_length(length: u64) -> String {
     } else if length >= 1_000 {
         format!("{:.1}K context", length as f64 / 1_000.0)
     } else {
-        format!("{} context", length)
+        format!("{length} context")
     }
 }
 
@@ -438,7 +438,7 @@ mod tests {
         // Verify
         match result {
             Command::Shell(cmd) => assert_eq!(cmd, "ls -la"),
-            _ => panic!("Expected Shell command, got {:?}", result),
+            _ => panic!("Expected Shell command, got {result:?}"),
         }
     }
 
@@ -453,7 +453,7 @@ mod tests {
         // Verify
         match result {
             Command::Shell(cmd) => assert_eq!(cmd, ""),
-            _ => panic!("Expected Shell command, got {:?}", result),
+            _ => panic!("Expected Shell command, got {result:?}"),
         }
     }
 
@@ -468,7 +468,7 @@ mod tests {
         // Verify
         match result {
             Command::Shell(cmd) => assert_eq!(cmd, "echo 'test'"),
-            _ => panic!("Expected Shell command, got {:?}", result),
+            _ => panic!("Expected Shell command, got {result:?}"),
         }
     }
 

--- a/crates/forge_main/src/prompt.rs
+++ b/crates/forge_main/src/prompt.rs
@@ -73,7 +73,7 @@ impl Prompt for ForgePrompt {
         let mut result = String::with_capacity(32);
 
         // Start with bracket and version
-        let _ = write!(result, "[{}", VERSION);
+        let _ = write!(result, "[{VERSION}");
 
         // Append model if available
         if let Some(model) = self.model.as_ref() {
@@ -82,7 +82,7 @@ impl Prompt for ForgePrompt {
                 .split('/')
                 .next_back()
                 .unwrap_or_else(|| model.as_str());
-            let _ = write!(result, "/{}", formatted_model);
+            let _ = write!(result, "/{formatted_model}");
         }
 
         // Append usage info
@@ -91,7 +91,7 @@ impl Prompt for ForgePrompt {
             .as_ref()
             .unwrap_or(&Usage::default())
             .total_tokens;
-        let _ = write!(result, "/{}", usage);
+        let _ = write!(result, "/{usage}");
         let _ = write!(result, "]");
 
         // Apply styling once at the end
@@ -125,7 +125,7 @@ impl Prompt for ForgePrompt {
 
         // Handle empty search term more elegantly
         if history_search.term.is_empty() {
-            let _ = write!(result, "({}reverse-search) ", prefix);
+            let _ = write!(result, "({prefix}reverse-search) ");
         } else {
             let _ = write!(
                 result,

--- a/crates/forge_main/src/tools_display.rs
+++ b/crates/forge_main/src/tools_display.rs
@@ -21,7 +21,7 @@ pub fn format_tools(tools: &[ToolDefinition]) -> String {
             out.push('\n');
         }
 
-        out.push_str(&format!("{}\n{}\n{}\n", name, description, schema));
+        out.push_str(&format!("{name}\n{description}\n{schema}\n"));
     }
 
     out

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -161,8 +161,7 @@ impl<F: API> UI<F> {
                     let message_reduction = compaction_result.message_reduction_percentage();
 
                     let content = TitleFormat::action(format!(
-                        "Context size reduced by {:.1}% (tokens), {:.1}% (messages)",
-                        token_reduction, message_reduction
+                        "Context size reduced by {token_reduction:.1}% (tokens), {message_reduction:.1}% (messages)"
                     ))
                     .format();
                     self.spinner.stop(Some(content))?;
@@ -177,21 +176,21 @@ impl<F: API> UI<F> {
                 }
                 Command::Info => {
                     let info = Info::from(&self.state).extend(Info::from(&self.api.environment()));
-                    println!("{}", info);
+                    println!("{info}");
                 }
                 Command::Message(ref content) => {
                     self.spinner.start()?;
                     let chat_result = self.chat(content.clone()).await;
                     if let Err(err) = chat_result {
                         tokio::spawn(
-                            TRACKER.dispatch(forge_tracker::EventKind::Error(format!("{:?}", err))),
+                            TRACKER.dispatch(forge_tracker::EventKind::Error(format!("{err:?}"))),
                         );
                         error!(error = ?err, "Chat request failed");
 
                         println!(
                             "{}",
                             TitleFormat::action("Error")
-                                .error(format!("{:?}", err))
+                                .error(format!("{err:?}"))
                                 .format()
                         );
                     }
@@ -204,13 +203,13 @@ impl<F: API> UI<F> {
                 }
                 Command::Help => {
                     let info = Info::from(self.command.as_ref());
-                    println!("{}", info);
+                    println!("{info}");
                 }
                 Command::Tools => {
                     use crate::tools_display::format_tools;
                     let tools = self.api.tools().await;
                     let output = format_tools(&tools);
-                    println!("{}", output);
+                    println!("{output}");
                 }
                 Command::Exit => {
                     update_forge().await;
@@ -300,7 +299,7 @@ impl<F: API> UI<F> {
 
             println!(
                 "{}",
-                TitleFormat::action(format!("Switched to model: {}", model)).format()
+                TitleFormat::action(format!("Switched to model: {model}")).format()
             );
         }
 

--- a/crates/forge_provider/src/anthropic/provider.rs
+++ b/crates/forge_provider/src/anthropic/provider.rs
@@ -136,7 +136,7 @@ impl ProviderService for Anthropic {
                         reqwest_eventsource::Error::InvalidContentType(_, ref response) => {
                             let status_code = response.status();
                             debug!(response = ?response, "Invalid content type");
-                            Some(Err(anyhow::anyhow!(error).context(format!("Http Status: {}", status_code))))
+                            Some(Err(anyhow::anyhow!(error).context(format!("Http Status: {status_code}" ))))
                         }
                         error => {
                             debug!(error = %error, "Failed to receive chat completion event");

--- a/crates/forge_provider/src/anthropic/request.rs
+++ b/crates/forge_provider/src/anthropic/request.rs
@@ -135,7 +135,7 @@ impl From<String> for Content {
             Some((media_type, data)) => Content::Image {
                 source: ImageSource {
                     type_: "base64".to_string(),
-                    media_type: Some(format!("image/{}", media_type)),
+                    media_type: Some(format!("image/{media_type}")),
                     data: Some(data),
                     url: None,
                 },

--- a/crates/forge_provider/src/anthropic/response.rs
+++ b/crates/forge_provider/src/anthropic/response.rs
@@ -111,7 +111,7 @@ pub enum ErrorData {
 impl Display for ErrorData {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ErrorData::OverloadedError { message } => write!(f, "OverloadedError: {}", message),
+            ErrorData::OverloadedError { message } => write!(f, "OverloadedError: {message}"),
         }
     }
 }
@@ -294,7 +294,7 @@ mod tests {
         ];
         for (name, input, expected) in tests {
             let actual: Event = serde_json::from_str(input).unwrap();
-            assert_eq!(actual, expected, "test failed for event data: {}", name);
+            assert_eq!(actual, expected, "test failed for event data: {name}");
         }
     }
 

--- a/crates/forge_provider/src/builder.rs
+++ b/crates/forge_provider/src/builder.rs
@@ -28,7 +28,7 @@ impl Client {
                     .provider(provider.clone())
                     .retry_config(retry_config.clone())
                     .build()
-                    .with_context(|| format!("Failed to initialize: {}", url))?,
+                    .with_context(|| format!("Failed to initialize: {url}"))?,
             )),
 
             Provider::Anthropic { url, key } => Ok(Client::Anthropic(
@@ -40,7 +40,7 @@ impl Client {
                     .retry_config(retry_config.clone())
                     .build()
                     .with_context(|| {
-                        format!("Failed to initialize Anthropic client with URL: {}", url)
+                        format!("Failed to initialize Anthropic client with URL: {url}")
                     })?,
             )),
         }

--- a/crates/forge_provider/src/open_router/provider.rs
+++ b/crates/forge_provider/src/open_router/provider.rs
@@ -55,7 +55,7 @@ impl OpenRouter {
         if let Some(ref api_key) = self.provider.key() {
             headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {}", api_key)).unwrap(),
+                HeaderValue::from_str(&format!("Bearer {api_key}")).unwrap(),
             );
         }
         headers.insert("X-Title", HeaderValue::from_static("forge"));
@@ -145,7 +145,7 @@ impl OpenRouter {
                         reqwest_eventsource::Error::InvalidContentType(_, ref response) => {
                             let status_code = response.status();
                             debug!(response = ?response, "Invalid content type");
-                            Some(Err(anyhow::anyhow!(error).context(format!("Http Status: {}", status_code))))
+                            Some(Err(anyhow::anyhow!(error).context(format!("Http Status: {status_code}" ))))
 
                         }
                         error => {

--- a/crates/forge_provider/src/open_router/response.rs
+++ b/crates/forge_provider/src/open_router/response.rs
@@ -71,7 +71,7 @@ impl Display for ErrorResponse {
         write!(f, "message: {}", self.message)?;
         if !self.metadata.is_empty() {
             if let Ok(str_repr) = serde_json::to_string(&self.metadata) {
-                write!(f, ", details: {}", str_repr)?;
+                write!(f, ", details: {str_repr}")?;
             }
         }
         Ok(())
@@ -200,7 +200,7 @@ mod tests {
         // check if the response is compatible with the OpenRouterResponse
         fn test_response_compatibility(message: &str) -> bool {
             let open_router_response = serde_json::from_str::<OpenRouterResponse>(message)
-                .with_context(|| format!("Failed to parse OpenRouter response: {}", message))
+                .with_context(|| format!("Failed to parse OpenRouter response: {message}"))
                 .and_then(|event| {
                     ChatCompletionMessage::try_from(event.clone())
                         .with_context(|| "Failed to create completion message")

--- a/crates/forge_provider/src/open_router/transformers/transformer.rs
+++ b/crates/forge_provider/src/open_router/transformers/transformer.rs
@@ -19,7 +19,7 @@ pub trait Transformer {
         Self: Sized,
     {
         let regex =
-            Regex::new(pattern).unwrap_or_else(|_| panic!("Invalid regex pattern {}", pattern));
+            Regex::new(pattern).unwrap_or_else(|_| panic!("Invalid regex pattern {pattern}"));
 
         self.when(move |req| {
             req.model

--- a/crates/forge_services/src/attachment.rs
+++ b/crates/forge_services/src/attachment.rs
@@ -52,7 +52,7 @@ impl<F: Infrastructure> ForgeChatRequest<F> {
             _ => None,
         }) {
             let base_64_encoded = base64::engine::general_purpose::STANDARD.encode(read);
-            let content = format!("data:image/{};base64,{}", img_extension, base_64_encoded);
+            let content = format!("data:image/{img_extension};base64,{base_64_encoded}");
             Ok(Attachment { content, path, content_type: ContentType::Image })
         } else {
             let content = String::from_utf8(read.to_vec())?;
@@ -439,7 +439,7 @@ pub mod tests {
             base64::engine::general_purpose::STANDARD.encode("mock-binary-content");
         assert_eq!(
             attachment.content,
-            format!("data:image/png;base64,{}", expected_base64)
+            format!("data:image/png;base64,{expected_base64}")
         );
     }
 
@@ -465,7 +465,7 @@ pub mod tests {
         let expected_base64 = base64::engine::general_purpose::STANDARD.encode("mock-jpeg-content");
         assert_eq!(
             attachment.content,
-            format!("data:image/jpeg;base64,{}", expected_base64)
+            format!("data:image/jpeg;base64,{expected_base64}")
         );
     }
 

--- a/crates/forge_services/src/compaction.rs
+++ b/crates/forge_services/src/compaction.rs
@@ -74,9 +74,8 @@ impl<T: TemplateService, P: ProviderService> ForgeCompactionService<T, P> {
         );
 
         let summary = format!(
-            r#"Continuing from a prior analysis. Below is a compacted summary of the ongoing session. Use this summary as authoritative context for your reasoning and decision-making. You do not need to repeat or reanalyze it unless specifically asked: <summary>{}</summary> Proceed based on this context.
-        "#,
-            summary
+            r#"Continuing from a prior analysis. Below is a compacted summary of the ongoing session. Use this summary as authoritative context for your reasoning and decision-making. You do not need to repeat or reanalyze it unless specifically asked: <summary>{summary}</summary> Proceed based on this context.
+        "#
         );
 
         // Replace the sequence with a single summary message using splice

--- a/crates/forge_services/src/provider.rs
+++ b/crates/forge_services/src/provider.rs
@@ -37,7 +37,7 @@ impl ProviderService for ForgeProviderService {
         self.client
             .chat(model, request)
             .await
-            .with_context(|| format!("Failed to chat with model: {}", model))
+            .with_context(|| format!("Failed to chat with model: {model}"))
     }
 
     async fn models(&self) -> Result<Vec<Model>> {

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -130,7 +130,7 @@ mod test {
             _context: ToolCallContext,
             input: Self::Input,
         ) -> anyhow::Result<String> {
-            Ok(format!("Success with input: {}", input))
+            Ok(format!("Success with input: {input}"))
         }
     }
 

--- a/crates/forge_services/src/tools/fetch.rs
+++ b/crates/forge_services/src/tools/fetch.rs
@@ -68,12 +68,12 @@ impl Fetch {
                     if let Some(disallowed) = line.strip_prefix("Disallow: ") {
                         let disallowed = disallowed.trim();
                         let disallowed = if !disallowed.starts_with('/') {
-                            format!("/{}", disallowed)
+                            format!("/{disallowed}")
                         } else {
                             disallowed.to_string()
                         };
                         let path = if !path.starts_with('/') {
-                            format!("/{}", path)
+                            format!("/{path}")
                         } else {
                             path.to_string()
                         };
@@ -140,9 +140,7 @@ impl Fetch {
             Ok((
                 page_raw,
                 format!(
-                    "Content type {} cannot be simplified to markdown, but here is the raw content:\n",
-                    content_type
-                ),
+                    "Content type {content_type} cannot be simplified to markdown, but here is the raw content:\n"),
             ))
         }
     }
@@ -173,12 +171,10 @@ impl ExecutableTool for Fetch {
 
         if end < original_length {
             truncated.push_str(&format!(
-                "\n\n<error>Content truncated. Call the fetch tool with a start_index of {} to get more content.</error>",
-                end
-            ));
+                "\n\n<error>Content truncated. Call the fetch tool with a start_index of {end} to get more content.</error>"));
         }
 
-        Ok(format!("{}Contents of {}:\n{}", prefix, url, truncated))
+        Ok(format!("{prefix}Contents of {url}:\n{truncated}"))
     }
 }
 
@@ -303,8 +299,7 @@ mod tests {
         let err = result.unwrap_err();
         assert!(
             err.to_string().contains("robots.txt"),
-            "Expected error containing 'robots.txt', got: {}",
-            err
+            "Expected error containing 'robots.txt', got: {err}"
         );
     }
 

--- a/crates/forge_services/src/tools/fs/file_info.rs
+++ b/crates/forge_services/src/tools/fs/file_info.rs
@@ -39,7 +39,7 @@ impl ExecutableTool for FSFileInfo {
         let meta = tokio::fs::metadata(&input.path)
             .await
             .with_context(|| format!("Failed to get metadata for '{}'", input.path))?;
-        Ok(format!("{:?}", meta))
+        Ok(format!("{meta:?}"))
     }
 }
 

--- a/crates/forge_services/src/tools/fs/fs_find.rs
+++ b/crates/forge_services/src/tools/fs/fs_find.rs
@@ -37,7 +37,7 @@ impl FSFindInput {
         Ok(match &self.file_pattern {
             Some(pattern) => Some(
                 glob::Pattern::new(pattern)
-                    .with_context(|| format!("Invalid glob pattern: {}", pattern))?,
+                    .with_context(|| format!("Invalid glob pattern: {pattern}"))?,
             ),
             None => None,
         })
@@ -98,14 +98,11 @@ impl<F: Infrastructure> FSFind<F> {
 
         let sub_title = match (&input.regex, &input.file_pattern) {
             (Some(regex), Some(pattern)) => {
-                format!(
-                    "for '{}' in '{}' files at {}",
-                    regex, pattern, formatted_dir
-                )
+                format!("for '{regex}' in '{pattern}' files at {formatted_dir}")
             }
-            (Some(regex), None) => format!("for '{}' at {}", regex, formatted_dir),
-            (None, Some(pattern)) => format!("for '{}' at {}", pattern, formatted_dir),
-            (None, None) => format!("at {}", formatted_dir),
+            (Some(regex), None) => format!("for '{regex}' at {formatted_dir}"),
+            (None, Some(pattern)) => format!("for '{pattern}' at {formatted_dir}"),
+            (None, None) => format!("at {formatted_dir}"),
         };
 
         Ok(TitleFormat::new("search").sub_title(sub_title))
@@ -126,10 +123,10 @@ impl<F: Infrastructure> FSFind<F> {
         // Create content regex pattern if provided
         let regex = match &input.regex {
             Some(regex) => {
-                let pattern = format!("(?i){}", regex); // Case-insensitive by default
+                let pattern = format!("(?i){regex}"); // Case-insensitive by default
                 Some(
                     Regex::new(&pattern)
-                        .with_context(|| format!("Invalid regex pattern: {}", regex))?,
+                        .with_context(|| format!("Invalid regex pattern: {regex}"))?,
                 )
             }
             None => None,

--- a/crates/forge_services/src/tools/fs/fs_read.rs
+++ b/crates/forge_services/src/tools/fs/fs_read.rs
@@ -128,7 +128,7 @@ mod test {
         // Display a message - just for testing
         let title = "Read";
         let message = TitleFormat::new(title).sub_title(path.display().to_string());
-        println!("{}", message);
+        println!("{message}");
 
         // Assert the content matches
         assert_eq!(content, test_content);

--- a/crates/forge_services/src/tools/fs/fs_undo.rs
+++ b/crates/forge_services/src/tools/fs/fs_undo.rs
@@ -74,8 +74,7 @@ impl<F: Infrastructure> ExecutableTool for FsUndo<F> {
         context.send_text(message.format()).await?;
 
         Ok(format!(
-            "Successfully undid last operation on path: {}",
-            display_path
+            "Successfully undid last operation on path: {display_path}"
         ))
     }
 }

--- a/crates/forge_services/src/tools/patch.rs
+++ b/crates/forge_services/src/tools/patch.rs
@@ -80,9 +80,9 @@ fn apply_replacement(
     if search.is_empty() {
         return match operation {
             // Append to the end of the file
-            Operation::Append => Ok(format!("{}{}", source, content)),
+            Operation::Append => Ok(format!("{source}{content}")),
             // Prepend to the beginning of the file
-            Operation::Prepend => Ok(format!("{}{}", content, source)),
+            Operation::Prepend => Ok(format!("{content}{source}")),
             // Replace is equivalent to completely replacing the file
             Operation::Replace => Ok(content.to_string()),
             // Swap doesn't make sense with empty search - keep source unchanged
@@ -241,8 +241,7 @@ impl<F: Infrastructure> ApplyPatchJson<F> {
 fn format_output(path: &str, content: &str, warning: Option<&str>) -> String {
     if let Some(w) = warning {
         format!(
-            "<file_content\n  path=\"{}\"\n  syntax_checker_warning=\"{}\">\n{}</file_content>\n",
-            path, w, content
+            "<file_content\n  path=\"{path}\"\n  syntax_checker_warning=\"{w}\">\n{content}</file_content>\n"
         )
     } else {
         format!(

--- a/crates/forge_services/src/tools/registry.rs
+++ b/crates/forge_services/src/tools/registry.rs
@@ -216,8 +216,7 @@ pub mod tests {
 
         assert!(
             !any_exceeded,
-            "One or more tools exceed the maximum description length of {}",
-            MAX_DESCRIPTION_LENGTH
+            "One or more tools exceed the maximum description length of {MAX_DESCRIPTION_LENGTH}"
         );
     }
 }

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -242,8 +242,7 @@ mod tests {
 
         assert!(
             matches_pattern,
-            "Error message '{}' did not match any expected patterns for this platform: {:?}",
-            err, COMMAND_NOT_FOUND_PATTERNS
+            "Error message '{err}' did not match any expected patterns for this platform: {COMMAND_NOT_FOUND_PATTERNS:?}"
         );
     }
 

--- a/crates/forge_snaps/src/service.rs
+++ b/crates/forge_snaps/src/service.rs
@@ -70,7 +70,7 @@ impl SnapshotService {
         // Retrieve the latest snapshot path
         let snapshot_path = Self::find_recent_snapshot(&snapshot_dir)
             .await?
-            .context(format!("No valid snapshots found for {:?}", path))?;
+            .context(format!("No valid snapshots found for {path:?}"))?;
 
         // Restore the content
         let content = ForgeFS::read(&snapshot_path).await?;

--- a/crates/forge_snaps/src/snapshot.rs
+++ b/crates/forge_snaps/src/snapshot.rs
@@ -90,7 +90,7 @@ impl Snapshot {
             .format("%Y-%m-%d_%H-%M-%S-%9f")
             .to_string();
 
-        let filename = format!("{}.snap", formatted_time);
+        let filename = format!("{formatted_time}.snap");
         let path = PathBuf::from(self.path_hash()).join(PathBuf::from(filename));
         if let Some(cwd) = cwd {
             cwd.join(path)

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -103,11 +103,11 @@ impl SpinnerManager {
 
             // Then print the message if provided
             if let Some(msg) = message {
-                println!("{}", msg);
+                println!("{msg}");
             }
         } else if let Some(message) = message {
             // If there's no spinner but we have a message, just print it
-            println!("{}", message);
+            println!("{message}");
         }
 
         self.start_time = None;

--- a/crates/forge_template/src/element.rs
+++ b/crates/forge_template/src/element.rs
@@ -63,7 +63,7 @@ impl Element {
 
         result.push_str(&format!("<{}", self.name));
         for (key, value) in &self.attr {
-            result.push_str(&format!(" {}=\"{}\"", key, value));
+            result.push_str(&format!(" {key}=\"{value}\""));
         }
         result.push('>');
 

--- a/crates/forge_tool_macros/src/lib.rs
+++ b/crates/forge_tool_macros/src/lib.rs
@@ -41,7 +41,7 @@ pub fn derive_description(input: TokenStream) -> TokenStream {
 
     // Join all lines with a space (or newline, if you prefer)
     if doc_lines.is_empty() {
-        panic!("No doc comment found for {}", name);
+        panic!("No doc comment found for {name}");
     }
     let doc_string = doc_lines.join("\n").trim().to_string();
 

--- a/crates/forge_tracker/src/dispatch.rs
+++ b/crates/forge_tracker/src/dispatch.rs
@@ -225,7 +225,7 @@ mod tests {
             .dispatch(EventKind::Prompt("ping".to_string()))
             .await
         {
-            panic!("Tracker dispatch error: {:?}", e);
+            panic!("Tracker dispatch error: {e:?}");
         }
     }
 }

--- a/crates/forge_walker/src/walker.rs
+++ b/crates/forge_walker/src/walker.rs
@@ -189,7 +189,7 @@ impl Walker {
 
             // Ensure directory paths end with '/' for is_dir() function
             let path_string = if is_dir {
-                format!("{}/", path_string)
+                format!("{path_string}/")
             } else {
                 path_string
             };
@@ -240,7 +240,7 @@ mod tests {
             let mut current = dir.path().to_path_buf();
 
             for i in 0..depth {
-                current = current.join(format!("level{}", i));
+                current = current.join(format!("level{i}"));
                 fs::create_dir(&current)?;
                 File::create(current.join(file_name))?.write_all(b"test")?;
             }
@@ -256,7 +256,7 @@ mod tests {
             fs::create_dir(&files_dir)?;
 
             for i in 0..count {
-                File::create(files_dir.join(format!("{}{}.txt", prefix, i)))?.write_all(b"test")?;
+                File::create(files_dir.join(format!("{prefix}{i}.txt")))?.write_all(b"test")?;
             }
             Ok((dir, files_dir))
         }


### PR DESCRIPTION
- Updated various files to replace `format!("...{}", var)` with the more concise `format!("{var}")` syntax.
- Changes made across multiple modules including `conversation_html.rs`, `orch.rs`, `provider.rs`, `temperature.rs`, `text_utils.rs`, `tool_call_record.rs`, `tool_result.rs`, `env.rs`, `build.rs`, `auto_update.rs`, `banner.rs`, `search_term.rs`, `info.rs`, `model.rs`, `prompt.rs`, `tools_display.rs`, `ui.rs`, `anthropic/provider.rs`, `anthropic/request.rs`, `anthropic/response.rs`, `builder.rs`, `open_router/provider.rs`, `open_router/response.rs`, `open_router/transformers/transformer.rs`, `attachment.rs`, `compaction.rs`, `tool_service.rs`, `fetch.rs`, `file_info.rs`, `fs_find.rs`, `fs_read.rs`, `fs_undo.rs`, `patch.rs`, `registry.rs`, `shell.rs`, `service.rs`, `snapshot.rs`, `lib.rs`, `element.rs`, `lib.rs`, `dispatch.rs`, and `walker.rs`.