### PR TITLE
fix(orchestrator): improve handling of interrupted tool responses

### DIFF
--- a/crates/forge_display/src/markdown.rs
+++ b/crates/forge_display/src/markdown.rs
@@ -15,7 +15,7 @@ impl MarkdownFormat {
     /// Create a new MarkdownFormat with the default skin
     pub fn new() -> Self {
         let mut skin = MadSkin::default();
-        let compound_style = CompoundStyle::new(Some(gray(17)), None, Default::default());
+        let compound_style = CompoundStyle::new(None, Some(gray(17)), Default::default());
         skin.inline_code = compound_style.clone();
         skin.code_block = LineStyle::new(compound_style, Default::default());
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -258,10 +258,14 @@ impl<A: Services> Orchestrator<A> {
             .collect::<Vec<_>>()
             .join("");
 
-        if tool_interrupted && !content.trim().ends_with("</forge_tool_call>") {
-            content.push_str(
-             "\n[Response interrupted by tool result. Use only one tool at the end of the message]",
-          );
+        if tool_interrupted {
+            if let Some((i, right)) = content.rmatch_indices("</forge_tool_call>").next() {
+                content.truncate(i + right.len());
+
+                content.push_str(
+                    "\n[Response interrupted by tool result. Use only one tool at the end of the message]",
+                 );
+            }
         }
 
         // Extract all tool calls in a fully declarative way with combined sources

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -237,6 +237,28 @@ impl<A: Services> Orchestrator<A> {
             }
         }
 
+        // Get the full content from all messages
+        let mut content = messages
+            .iter()
+            .flat_map(|m| m.content.iter())
+            .map(|content| content.as_str())
+            .collect::<Vec<_>>()
+            .join("");
+
+        if tool_interrupted && !content.trim().ends_with("</forge_tool_call>") {
+            if let Some((i, right)) = content.rmatch_indices("</forge_tool_call>").next() {
+                content.truncate(i + right.len());
+
+                // Add a comment for the assistant to signal interruption
+                content.push_str("\n");
+                content.push_str("<forge_feedback>");
+                content.push_str(
+                    "Response interrupted by tool result. Use only one tool at the end of the message",
+                 );
+                content.push_str("</forge_feedback>");
+            }
+        }
+
         // Send the complete message
         self.send(
             agent,
@@ -249,24 +271,6 @@ impl<A: Services> Orchestrator<A> {
             },
         )
         .await?;
-
-        // Get the full content from all messages
-        let mut content = messages
-            .iter()
-            .flat_map(|m| m.content.iter())
-            .map(|content| content.as_str())
-            .collect::<Vec<_>>()
-            .join("");
-
-        if tool_interrupted {
-            if let Some((i, right)) = content.rmatch_indices("</forge_tool_call>").next() {
-                content.truncate(i + right.len());
-
-                content.push_str(
-                    "\n[Response interrupted by tool result. Use only one tool at the end of the message]",
-                 );
-            }
-        }
 
         // Extract all tool calls in a fully declarative way with combined sources
         // Start with complete tool calls (for non-streaming mode)

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -250,7 +250,7 @@ impl<A: Services> Orchestrator<A> {
                 content.truncate(i + right.len());
 
                 // Add a comment for the assistant to signal interruption
-                content.push_str("\n");
+                content.push('\n');
                 content.push_str("<forge_feedback>");
                 content.push_str(
                     "Response interrupted by tool result. Use only one tool at the end of the message",


### PR DESCRIPTION
## Summary
This PR enhances the robustness of the tool execution system by implementing intelligent truncation of interrupted tool responses. It prevents execution of malformed or partial tool instructions by precisely locating and preserving only complete tool calls.

## Overview
This PR enhances the reliability of the tool response handling mechanism in the Orchestrator by properly truncating incomplete tool calls.

## Key Improvements
- Improves how we handle interrupted tool responses by finding the last valid tool call and truncating properly
- Uses pattern matching to locate the closing tag of the last complete tool call
- Properly truncates any partial/incomplete tool calls after the interruption point
- Helps prevent potential parsing errors or execution of incomplete tool instructions

## Technical Implementation
The change uses `rmatch_indices` to find the last occurrence of the closing tag and precisely truncates the content at that position before appending the notification message. It also replaces the plain text notification with structured feedback in XML format.