### PR TITLE
fix(software-designer): restrict agent to plan creation only

### DIFF
--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -53,6 +53,9 @@ agents:
     user_prompt: |-
       <task>{{event.value}}</task>
       <current_time>{{current_time}}</current_time>
+      Only create new plans or update existing ones.
+      Do not modify, create, or delete any code files.
+      
     ephemeral: false
     tools:
       - forge_tool_fs_read


### PR DESCRIPTION
## Core Functionality Improvements

This PR adds explicit instructions to the software-designer agent to only create and update plans, and not modify any code files. This prevents the agent from making unwanted code changes when it should be focused on planning.

These restrictions help maintain a clear separation of concerns between the planning and implementation phases in the software development workflow.