### PR TITLE
feat: add token estimation feature

### DIFF
--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -345,7 +345,7 @@ impl Key for Agent {
 pub fn estimate_token_count(text: &str) -> u64 {
     // A very rough estimation that assumes ~4 characters per token on average
     // In a real implementation, this should use a proper LLM-specific tokenizer
-    text.len() as u64 / 5
+    text.len() as u64 / 4
 }
 
 // The Transform enum has been removed

--- a/crates/forge_domain/src/message.rs
+++ b/crates/forge_domain/src/message.rs
@@ -10,6 +10,7 @@ pub struct Usage {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
+    pub estimated_tokens: Option<u64>,
 }
 
 /// Represents a message that was received from the LLM provider

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -51,18 +52,22 @@ impl Info {
 
 impl From<&Usage> for Info {
     fn from(usage: &Usage) -> Self {
-        let mut info = Info::new()
-            .add_title("Usage".to_string())
-            .add_key_value("Prompt", usage.prompt_tokens)
-            .add_key_value("Completion", usage.completion_tokens)
-            .add_key_value("Total Reported", usage.total_tokens);
+        let mut info = Info::new();
+        let estimated = usage.estimated_tokens.unwrap_or(0);
 
-        // Add estimated tokens if available
-        if let Some(estimated) = usage.estimated_tokens {
-            info = info.add_key_value("Total Estimated", estimated);
+        if estimated > usage.prompt_tokens {
+            info = info.add_key_value("Prompt", format!("~{}", estimated));
+        } else {
+            info = info.add_key_value("Prompt", usage.prompt_tokens)
         }
 
-        info
+        info.add_title("Usage".to_string())
+            .add_key_value(
+                "Prompt",
+                max(usage.prompt_tokens, usage.estimated_tokens.unwrap_or(0)),
+            )
+            .add_key_value("Completion", usage.completion_tokens)
+            .add_key_value("Total", usage.total_tokens)
     }
 }
 

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -56,7 +56,7 @@ impl From<&Usage> for Info {
         let estimated = usage.estimated_tokens.unwrap_or(0);
 
         if estimated > usage.prompt_tokens {
-            info = info.add_key_value("Prompt", format!("~{}", estimated));
+            info = info.add_key_value("Prompt", format!("~{estimated}"));
         } else {
             info = info.add_key_value("Prompt", usage.prompt_tokens)
         }

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -51,11 +51,18 @@ impl Info {
 
 impl From<&Usage> for Info {
     fn from(usage: &Usage) -> Self {
-        Info::new()
+        let mut info = Info::new()
             .add_title("Usage".to_string())
             .add_key_value("Prompt", usage.prompt_tokens)
             .add_key_value("Completion", usage.completion_tokens)
-            .add_key_value("Total", usage.total_tokens)
+            .add_key_value("Total Reported", usage.total_tokens);
+
+        // Add estimated tokens if available
+        if let Some(estimated) = usage.estimated_tokens {
+            info = info.add_key_value("Total Estimated", estimated);
+        }
+
+        info
     }
 }
 
@@ -100,7 +107,12 @@ impl From<&UIState> for Info {
         info = info
             .add_key_value("Prompt Tokens", value.usage.prompt_tokens)
             .add_key_value("Completion Tokens", value.usage.completion_tokens)
-            .add_key_value("Total Tokens", value.usage.total_tokens);
+            .add_key_value("Total Reported", value.usage.total_tokens);
+
+        // Add estimated tokens if available
+        if let Some(estimated) = value.usage.estimated_tokens {
+            info = info.add_key_value("Total Estimated", estimated);
+        }
 
         info
     }

--- a/crates/forge_main/src/prompt.rs
+++ b/crates/forge_main/src/prompt.rs
@@ -48,22 +48,21 @@ impl Prompt for ForgePrompt {
         let mut result = String::with_capacity(64); // Pre-allocate a reasonable size
 
         // Build the string step-by-step
-
-        let _ = write!(
+        write!(
             result,
             "{} {}",
             mode_style.paint(self.mode.to_string()),
             folder_style.paint(&current_dir)
-        );
+        ).unwrap();
 
         // Only append branch info if present
         if let Some(branch) = branch_opt {
             if branch != current_dir {
-                let _ = write!(result, " {} ", branch_style.paint(branch));
+                write!(result, " {} ", branch_style.paint(branch)).unwrap();
             }
         }
 
-        let _ = write!(result, "\n{} ", branch_style.paint(RIGHT_CHEVRON));
+        write!(result, "\n{} ", branch_style.paint(RIGHT_CHEVRON)).unwrap();
 
         Cow::Owned(result)
     }
@@ -73,7 +72,7 @@ impl Prompt for ForgePrompt {
         let mut result = String::with_capacity(32);
 
         // Start with bracket and version
-        let _ = write!(result, "[{VERSION}");
+        write!(result, "[{VERSION}").unwrap();
 
         // Append model if available
         if let Some(model) = self.model.as_ref() {
@@ -82,7 +81,7 @@ impl Prompt for ForgePrompt {
                 .split('/')
                 .next_back()
                 .unwrap_or_else(|| model.as_str());
-            let _ = write!(result, "/{formatted_model}");
+            write!(result, "/{formatted_model}").unwrap();
         }
 
         // Append usage info
@@ -91,14 +90,20 @@ impl Prompt for ForgePrompt {
             .as_ref()
             .unwrap_or(&Usage::default())
             .total_tokens;
+
         let estimated = self
             .usage
             .as_ref()
             .and_then(|u| u.estimated_tokens)
             .unwrap_or(0);
-        let max_tokens = std::cmp::max(reported, estimated);
-        let _ = write!(result, "/{max_tokens}");
-        let _ = write!(result, "]");
+
+        if estimated > reported {
+            write!(result, "/~{estimated}").unwrap();
+        } else {
+            write!(result, "/{reported}").unwrap();
+        }
+
+        write!(result, "]").unwrap();
 
         // Apply styling once at the end
         Cow::Owned(
@@ -131,13 +136,13 @@ impl Prompt for ForgePrompt {
 
         // Handle empty search term more elegantly
         if history_search.term.is_empty() {
-            let _ = write!(result, "({prefix}reverse-search) ");
+            write!(result, "({prefix}reverse-search) ").unwrap();
         } else {
-            let _ = write!(
+            write!(
                 result,
                 "({}reverse-search: {}) ",
                 prefix, history_search.term
-            );
+            ).unwrap();
         }
 
         Cow::Owned(Style::new().fg(Color::White).paint(&result).to_string())

--- a/crates/forge_main/src/prompt.rs
+++ b/crates/forge_main/src/prompt.rs
@@ -53,7 +53,8 @@ impl Prompt for ForgePrompt {
             "{} {}",
             mode_style.paint(self.mode.to_string()),
             folder_style.paint(&current_dir)
-        ).unwrap();
+        )
+        .unwrap();
 
         // Only append branch info if present
         if let Some(branch) = branch_opt {
@@ -142,7 +143,8 @@ impl Prompt for ForgePrompt {
                 result,
                 "({}reverse-search: {}) ",
                 prefix, history_search.term
-            ).unwrap();
+            )
+            .unwrap();
         }
 
         Cow::Owned(Style::new().fg(Color::White).paint(&result).to_string())

--- a/crates/forge_main/src/prompt.rs
+++ b/crates/forge_main/src/prompt.rs
@@ -208,9 +208,9 @@ mod tests {
 
     #[test]
     fn test_render_prompt_right_with_usage() {
-        let usage = Usage { 
-            prompt_tokens: 10, 
-            completion_tokens: 20, 
+        let usage = Usage {
+            prompt_tokens: 10,
+            completion_tokens: 20,
             total_tokens: 30,
             estimated_tokens: None,
         };
@@ -285,9 +285,9 @@ mod tests {
 
     #[test]
     fn test_render_prompt_right_with_model() {
-        let usage = Usage { 
-            prompt_tokens: 10, 
-            completion_tokens: 20, 
+        let usage = Usage {
+            prompt_tokens: 10,
+            completion_tokens: 20,
             total_tokens: 30,
             estimated_tokens: None,
         };

--- a/crates/forge_main/src/prompt.rs
+++ b/crates/forge_main/src/prompt.rs
@@ -86,12 +86,18 @@ impl Prompt for ForgePrompt {
         }
 
         // Append usage info
-        let usage = self
+        let reported = self
             .usage
             .as_ref()
             .unwrap_or(&Usage::default())
             .total_tokens;
-        let _ = write!(result, "/{usage}");
+        let estimated = self
+            .usage
+            .as_ref()
+            .and_then(|u| u.estimated_tokens)
+            .unwrap_or(0);
+        let max_tokens = std::cmp::max(reported, estimated);
+        let _ = write!(result, "/{max_tokens}");
         let _ = write!(result, "]");
 
         // Apply styling once at the end
@@ -202,7 +208,12 @@ mod tests {
 
     #[test]
     fn test_render_prompt_right_with_usage() {
-        let usage = Usage { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 };
+        let usage = Usage { 
+            prompt_tokens: 10, 
+            completion_tokens: 20, 
+            total_tokens: 30,
+            estimated_tokens: None,
+        };
         let mut prompt = ForgePrompt::default();
         prompt.usage(usage);
 
@@ -271,9 +282,15 @@ mod tests {
             .to_string();
         assert_eq!(actual, expected);
     }
+
     #[test]
     fn test_render_prompt_right_with_model() {
-        let usage = Usage { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 };
+        let usage = Usage { 
+            prompt_tokens: 10, 
+            completion_tokens: 20, 
+            total_tokens: 30,
+            estimated_tokens: None,
+        };
         let mut prompt = ForgePrompt::default();
         prompt.usage(usage);
         prompt.model(ModelId::new("anthropic/claude-3"));

--- a/crates/forge_main/src/state.rs
+++ b/crates/forge_main/src/state.rs
@@ -31,6 +31,7 @@ pub struct UIState {
     pub is_first: bool,
     pub model: Option<ModelId>,
     pub cached_models: Option<Vec<Model>>,
+    pub estimated_usage: Option<u64>,
 }
 
 impl UIState {
@@ -42,6 +43,7 @@ impl UIState {
             is_first: true,
             model: Default::default(),
             cached_models: Default::default(),
+            estimated_usage: Default::default(),
         }
     }
 }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -567,7 +567,10 @@ impl<F: API> UI<F> {
                 }
             }
             ChatResponse::Usage(u) => {
-                self.state.usage = u;
+                self.state.usage = u.clone();
+                if let Some(estimated) = u.estimated_tokens {
+                    self.state.estimated_usage = Some(estimated);
+                }
             }
         }
         Ok(())

--- a/crates/forge_provider/src/anthropic/response.rs
+++ b/crates/forge_provider/src/anthropic/response.rs
@@ -45,6 +45,17 @@ pub struct Usage {
     pub output_tokens: Option<u64>,
 }
 
+impl From<Usage> for forge_domain::Usage {
+    fn from(usage: Usage) -> Self {
+        forge_domain::Usage {
+            prompt_tokens: usage.input_tokens.unwrap_or(0),
+            completion_tokens: usage.output_tokens.unwrap_or(0),
+            total_tokens: usage.input_tokens.unwrap_or(0) + usage.output_tokens.unwrap_or(0),
+            estimated_tokens: None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum StopReason {

--- a/crates/forge_provider/src/open_router/response.rs
+++ b/crates/forge_provider/src/open_router/response.rs
@@ -106,6 +106,7 @@ impl From<ResponseUsage> for Usage {
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
             total_tokens: usage.total_tokens,
+            estimated_tokens: None,
         }
     }
 }


### PR DESCRIPTION
## Added Token Usage Estimation to Chat Responses
### Resolves - #713 
## Changes - 
- Added `estimated_tokens` field to track estimated token counts
- Enhanced orchestrator to calculate estimates from context
- Updated UI to display both reported and estimated totals
- Added provider support for Anthropic and OpenRouter

No breaking changes - `estimated_tokens` is optional and defaults to `None`.

### Working Proof - 

<img width="1052" alt="Screenshot 2025-05-01 at 11 05 54 AM" src="https://github.com/user-attachments/assets/3930c012-7ae2-4e78-981c-a9c8a000cc46" />



/claim #713