### PR TITLE
fix: auto-complete highlight doesn't match (#420)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,9 +1959,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2841,9 +2841,8 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfa8cb0ad84c396c936d8abb814703d7042a433d2da75a0c7060cbdc89109f3"
+version = "0.39.0"
+source = "git+https://github.com/nushell/reedline.git?rev=2dba3d3691f14844bbc38f9bad46fa66ba1f1ffa#2dba3d3691f14844bbc38f9bad46fa66ba1f1ffa"
 dependencies = [
  "chrono",
  "crossterm 0.28.1",
@@ -2854,9 +2853,9 @@ dependencies = [
  "strip-ansi-escapes",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ posthog-rs = { git = "https://github.com/PostHog/posthog-rs.git", rev = "a006a81
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-reedline = "0.38.0"
+reedline = { git = "https://github.com/nushell/reedline.git", rev = "2dba3d3691f14844bbc38f9bad46fa66ba1f1ffa" }
 regex = "1.11.1"
 reqwest = { version = "0.12.12", features = [
     "json",


### PR DESCRIPTION
The original reedline package is changed to https://github.com/nushell/reedline.git which implements the highlighting in the auto-complete feature.

![image](https://github.com/user-attachments/assets/d9ed4665-a3d8-48a3-a59e-764709ce4326)
