### PR TITLE
fix(tools): use JsonSchema instead of XML to Parse Tools

### DIFF
--- a/crates/forge_display/src/diff.rs
+++ b/crates/forge_display/src/diff.rs
@@ -26,7 +26,7 @@ impl DiffFormat {
 
         let mut output = format!(
             "{}\n\n",
-            TitleFormat::new(op_name).sub_title(path.display().to_string())
+            TitleFormat::info(op_name).sub_title(path.display().to_string())
         );
 
         if ops.is_empty() {

--- a/crates/forge_display/src/diff.rs
+++ b/crates/forge_display/src/diff.rs
@@ -26,7 +26,7 @@ impl DiffFormat {
 
         let mut output = format!(
             "{}\n\n",
-            TitleFormat::info(op_name).sub_title(path.display().to_string())
+            TitleFormat::debug(op_name).sub_title(path.display().to_string())
         );
 
         if ops.is_empty() {

--- a/crates/forge_display/src/markdown.rs
+++ b/crates/forge_display/src/markdown.rs
@@ -19,7 +19,9 @@ impl MarkdownFormat {
         let compound_style =
             CompoundStyle::new(Some(Color::Black), Some(gray(17)), Default::default());
         skin.inline_code = compound_style.clone();
-        skin.code_block = LineStyle::new(compound_style, Default::default());
+        // Code blocks: NO BG, CYAN FG
+        let codeblock_style = CompoundStyle::new(Some(Color::Cyan), None, Default::default());
+        skin.code_block = LineStyle::new(codeblock_style, Default::default());
 
         Self { skin, max_consecutive_newlines: 2 }
     }

--- a/crates/forge_display/src/markdown.rs
+++ b/crates/forge_display/src/markdown.rs
@@ -1,7 +1,7 @@
 use derive_setters::Setters;
 use regex::Regex;
-use termimad::crossterm::style::Color;
-use termimad::{gray, CompoundStyle, LineStyle, MadSkin};
+use termimad::crossterm::style::{Attribute, Color};
+use termimad::{CompoundStyle, LineStyle, MadSkin};
 
 /// MarkdownFormat provides functionality for formatting markdown text for
 /// terminal display.
@@ -16,10 +16,9 @@ impl MarkdownFormat {
     /// Create a new MarkdownFormat with the default skin
     pub fn new() -> Self {
         let mut skin = MadSkin::default();
-        let compound_style =
-            CompoundStyle::new(Some(Color::Black), Some(gray(17)), Default::default());
+        let compound_style = CompoundStyle::new(Some(Color::Cyan), None, Attribute::Bold.into());
         skin.inline_code = compound_style.clone();
-        // Code blocks: NO BG, CYAN FG
+
         let codeblock_style = CompoundStyle::new(Some(Color::Cyan), None, Default::default());
         skin.code_block = LineStyle::new(codeblock_style, Default::default());
 

--- a/crates/forge_display/src/title.rs
+++ b/crates/forge_display/src/title.rs
@@ -71,9 +71,9 @@ impl TitleFormat {
         let mut buf = String::new();
 
         let icon = match self.category {
-            Category::Action => "⏺".red(),
-            Category::Info => "⏺".red(),
-            Category::Debug => "⏺".red(),
+            Category::Action => "⏺".yellow(),
+            Category::Info => "⏺".white(),
+            Category::Debug => "⏺".cyan(),
             Category::Error => "⏺".red(),
         };
 

--- a/crates/forge_display/src/title.rs
+++ b/crates/forge_display/src/title.rs
@@ -3,13 +3,20 @@ use std::fmt::{self, Display, Formatter};
 use colored::Colorize;
 use derive_setters::Setters;
 
+#[derive(Clone)]
+pub enum Category {
+    Action,
+    Info,
+    Debug,
+    Error,
+}
+
 #[derive(Clone, Setters)]
 #[setters(into, strip_option)]
 pub struct TitleFormat {
     pub title: String,
     pub sub_title: Option<String>,
-    pub error: Option<String>,
-    pub is_user_action: bool,
+    pub category: Category,
 }
 
 pub trait TitleExt {
@@ -27,35 +34,50 @@ where
 
 impl TitleFormat {
     /// Create a status for executing a tool
-    pub fn new(tag: impl Into<String>) -> Self {
+    pub fn info(message: impl Into<String>) -> Self {
         Self {
-            title: tag.into(),
-            error: None,
-            sub_title: Default::default(),
-            is_user_action: false,
+            title: message.into(),
+            sub_title: None,
+            category: Category::Info,
         }
     }
 
     /// Create a status for executing a tool
-    pub fn action(title: impl Into<String>) -> Self {
+    pub fn action(message: impl Into<String>) -> Self {
         Self {
-            title: title.into(),
-            error: None,
-            sub_title: Default::default(),
-            is_user_action: true,
+            title: message.into(),
+            sub_title: None,
+            category: Category::Action,
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            title: message.into(),
+            sub_title: None,
+            category: Category::Error,
+        }
+    }
+
+    pub fn debug(message: impl Into<String>) -> Self {
+        Self {
+            title: message.into(),
+            sub_title: None,
+            category: Category::Debug,
         }
     }
 
     pub fn format(&self) -> String {
         let mut buf = String::new();
 
-        if self.error.is_some() {
-            buf.push_str(format!("{} ", "⏺".red()).as_str());
-        } else if self.is_user_action {
-            buf.push_str(format!("{} ", "⏺".yellow()).as_str());
-        } else {
-            buf.push_str(format!("{} ", "⏺".cyan()).as_str());
-        }
+        let icon = match self.category {
+            Category::Action => "⏺".red(),
+            Category::Info => "⏺".red(),
+            Category::Debug => "⏺".red(),
+            Category::Error => "⏺".red(),
+        };
+
+        buf.push_str(format!("{icon} ").as_str());
 
         // Add timestamp at the beginning if this is not a user action
         #[cfg(not(test))]
@@ -70,20 +92,17 @@ impl TitleFormat {
             );
         }
 
-        if self.error.is_some() {
-            buf.push_str(self.title.red().bold().to_string().as_str())
-        } else if self.is_user_action {
-            buf.push_str(self.title.as_str())
-        } else {
-            buf.push_str(self.title.dimmed().to_string().as_str())
+        let title = match self.category {
+            Category::Action => self.title.white(),
+            Category::Info => self.title.white(),
+            Category::Debug => self.title.dimmed(),
+            Category::Error => format!("{} {}", "ERROR:".bold(), self.title).red(),
         };
+
+        buf.push_str(title.to_string().as_str());
 
         if let Some(ref sub_title) = self.sub_title {
             buf.push_str(&format!(" {}", sub_title.dimmed()).to_string());
-        }
-
-        if let Some(ref error) = self.error {
-            buf.push_str(&format!(" {error}").to_string());
         }
 
         buf

--- a/crates/forge_display/src/title.rs
+++ b/crates/forge_display/src/title.rs
@@ -67,7 +67,7 @@ impl TitleFormat {
         }
     }
 
-    pub fn format(&self) -> String {
+    fn format(&self) -> String {
         let mut buf = String::new();
 
         let icon = match self.category {

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -494,7 +494,7 @@ impl<A: Services> Orchestrator<A> {
                 empty_tool_call_count += 1;
 
                 if empty_tool_call_count > 3 {
-                    bail!("Model is unable to follow instructions. Consider retrying or switching to a bigger model");
+                    bail!("Model is unable to follow instructions, consider retrying or switching to a bigger model.");
                 }
             }
 

--- a/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_failed_call.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_failed_call.snap
@@ -1,8 +1,12 @@
 ---
 source: crates/forge_domain/src/tool_call_record.rs
 expression: record.to_string()
+snapshot_kind: text
 ---
-<forge_tool_result tool="fs_write"><result><error><![CDATA[
+---
+tool_name: fs_write
+status: Failure
+---
+
 ERROR:
 Caused by: Permission denied
-]]></error></result></forge_tool_result>

--- a/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_successful_call.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_successful_call.snap
@@ -1,5 +1,10 @@
 ---
 source: crates/forge_domain/src/tool_call_record.rs
 expression: record.to_string()
+snapshot_kind: text
 ---
-<forge_tool_result tool="fs_read"><result><content><![CDATA[Contents of the file]]></content></result></forge_tool_result>
+---
+tool_name: fs_read
+status: Success
+---
+Contents of the file

--- a/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_with_special_chars.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__tool_call_record__tests__display_with_special_chars.snap
@@ -1,5 +1,10 @@
 ---
 source: crates/forge_domain/src/tool_call_record.rs
 expression: record.to_string()
+snapshot_kind: text
 ---
-<forge_tool_result tool="test_tool"><result><content><![CDATA[Result with <tags> & special "characters"]]></content></result></forge_tool_result>
+---
+tool_name: test_tool
+status: Success
+---
+Result with <tags> & special "characters"

--- a/crates/forge_domain/src/snapshots/forge_domain__tool_usage__tests__tool_usage_prompt_to_string.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__tool_usage__tests__tool_usage_prompt_to_string.snap
@@ -3,17 +3,4 @@ source: crates/forge_domain/src/tool_usage.rs
 expression: prompt
 snapshot_kind: text
 ---
-1. forge_tool_mango:
-Description: This is a mango tool
-Usage:
-<forge_tool_call>
-<forge_tool_mango>
-<param1>
-<!-- required -->
-<!-- This is parameter 1 -->
-</param1>
-<param2>
-<!-- This is parameter 2 -->
-</param2>
-</forge_tool_mango>
-</forge_tool_call>
+{"name":"forge_tool_mango","arguments":{"param1":{"description":"This is parameter 1","type":"string","is_required":true},"param2":{"description":"This is parameter 2","type":["string","null"],"is_required":false}}}

--- a/crates/forge_domain/src/tool_call.rs
+++ b/crates/forge_domain/src/tool_call.rs
@@ -3,8 +3,7 @@ use derive_setters::Setters;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::tool_call_parser::parse;
-use crate::{Error, Result, ToolName};
+use crate::{extract_tag_content, Error, Result, ToolName};
 
 /// Unique identifier for a using a tool
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -128,7 +127,12 @@ impl ToolCallFull {
 
     /// Parse multiple tool calls from XML format.
     pub fn try_from_xml(input: &str) -> std::result::Result<Vec<Self>, Error> {
-        parse(input)
+        match extract_tag_content(input, "forge_tool_call") {
+            None => Ok(Default::default()),
+            Some(content) => Ok(vec![
+                serde_json::from_str(content).map_err(Error::ToolCallArgument)?
+            ]),
+        }
     }
 }
 

--- a/crates/forge_domain/src/tool_call_context.rs
+++ b/crates/forge_domain/src/tool_call_context.rs
@@ -67,12 +67,12 @@ impl ToolCallContext {
         }
     }
 
-    pub async fn send_text(&self, content: String) -> anyhow::Result<()> {
+    pub async fn send_text(&self, content: impl ToString) -> anyhow::Result<()> {
         if let Some(agent_id) = &self.agent_id {
             self.send(AgentMessage::new(
                 agent_id.clone(),
                 ChatResponse::Text {
-                    text: content.as_str().to_string(),
+                    text: content.to_string(),
                     is_complete: true,
                     is_md: false,
                     is_summary: false,

--- a/crates/forge_domain/src/tool_call_record.rs
+++ b/crates/forge_domain/src/tool_call_record.rs
@@ -18,22 +18,17 @@ pub struct ToolCallRecord {
 impl Display for ToolCallRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let tool_name = self.tool_call.name.as_str();
-        write!(f, "<forge_tool_result tool=\"{tool_name}\">")?;
 
-        write!(f, "<result>")?;
-
+        writeln!(f, "---")?;
+        writeln!(f, "tool_name: {}", tool_name)?;
         if self.tool_result.is_error {
-            write!(f, "<error><![CDATA[{}]]></error>", self.tool_result.content)?;
+            writeln!(f, "status: Failure")?;
         } else {
-            write!(
-                f,
-                "<content><![CDATA[{}]]></content>",
-                self.tool_result.content
-            )?;
+            writeln!(f, "status: Success")?;
         }
+        writeln!(f, "---")?;
 
-        write!(f, "</result>")?;
-        write!(f, "</forge_tool_result>")?;
+        writeln!(f, "{}", self.tool_result.content)?;
 
         Ok(())
     }

--- a/crates/forge_domain/src/tool_call_record.rs
+++ b/crates/forge_domain/src/tool_call_record.rs
@@ -20,7 +20,7 @@ impl Display for ToolCallRecord {
         let tool_name = self.tool_call.name.as_str();
 
         writeln!(f, "---")?;
-        writeln!(f, "tool_name: {}", tool_name)?;
+        writeln!(f, "tool_name: {tool_name}")?;
         if self.tool_result.is_error {
             writeln!(f, "status: Failure")?;
         } else {

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -48,7 +48,7 @@ impl Console {
                     match self.command.parse(&text) {
                         Ok(command) => return Ok(command),
                         Err(e) => {
-                            println!("{}", TitleFormat::error(e.to_string()).format());
+                            println!("{}", TitleFormat::error(e.to_string()));
                         }
                     }
                 }

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -48,10 +48,7 @@ impl Console {
                     match self.command.parse(&text) {
                         Ok(command) => return Ok(command),
                         Err(e) => {
-                            println!(
-                                "{}",
-                                TitleFormat::new("Command").error(e.to_string()).format()
-                            );
+                            println!("{}", TitleFormat::error(e.to_string()).format());
                         }
                     }
                 }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -531,7 +531,9 @@ impl<F: API> UI<F> {
                     self.writeln(text)?;
                 }
             }
-            ChatResponse::ToolCallStart(_) => {}
+            ChatResponse::ToolCallStart(_) => {
+                self.spinner.stop(None)?;
+            }
             ChatResponse::ToolCallEnd(toolcall_result) => {
                 // Only track toolcall name in case of success else track the error.
                 let payload = if toolcall_result.is_error {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -156,12 +156,7 @@ impl<F: API> UI<F> {
         match self.run_inner().await {
             Ok(_) => {}
             Err(error) => {
-                println!(
-                    "{}",
-                    TitleFormat::action("Error")
-                        .error(format!("{error:?}"))
-                        .format()
-                );
+                println!("{}", TitleFormat::error(format!("{error:?}")).format());
             }
         }
     }
@@ -225,12 +220,7 @@ impl<F: API> UI<F> {
                         );
                         error!(error = ?err, "Chat request failed");
 
-                        println!(
-                            "{}",
-                            TitleFormat::action("Error")
-                                .error(format!("{err:?}"))
-                                .format()
-                        );
+                        println!("{}", TitleFormat::error(format!("{err:?}")).format());
                     }
                 }
                 Command::Act => {
@@ -259,9 +249,8 @@ impl<F: API> UI<F> {
                     if let Err(e) = self.dispatch_event(event.into()).await {
                         println!(
                             "{}",
-                            TitleFormat::action("Failed to execute the command")
-                                .sub_title("Command Execution")
-                                .error(e.to_string())
+                            TitleFormat::error("Failed to execute the command")
+                                .sub_title(e.to_string())
                                 .format()
                         );
                     }
@@ -528,9 +517,8 @@ impl<F: API> UI<F> {
             } else {
                 println!(
                     "{}",
-                    TitleFormat::action("Could not create dump")
-                        .error("Conversation not found")
-                        .sub_title(format!("conversation_id: {conversation_id}"))
+                    TitleFormat::error("Could not create dump")
+                        .sub_title(format!("Conversation: {conversation_id} was not found"))
                         .format()
                 );
             }
@@ -547,7 +535,7 @@ impl<F: API> UI<F> {
                     }
 
                     if is_summary {
-                        text = TitleFormat::action(text).to_string();
+                        text = TitleFormat::debug(text).to_string();
                     }
 
                     self.spinner.stop(Some(text))?;

--- a/crates/forge_services/src/tools/fetch.rs
+++ b/crates/forge_services/src/tools/fetch.rs
@@ -106,7 +106,7 @@ impl Fetch {
             .map_err(|e| anyhow!("Failed to fetch URL {}: {}", url, e))?;
 
         let title_format =
-            TitleFormat::info(format!("GET {}", response.status())).sub_title(url.as_str());
+            TitleFormat::debug(format!("GET {}", response.status())).sub_title(url.as_str());
         context.send_text(title_format.format()).await?;
 
         if !response.status().is_success() {

--- a/crates/forge_services/src/tools/fetch.rs
+++ b/crates/forge_services/src/tools/fetch.rs
@@ -106,7 +106,7 @@ impl Fetch {
             .map_err(|e| anyhow!("Failed to fetch URL {}: {}", url, e))?;
 
         let title_format =
-            TitleFormat::new(format!("GET {}", response.status())).sub_title(url.as_str());
+            TitleFormat::info(format!("GET {}", response.status())).sub_title(url.as_str());
         context.send_text(title_format.format()).await?;
 
         if !response.status().is_success() {

--- a/crates/forge_services/src/tools/fetch.rs
+++ b/crates/forge_services/src/tools/fetch.rs
@@ -105,9 +105,11 @@ impl Fetch {
             .await
             .map_err(|e| anyhow!("Failed to fetch URL {}: {}", url, e))?;
 
-        let title_format =
-            TitleFormat::debug(format!("GET {}", response.status())).sub_title(url.as_str());
-        context.send_text(title_format.format()).await?;
+        context
+            .send_text(
+                TitleFormat::debug(format!("GET {}", response.status())).sub_title(url.as_str()),
+            )
+            .await?;
 
         if !response.status().is_success() {
             return Err(anyhow!(

--- a/crates/forge_services/src/tools/fs/fs_find.rs
+++ b/crates/forge_services/src/tools/fs/fs_find.rs
@@ -114,7 +114,7 @@ impl<F: Infrastructure> FSFind<F> {
 
         let title_format = self.create_title(&input)?;
 
-        context.send_text(title_format.format()).await?;
+        context.send_text(title_format).await?;
 
         if !dir.exists() {
             return Err(anyhow::anyhow!("Directory '{}' does not exist", input.path));

--- a/crates/forge_services/src/tools/fs/fs_find.rs
+++ b/crates/forge_services/src/tools/fs/fs_find.rs
@@ -105,7 +105,7 @@ impl<F: Infrastructure> FSFind<F> {
             (None, None) => format!("at {formatted_dir}"),
         };
 
-        Ok(TitleFormat::info(title))
+        Ok(TitleFormat::debug(title))
     }
 
     async fn call(&self, context: ToolCallContext, input: FSFindInput) -> anyhow::Result<String> {

--- a/crates/forge_services/src/tools/fs/fs_find.rs
+++ b/crates/forge_services/src/tools/fs/fs_find.rs
@@ -105,7 +105,7 @@ impl<F: Infrastructure> FSFind<F> {
             (None, None) => format!("at {formatted_dir}"),
         };
 
-        Ok(TitleFormat::new(title))
+        Ok(TitleFormat::info(title))
     }
 
     async fn call(&self, context: ToolCallContext, input: FSFindInput) -> anyhow::Result<String> {

--- a/crates/forge_services/src/tools/fs/fs_read.rs
+++ b/crates/forge_services/src/tools/fs/fs_read.rs
@@ -146,7 +146,7 @@ impl<F: Infrastructure> FSRead<F> {
             subtitle.push_str(&format!(" ({range_info})"));
         }
 
-        let message = TitleFormat::new(title).sub_title(subtitle);
+        let message = TitleFormat::info(title).sub_title(subtitle);
 
         // Send the formatted message
         context.send_text(message.format()).await?;
@@ -263,7 +263,7 @@ mod test {
 
         // Display a message - just for testing
         let title = "Read";
-        let message = TitleFormat::new(title).sub_title(path.display().to_string());
+        let message = TitleFormat::info(title).sub_title(path.display().to_string());
         println!("{message}");
 
         // Assert the content matches

--- a/crates/forge_services/src/tools/fs/fs_read.rs
+++ b/crates/forge_services/src/tools/fs/fs_read.rs
@@ -149,7 +149,7 @@ impl<F: Infrastructure> FSRead<F> {
         let message = TitleFormat::debug(title).sub_title(subtitle);
 
         // Send the formatted message
-        context.send_text(message.format()).await?;
+        context.send_text(message).await?;
 
         Ok(())
     }

--- a/crates/forge_services/src/tools/fs/fs_read.rs
+++ b/crates/forge_services/src/tools/fs/fs_read.rs
@@ -146,7 +146,7 @@ impl<F: Infrastructure> FSRead<F> {
             subtitle.push_str(&format!(" ({range_info})"));
         }
 
-        let message = TitleFormat::info(title).sub_title(subtitle);
+        let message = TitleFormat::debug(title).sub_title(subtitle);
 
         // Send the formatted message
         context.send_text(message.format()).await?;
@@ -263,7 +263,7 @@ mod test {
 
         // Display a message - just for testing
         let title = "Read";
-        let message = TitleFormat::info(title).sub_title(path.display().to_string());
+        let message = TitleFormat::debug(title).sub_title(path.display().to_string());
         println!("{message}");
 
         // Assert the content matches

--- a/crates/forge_services/src/tools/fs/fs_undo.rs
+++ b/crates/forge_services/src/tools/fs/fs_undo.rs
@@ -70,7 +70,7 @@ impl<F: Infrastructure> ExecutableTool for FsUndo<F> {
         let display_path = self.format_display_path(path)?;
 
         // Display a message about the file being undone
-        let message = TitleFormat::info("Undo").sub_title(display_path.clone());
+        let message = TitleFormat::debug("Undo").sub_title(display_path.clone());
         context.send_text(message.format()).await?;
 
         Ok(format!(

--- a/crates/forge_services/src/tools/fs/fs_undo.rs
+++ b/crates/forge_services/src/tools/fs/fs_undo.rs
@@ -70,7 +70,7 @@ impl<F: Infrastructure> ExecutableTool for FsUndo<F> {
         let display_path = self.format_display_path(path)?;
 
         // Display a message about the file being undone
-        let message = TitleFormat::new("Undo").sub_title(display_path.clone());
+        let message = TitleFormat::info("Undo").sub_title(display_path.clone());
         context.send_text(message.format()).await?;
 
         Ok(format!(

--- a/crates/forge_services/src/tools/fs/fs_undo.rs
+++ b/crates/forge_services/src/tools/fs/fs_undo.rs
@@ -71,7 +71,7 @@ impl<F: Infrastructure> ExecutableTool for FsUndo<F> {
 
         // Display a message about the file being undone
         let message = TitleFormat::debug("Undo").sub_title(display_path.clone());
-        context.send_text(message.format()).await?;
+        context.send_text(message).await?;
 
         Ok(format!(
             "Successfully undid last operation on path: {display_path}"

--- a/crates/forge_services/src/tools/registry.rs
+++ b/crates/forge_services/src/tools/registry.rs
@@ -27,7 +27,7 @@ impl<F: Infrastructure> ToolRegistry<F> {
             FSRemove::new(self.infra.clone()).into(),
             FSList::default().into(),
             FSFind::new(self.infra.clone()).into(),
-            FSFileInfo.into(),
+            FSFileInfo::new(self.infra.clone()).into(),
             FsUndo::new(self.infra.clone()).into(),
             ApplyPatchJson::new(self.infra.clone()).into(),
             Shell::new(self.infra.clone()).into(),

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -112,7 +112,7 @@ impl<I: Infrastructure> ExecutableTool for Shell<I> {
         let title_format = TitleFormat::debug(format!("Execute [{}]", self.env.shell.as_str()))
             .sub_title(&input.command);
 
-        context.send_text(title_format.format()).await?;
+        context.send_text(title_format).await?;
 
         let output = self
             .infra

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -109,7 +109,7 @@ impl<I: Infrastructure> ExecutableTool for Shell<I> {
         if input.command.trim().is_empty() {
             bail!("Command string is empty or contains only whitespace".to_string());
         }
-        let title_format = TitleFormat::info(format!("Execute [{}]", self.env.shell.as_str()))
+        let title_format = TitleFormat::debug(format!("Execute [{}]", self.env.shell.as_str()))
             .sub_title(&input.command);
 
         context.send_text(title_format.format()).await?;

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -109,7 +109,7 @@ impl<I: Infrastructure> ExecutableTool for Shell<I> {
         if input.command.trim().is_empty() {
             bail!("Command string is empty or contains only whitespace".to_string());
         }
-        let title_format = TitleFormat::new(format!("Execute [{}]", self.env.shell.as_str()))
+        let title_format = TitleFormat::info(format!("Execute [{}]", self.env.shell.as_str()))
             .sub_title(&input.command);
 
         context.send_text(title_format.format()).await?;

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -117,4 +117,15 @@ impl SpinnerManager {
         self.message = None;
         Ok(())
     }
+
+    pub fn write_ln(&mut self, message: impl ToString) -> Result<()> {
+        let is_running = self.spinner.is_some();
+        let prev_message = self.message.clone();
+        self.stop(Some(message.to_string()))?;
+        if is_running {
+            self.start(prev_message.as_deref())?
+        }
+
+        Ok(())
+    }
 }

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -22,7 +22,6 @@ agents:
       {{> system-prompt-engineer-act.hbs }}
     user_prompt: |-
       <task>{{event.value}}</task>
-      <current_time>{{current_time}}</current_time>
     ephemeral: false
     tools:
       - forge_tool_fs_read

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: google/gemini-2.5-flash-preview
+model: anthropic/claude-3.7-sonnet
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: google/gemini-flash-1.5
+model: anthropic/claude-3.7-sonnet
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: anthropic/claude-3.7-sonnet
+model: google/gemini-2.5-flash-preview
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: anthropic/claude-3.7-sonnet
+model: google/gemini-2.5-pro-exp-03-25
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: google/gemini-2.5-pro-exp-03-25
+model: anthropic/claude-3.7-sonnet
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/forge.yaml
+++ b/forge.yaml
@@ -9,7 +9,7 @@ commands:
     - Understand the current PR deeply using the GH CLI and update the PR title and description
     - Make sure the title follows conventional commits standard
     - Top-level summary should contain 2-3 lines about the core functionality improvements
-model: anthropic/claude-3.7-sonnet
+model: google/gemini-flash-1.5
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:

--- a/templates/partial-tool-information.hbs
+++ b/templates/partial-tool-information.hbs
@@ -1,30 +1,12 @@
 {{#if (not tool_supported)}}
+<available_tools>
+{{tool_information}}
+</available_tools>
+
 Tool Usage Instructions:
 
 You have access to set of tools as described in the <available_tools> tag. You can use one tool per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
 
-Tool Use Formatting Rules:
+{{> partial-tool-use-example.hbs }}
 
-1. You can only make one tool call per message.
-2. Each tool call must be wrapped in `<forge_tool_call>` tags.
-
-Here's a correct example structure:
-
-```
-<forge_tool_call>
-{"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
-</forge_tool_call>
-```
-
-Important:
-
-- ALWAYS use JSON format inside `forge_tool_call`
-- If you need to make multiple tool calls, send them in separate messages
-
-Before using a tool, ensure all required arguments are available. 
-If any required arguments are missing, do not attempt to use the tool.
-
-<available_tools>
-{{tool_information}}
-</available_tools>
 {{/if}}

--- a/templates/partial-tool-information.hbs
+++ b/templates/partial-tool-information.hbs
@@ -5,31 +5,24 @@ You have access to set of tools as described in the <available_tools> tag. You c
 
 Tool Use Formatting Rules:
 
-1. Tool use is formatted using XML-style tags ONLY.
-2. You can only make one tool call per message.
-3. Each tool call must be wrapped in `<forge_tool_call>` tags.
-4. The actual tool name (e.g., forge_tool_fs_read) must be used as the enclosing tag.
-5. Each parameter must be enclosed within its own set of tags.
+1. You can only make one tool call per message.
+2. Each tool call must be wrapped in `<forge_tool_call>` tags.
+
 Here's a correct example structure:
 
 ```
 <forge_tool_call>
-<forge_tool_fs_read>
-<path>/path/to/file</path>
-<recursive>true</recursive>
-</forge_tool_fs_read>
+{"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
 </forge_tool_call>
 ```
 
 Important:
 
-- ALWAYS use XML format, even for multiple operations
-- Do NOT use JSON format (e.g., `tool_name({"param": "value"})`)
-- Do NOT mix formats in the same message
+- ALWAYS use JSON format inside `forge_tool_call`
 - If you need to make multiple tool calls, send them in separate messages
 
-Before using a tool, ensure all required parameters are available. 
-If any required parameters are missing, do not attempt to use the tool.
+Before using a tool, ensure all required arguments are available. 
+If any required arguments are missing, do not attempt to use the tool.
 
 <available_tools>
 {{tool_information}}

--- a/templates/partial-tool-information.hbs
+++ b/templates/partial-tool-information.hbs
@@ -5,7 +5,10 @@
 
 Tool Usage Instructions:
 
-You have access to set of tools as described in the <available_tools> tag. You can use one tool per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+1. You have access to set of tools as described in the <available_tools> tag. 
+2. You can use one tool per message, and will receive the result of that tool use in the user's response. 
+3. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+4. Ensure to use the `tool_forge_attempt_completion` tool to signal completion of a task.
 
 {{> partial-tool-use-example.hbs }}
 

--- a/templates/partial-tool-required.hbs
+++ b/templates/partial-tool-required.hbs
@@ -3,16 +3,11 @@ You did not use the tool or used it incorrectly in your previous response!
 Please retry with correct tool use
 </error>
 
-Here's a correct example structure:
-
-```
-<forge_tool_call>
-{"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
-</forge_tool_call>
-```
+{{> partial-tool-use-example.hbs }}
 
 Next Steps: If you have completed the user's task, use the `tool_forge_attempt_completion`
-tool. If you require additional information from the user, use the
+tool with a message. If you require additional information from the user, use the
 `tool_forge_followup` tool. Otherwise, if you have not completed the task and do
 not need additional information, then proceed with the next step of the task.
-(This is an automated message, so do not respond to it conversationally.)
+
+[This is an automated message, so do not respond to it conversationally.]

--- a/templates/partial-tool-required.hbs
+++ b/templates/partial-tool-required.hbs
@@ -10,4 +10,4 @@ tool with a message. If you require additional information from the user, use th
 `tool_forge_followup` tool. Otherwise, if you have not completed the task and do
 not need additional information, then proceed with the next step of the task.
 
-[This is an automated message, so do not respond to it conversationally.]
+[This is an automated message, so do not apologize, appreciate or be conversational]

--- a/templates/partial-tool-required.hbs
+++ b/templates/partial-tool-required.hbs
@@ -7,10 +7,7 @@ Here's a correct example structure:
 
 ```
 <forge_tool_call>
-<forge_tool_fs_read>
-<path>/path/to/file</path>
-<recursive>true</recursive>
-</forge_tool_fs_read>
+{"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
 </forge_tool_call>
 ```
 

--- a/templates/partial-tool-use-example.hbs
+++ b/templates/partial-tool-use-example.hbs
@@ -1,0 +1,20 @@
+Tool Use Formatting Rules:
+
+1. You can only make one tool call per message.
+2. Each tool call must be wrapped in `<forge_tool_call>` tags.
+
+Here's a correct example structure:
+
+<forge_tool_call>
+{"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
+</forge_tool_call>
+
+Important:
+
+1. ALWAYS use JSON format inside `forge_tool_call` tags.
+2. Specify the name of tool in the `name` field.
+3. Specify the tool arguments in the `arguments` field.
+4. If you need to make multiple tool calls, send them in separate messages
+
+Before using a tool, ensure all required arguments are available. 
+If any required arguments are missing, do not attempt to use the tool.

--- a/templates/partial-tool-use-example.hbs
+++ b/templates/partial-tool-use-example.hbs
@@ -5,9 +5,17 @@ Tool Use Formatting Rules:
 
 Here's a correct example structure:
 
+Example 1:
 <forge_tool_call>
 {"name": "forge_tool_fs_read", "arguments": {"path": "/a/b/c.txt"}}
 </forge_tool_call>
+
+
+Example 2:
+<forge_tool_call>
+{"name": "forge_tool_fs_write", "arguments": {"path": "/a/b/c.txt", "content": "Hello World!"}}
+</forge_tool_call>
+
 
 Important:
 


### PR DESCRIPTION
## Overview
This PR enhances the tool call handling and fixes critical compilation errors affecting the FSFileInfo tool and UI components. The primary improvements include:

- Properly implements the FSFileInfo tool with Infrastructure parameter support to fix compilation errors
- Addresses type conversion issues in UI spinner component by converting TitleFormat to String
- Improves tool usage instructions with better JSON schema-based formatting
- Enhances display consistency across tool invocations with standardized formatting

## Specific Enhancements
- Refactors FSFileInfo to properly handle Arc<F> infrastructure parameter
- Updates all test cases to conform to the new interface
- Adds proper type conversion for TitleFormat in UI components
- Improves text handling in various display modules
- Simplifies tool usage instructions with clearer examples
- Updates formatting styles for improved visibility and readability

## Technical Details
The PR addresses two critical compilation errors:
1. Incorrect usage of FSFileInfo struct in registry.rs which required proper infrastructure parameter passing
2. Type mismatch in ui.rs where TitleFormat was being passed to methods expecting String

All tests pass with the fixed implementation, ensuring stability of the codebase.