### PR TITLE
feat: added once-daily update prompts and an update command for manual updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crokey"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +910,7 @@ dependencies = [
  "inquire",
  "insta",
  "lazy_static",
+ "merge",
  "nu-ansi-term 0.50.1",
  "pretty_assertions",
  "reedline",
@@ -893,6 +924,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "update-informer",
 ]
 
 [[package]]
@@ -1497,6 +1529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2954,6 +2995,7 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.2.0",
@@ -3108,6 +3150,7 @@ version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4145,6 +4188,38 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "update-informer"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53813bf5d5f0d8430794f8cc48e99521cc9e298066958d16383ccb8b39d182a7"
+dependencies = [
+ "etcetera",
+ "reqwest 0.12.12",
+ "semver",
+ "serde",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.21",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.7",
+]
 
 [[package]]
 name = "url"

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -5,6 +5,7 @@ mod chat_request;
 mod chat_response;
 mod compaction_result;
 mod conversation_html;
+mod update;
 
 mod context;
 mod conversation;
@@ -74,4 +75,5 @@ pub use tool_definition::*;
 pub use tool_name::*;
 pub use tool_result::*;
 pub use tool_usage::*;
+pub use update::*;
 pub use workflow::*;

--- a/crates/forge_domain/src/update.rs
+++ b/crates/forge_domain/src/update.rs
@@ -1,0 +1,43 @@
+use merge::Merge;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UpdateFrequency {
+    #[serde(rename = "daily")]
+    Daily,
+    #[serde(rename = "weekly")]
+    Weekly,
+    #[serde(rename = "never")]
+    Never,
+}
+
+impl Default for UpdateFrequency {
+    fn default() -> Self {
+        Self::Daily
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Merge, Default, PartialEq)]
+pub struct Update {
+    pub check_frequency: Option<UpdateFrequency>,
+    pub auto_update: Option<bool>,
+}
+
+pub fn update_config(base: &mut Option<Update>, other: Option<Update>) {
+    if let Some(other) = other {
+        // If base is None, create a new update config
+        let mut update = base.clone().unwrap_or_default();
+
+        // Only update the values that are set in the other config
+        if other.auto_update.is_some() {
+            update.auto_update = other.auto_update;
+        }
+
+        if other.check_frequency.is_some() {
+            update.check_frequency = other.check_frequency;
+        }
+
+        // Apply merged config to the base config
+        *base = Some(update);
+    }
+} 

--- a/crates/forge_domain/src/workflow.rs
+++ b/crates/forge_domain/src/workflow.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::temperature::Temperature;
+use crate::update::Update;
 use crate::{Agent, AgentId, ModelId};
 
 /// Configuration for a workflow that contains all settings
@@ -67,6 +68,11 @@ pub struct Workflow {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub tool_supported: Option<bool>,
+    
+    /// Configurations that can be used to update forge
+    #[merge(strategy = crate::update::update_config)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updates: Option<Update>,
 }
 
 impl Default for Workflow {
@@ -102,6 +108,7 @@ impl Workflow {
             custom_rules: None,
             temperature: None,
             tool_supported: None,
+            updates: None,
         }
     }
 
@@ -137,6 +144,7 @@ mod tests {
         assert_eq!(actual.custom_rules, None);
         assert_eq!(actual.temperature, None);
         assert_eq!(actual.tool_supported, None);
+        assert_eq!(actual.updates, None);
     }
 
     #[test]

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -15,6 +15,7 @@ forge_snaps.workspace = true
 forge_spinner.workspace = true
 inquire.workspace = true
 serde_yml.workspace = true
+merge.workspace = true
 
 forge_fs.workspace = true
 tokio.workspace = true
@@ -36,6 +37,11 @@ strum.workspace = true
 strum_macros.workspace = true
 base64.workspace = true
 convert_case.workspace = true
+update-informer = { version = "1.2.0", default-features = false, features = [
+    "npm",
+    "ureq",
+    "rustls-tls",
+] }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_main/src/auto_update.rs
+++ b/crates/forge_main/src/auto_update.rs
@@ -55,17 +55,13 @@ pub async fn check_for_update(frequency: UpdateFrequency, auto_update: bool) {
     // Check if version is development version, in which case we skip the update check
     if VERSION.contains("dev") || VERSION == "0.1.0" {
         // Skip update for development version 0.1.0
-        println!("DEBUG: Skipping update check for development version");
         return;
     }
-
-    println!("DEBUG: Checking for updates with frequency: {:?}, auto_update: {}", frequency, auto_update);
     
     // If we're using a test version (like 0.79.0), force a check regardless of frequency
     let is_test_version = VERSION != "0.1.0" && !VERSION.starts_with("0.8");
     
     let informer = if is_test_version {
-        println!("DEBUG: Using test version, forcing update check");
         update_informer::new(registry::Npm, "@antinomyhq/forge", VERSION).interval(Duration::ZERO)
     } else {
         update_informer::new(registry::Npm, "@antinomyhq/forge", VERSION).interval(
@@ -77,18 +73,12 @@ pub async fn check_for_update(frequency: UpdateFrequency, auto_update: bool) {
         )
     };
 
-    println!("DEBUG: About to check version");
-    match informer.check_version() {
-        Ok(Some(version)) => {
-            println!("DEBUG: Update available: {}", version);
-            if auto_update {
-                update_forge().await;
-            } else {
-                confirm_update(version).await;
-            }
+    if let Some(version) = informer.check_version().ok().flatten() {
+        if auto_update {
+            update_forge().await;
+        } else {
+            confirm_update(version).await;
         }
-        Ok(None) => println!("DEBUG: No update available or already checked recently"),
-        Err(e) => println!("DEBUG: Error checking for updates: {:?}", e),
     }
 }
 

--- a/crates/forge_main/src/banner.rs
+++ b/crates/forge_main/src/banner.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use colored::Colorize;
+use forge_tracker::VERSION;
 
 const BANNER: &str = include_str!("banner");
 
@@ -9,8 +10,9 @@ pub fn display() -> io::Result<()> {
 
     // Define the labels as tuples of (key, value)
     let labels = [
+        ("Version", VERSION),
         ("New conversation:", "/new"),
-        ("Get started:", "/info, /help"),
+        ("Get started:", "/info, /help, /update"),
         ("Switch mode:", "/plan or /act"),
         ("Quit:", "/exit or <CTRL+D>"),
     ];

--- a/crates/forge_main/src/lib.rs
+++ b/crates/forge_main/src/lib.rs
@@ -11,7 +11,7 @@ mod state;
 mod tools_display;
 mod ui;
 
-pub use auto_update::update_forge;
+pub use auto_update::check_for_update;
 pub use cli::Cli;
 use lazy_static::lazy_static;
 pub use ui::UI;

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -181,6 +181,7 @@ impl ForgeCommandManager {
             "/help" => Ok(Command::Help),
             "/model" => Ok(Command::Model),
             "/tools" => Ok(Command::Tools),
+            "/update" => Ok(Command::Update),
             text => {
                 let parts = text.split_ascii_whitespace().collect::<Vec<&str>>();
 
@@ -230,6 +231,9 @@ pub enum Command {
     /// Exit the application without any further action.
     #[strum(props(usage = "Exit the application"))]
     Exit,
+    /// Updates the forge version
+    #[strum(props(usage = "Updates to the latest compatible version of forge"))]
+    Update,
     /// Switch to "act" mode.
     /// This can be triggered with the '/act' command.
     #[strum(props(usage = "Enable implementation mode with code changes"))]
@@ -267,6 +271,7 @@ impl Command {
             Command::Compact => "/compact",
             Command::New => "/new",
             Command::Message(_) => "/message",
+            Command::Update => "/update",
             Command::Info => "/info",
             Command::Exit => "/exit",
             Command::Act => "/act",

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -165,7 +165,6 @@ impl<F: API> UI<F> {
     }
 
     async fn get_update_configuration(&self) -> Result<Update> {
-        println!("DEBUG: Getting update configuration");
         let mut workflow = Workflow::default();
         let user_workflow = self.api.read_workflow(self.cli.workflow.as_deref()).await?;
         workflow.merge(user_workflow);
@@ -179,19 +178,13 @@ impl<F: API> UI<F> {
             update.auto_update = Some(false);
         }
 
-        println!("DEBUG: Update config: frequency={:?}, auto_update={:?}", 
-                 update.check_frequency, update.auto_update);
         Ok(update)
     }
 
     async fn run_inner(&mut self) -> Result<()> {
-        println!("DEBUG: Starting run_inner");
         if let Ok(config) = self.get_update_configuration().await {
             // Recurring update check.
-            println!("DEBUG: About to call check_for_update with config");
             check_for_update(config.check_frequency.unwrap(), config.auto_update.unwrap()).await;
-        } else {
-            println!("DEBUG: Failed to get update configuration");
         }
 
         // Check for dispatch flag first
@@ -272,7 +265,6 @@ impl<F: API> UI<F> {
                 }
                 Command::Update => {
                     // One time update check
-                    println!("DEBUG: Update command received");
                     check_for_update(UpdateFrequency::Never, false).await;
                 }
                 Command::Exit => {

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -1,6 +1,10 @@
 variables:
   mode: ACT
 
+updates:
+  check_frequency: "daily"
+  auto_update: false
+
 # Define model anchors with simpler, purpose-based names
 models:
   # Role-based model definitions - easy to swap implementation


### PR DESCRIPTION
# Once-Daily Update Prompts
### Closes #711
- Replace automatic updates on exit with configurable startup checks
- Prompt users with version info when updates are available
- Add `/update` command for manual update checks
- Add configuration options in `forge.default.yaml`
- Display current version in the banner

## Configuration

```yaml
updates:
  check_frequency: "daily"  # Options: daily, weekly, never
  auto_update: false        # If true, updates without prompting
```

## Implementation Details

- Uses `update-informer` crate for efficient update checking
- Respects user choice by not prompting again until next check period
- Updates immediately when confirmed
- Handles development versions and edge cases gracefully
### Demo - 
```
APP_VERSION=0.78.0 FORGE_KEY=forge_key  cargo run
```
<img width="1205" alt="Screenshot 2025-05-04 at 12 34 16 AM" src="https://github.com/user-attachments/assets/cf4c384f-ecfa-4149-87d9-4d61ec0d0cd5" />


/claim #711