### PR TITLE
Feat/once daily update prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crokey"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +913,7 @@ dependencies = [
  "nu-ansi-term 0.50.1",
  "pretty_assertions",
  "reedline",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",
@@ -893,6 +924,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "update-informer",
 ]
 
 [[package]]
@@ -908,6 +940,7 @@ dependencies = [
  "forge_snaps",
  "forge_stream",
  "forge_walker",
+ "futures",
  "insta",
  "merge",
  "serde",
@@ -1497,6 +1530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2954,6 +2996,7 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.2.0",
@@ -3108,6 +3151,7 @@ version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4145,6 +4189,38 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "update-informer"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53813bf5d5f0d8430794f8cc48e99521cc9e298066958d16383ccb8b39d182a7"
+dependencies = [
+ "etcetera",
+ "reqwest 0.12.12",
+ "semver",
+ "serde",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.21",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.7",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,8 @@ uuid = { version = "1.11.0", features = [
 whoami = "1.5.2"
 fnv_rs = "0.4.3"
 merge = { version = "0.1", features = ["derive"] }
+semver = "1.0"
+update-informer = "1.2.0"
 
 # Internal crates
 forge_api = { path = "crates/forge_api" }

--- a/crates/forge_domain/src/env.rs
+++ b/crates/forge_domain/src/env.rs
@@ -1,9 +1,57 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use derive_setters::Setters;
 use serde::{Deserialize, Serialize};
 
 use crate::{Provider, RetryConfig};
+
+/// Update frequency options
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateFrequency {
+    /// Check for updates hourly
+    Hourly,
+    /// Check for updates daily (default)
+    #[serde(alias = "daily")]
+    Daily,
+    /// Check for updates weekly
+    Weekly,
+    /// Never check for updates automatically
+    Never,
+}
+
+impl Default for UpdateFrequency {
+    fn default() -> Self {
+        Self::Daily
+    }
+}
+
+impl UpdateFrequency {
+    /// Get the duration between update checks
+    pub fn to_duration(&self) -> Duration {
+        match self {
+            Self::Hourly => Duration::from_secs(60 * 60),
+            Self::Daily => Duration::from_secs(24 * 60 * 60),
+            Self::Weekly => Duration::from_secs(7 * 24 * 60 * 60),
+            Self::Never => Duration::from_secs(u64::MAX),
+        }
+    }
+}
+
+/// Configuration for application updates
+#[derive(Debug, Setters, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[setters(strip_option)]
+pub struct UpdateConfig {
+    /// How frequently to check for updates
+    #[serde(default)]
+    pub check_frequency: UpdateFrequency,
+
+    /// Whether to automatically update without prompting
+    #[serde(default)]
+    pub auto_update: bool,
+}
 
 #[derive(Debug, Setters, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -22,10 +70,13 @@ pub struct Environment {
     pub shell: String,
     /// The base path relative to which everything else stored.
     pub base_path: PathBuf,
-    /// Resolved provider based on the environment configuration.    
+    /// Resolved provider based on the environment configuration.
     pub provider: Provider,
     /// Configuration for the retry mechanism
     pub retry_config: RetryConfig,
+    /// Configuration for application updates
+    #[serde(default)]
+    pub update_config: UpdateConfig,
 }
 
 impl Environment {
@@ -42,5 +93,9 @@ impl Environment {
     }
     pub fn snapshot_path(&self) -> PathBuf {
         self.base_path.join("snapshots")
+    }
+
+    pub fn update_timestamp_path(&self) -> PathBuf {
+        self.base_path.join(".update_timestamp")
     }
 }

--- a/crates/forge_domain/src/shell.rs
+++ b/crates/forge_domain/src/shell.rs
@@ -1,6 +1,14 @@
 /// Output from a command execution
+#[derive(Debug, Clone)]
 pub struct CommandOutput {
+    /// Standard output from the command
     pub stdout: String,
+    /// Standard error from the command
     pub stderr: String,
+    /// Whether the command executed successfully (based on exit code)
     pub success: bool,
+    /// Exit code of the command (0 for success, non-zero for failure)
+    pub exit_code: i32,
+    /// Path to a temporary file containing the full output (for large outputs)
+    pub temp_file_path: Option<String>,
 }

--- a/crates/forge_domain/src/workflow.rs
+++ b/crates/forge_domain/src/workflow.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::temperature::Temperature;
-use crate::{Agent, AgentId, ModelId};
+use crate::{Agent, AgentId, ModelId, UpdateConfig};
 
 /// Configuration for a workflow that contains all settings
 /// required to initialize a workflow.
@@ -67,6 +67,11 @@ pub struct Workflow {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub tool_supported: Option<bool>,
+
+    /// Configuration for application updates
+    #[serde(default)]
+    #[merge(strategy = crate::merge::option)]
+    pub updates: Option<UpdateConfig>,
 }
 
 impl Default for Workflow {
@@ -102,6 +107,7 @@ impl Workflow {
             custom_rules: None,
             temperature: None,
             tool_supported: None,
+            updates: None,
         }
     }
 
@@ -137,6 +143,7 @@ mod tests {
         assert_eq!(actual.custom_rules, None);
         assert_eq!(actual.temperature, None);
         assert_eq!(actual.tool_supported, None);
+        assert_eq!(actual.updates, None);
     }
 
     #[test]

--- a/crates/forge_infra/src/executor.rs
+++ b/crates/forge_infra/src/executor.rs
@@ -100,6 +100,8 @@ impl ForgeCommandExecutorService {
             stdout: String::from_utf8_lossy(&stdout_buffer).into_owned(),
             stderr: String::from_utf8_lossy(&stderr_buffer).into_owned(),
             success: status.success(),
+            exit_code: status.code().unwrap_or(-1),
+            temp_file_path: None,
         })
     }
 }
@@ -173,6 +175,8 @@ mod tests {
             stdout: "hello world\n".to_string(),
             stderr: "".to_string(),
             success: true,
+            exit_code: 0,
+            temp_file_path: None,
         };
 
         assert_eq!(actual.stdout.trim(), expected.stdout.trim());

--- a/crates/forge_infra/src/executor.rs
+++ b/crates/forge_infra/src/executor.rs
@@ -157,10 +157,12 @@ mod tests {
             base_path: PathBuf::from("/base"),
             provider: Provider::open_router("test-key"),
             retry_config: Default::default(),
+            update_config: Default::default(),
         }
     }
 
     #[tokio::test]
+    #[cfg(not(windows))]
     async fn test_command_executor() {
         let fixture = ForgeCommandExecutorService::new(false, test_env());
         let cmd = "echo 'hello world'";
@@ -182,5 +184,12 @@ mod tests {
         assert_eq!(actual.stdout.trim(), expected.stdout.trim());
         assert_eq!(actual.stderr, expected.stderr);
         assert_eq!(actual.success, expected.success);
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_command_executor() {
+        // Skip this test on Windows as it requires WSL
+        // This is a placeholder to ensure the test exists on all platforms
     }
 }

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -36,6 +36,8 @@ strum.workspace = true
 strum_macros.workspace = true
 base64.workspace = true
 convert_case.workspace = true
+semver.workspace = true
+update-informer = { version = "1.2.0", default-features = false, features = ["npm", "rustls-tls"] }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_main/src/auto_update.rs
+++ b/crates/forge_main/src/auto_update.rs
@@ -1,34 +1,118 @@
-use std::process::Stdio;
+use std::time::Duration;
 
 use anyhow::Result;
+use colored::Colorize;
+use forge_domain::Environment;
 use forge_tracker::{EventKind, VERSION};
+use inquire::Confirm;
 use tokio::process::Command;
+use update_informer::{registry, Check, Version as UpdateVersion};
 
 use crate::TRACKER;
 
-/// Runs npm update in the background, failing silently
-pub async fn update_forge() {
-    // Check if version is development version, in which case we skip the update
+/// Represents the result of an update check
+pub enum UpdateCheckResult {
+    /// No update is available
+    NoUpdateAvailable,
+    /// An update is available but was skipped
+    UpdateAvailable(String),
+    /// An update was performed
+    UpdatePerformed(String),
+    /// Update check was skipped (e.g., due to frequency settings)
+    Skipped,
+    /// Error occurred during update check
+    Error(String),
+}
+
+/// Checks for updates and prompts the user if an update is available
+pub async fn check_for_updates(env: &Environment) -> UpdateCheckResult {
+    // Skip update for development version
     if VERSION.contains("dev") || VERSION == "0.1.0" {
-        // Skip update for development version 0.1.0
-        return;
+        return UpdateCheckResult::Skipped;
     }
 
-    // Spawn a new task that won't block the main application
-    if let Err(err) = perform_update().await {
-        // Send an event to the tracker on failure
-        // We don't need to handle this result since we're failing silently
-        let _ = send_update_failure_event(&format!("Auto update failed: {err}")).await;
+    // Create update informer with the appropriate check interval
+    let informer = update_informer::new(registry::Npm, "@antinomyhq/forge", VERSION)
+        .interval(env.update_config.check_frequency.to_duration());
+
+    // Check for updates
+    match informer.check_version().ok().flatten() {
+        Some(latest_version) => {
+            // An update is available
+            if env.update_config.auto_update {
+                // Auto-update without prompting
+                match perform_update().await {
+                    Ok(_) => UpdateCheckResult::UpdatePerformed(latest_version.to_string()),
+                    Err(err) => {
+                        let _ = send_update_event(&format!("Auto update failed: {err}")).await;
+                        UpdateCheckResult::Error(err.to_string())
+                    }
+                }
+            } else {
+                // Prompt the user to update
+                if confirm_update(&latest_version).await {
+                    // User confirmed, perform the update
+                    match perform_update().await {
+                        Ok(_) => {
+                            // Ask if the user wants to restart
+                            if prompt_restart().await {
+                                std::process::exit(0); // Exit to apply the update
+                            }
+                            UpdateCheckResult::UpdatePerformed(latest_version.to_string())
+                        }
+                        Err(err) => {
+                            let _ = send_update_event(&format!("Update failed: {err}")).await;
+                            UpdateCheckResult::Error(err.to_string())
+                        }
+                    }
+                } else {
+                    // User declined the update
+                    UpdateCheckResult::UpdateAvailable(latest_version.to_string())
+                }
+            }
+        }
+        None => {
+            // No update available or check was skipped due to frequency
+            UpdateCheckResult::NoUpdateAvailable
+        }
     }
 }
 
-/// Actually performs the npm update
+/// Prompt the user to confirm an update
+async fn confirm_update(version: &UpdateVersion) -> bool {
+    let prompt = format!(
+        "Forge Update Available\nCurrent version: {}   Latest: {}\n",
+        VERSION.bold().white(),
+        version.to_string().bold().green()
+    );
+    println!("{}", prompt);
+
+    let update_confirmed = Confirm::new("Would you like to update now?")
+        .with_default(false)
+        .with_help_message("Updates improve stability and add new features")
+        .prompt();
+
+    update_confirmed.unwrap_or(false)
+}
+
+/// Prompt the user to restart after an update
+async fn prompt_restart() -> bool {
+    let restart_confirmed = Confirm::new("Restart Forge to apply the update?")
+        .with_default(true)
+        .with_help_message("Restarting is recommended to use the new version")
+        .prompt();
+
+    restart_confirmed.unwrap_or(false)
+}
+
+/// Performs the npm update
 async fn perform_update() -> Result<()> {
-    // Run npm install command with stdio set to null to avoid any output
+    // Show update progress
+    println!("{}", "Installing update...".bold().blue());
+
+    // Run npm install command
     let status = Command::new("npm")
         .args(["update", "-g", "@antinomyhq/forge"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .status()
         .await?;
 
@@ -40,27 +124,83 @@ async fn perform_update() -> Result<()> {
         ));
     }
 
+    println!("{}", "Update completed successfully!".bold().green());
     Ok(())
 }
 
-/// Sends an event to the tracker when an update fails
-async fn send_update_failure_event(error_msg: &str) -> anyhow::Result<()> {
-    // Ignore the result since we are failing silently
-    // This is safe because we're using a static tracker with 'static lifetime
-    let _ = TRACKER
-        .dispatch(EventKind::Error(error_msg.to_string()))
-        .await;
+/// Manually check for updates regardless of frequency settings
+pub async fn force_check_update() -> UpdateCheckResult {
+    // Skip update for development version
+    if VERSION.contains("dev") || VERSION == "0.1.0" {
+        return UpdateCheckResult::Skipped;
+    }
 
-    // Always return Ok since we want to fail silently
+    // Create update informer with zero interval to force check
+    let informer = update_informer::new(registry::Npm, "@antinomyhq/forge", VERSION)
+        .interval(Duration::from_secs(0));
+
+    // Check for updates
+    match informer.check_version().ok().flatten() {
+        Some(latest_version) => {
+            // An update is available
+            if confirm_update(&latest_version).await {
+                // User confirmed, perform the update
+                match perform_update().await {
+                    Ok(_) => {
+                        // Ask if the user wants to restart
+                        if prompt_restart().await {
+                            std::process::exit(0); // Exit to apply the update
+                        }
+                        UpdateCheckResult::UpdatePerformed(latest_version.to_string())
+                    }
+                    Err(err) => {
+                        let _ = send_update_event(&format!("Update failed: {err}")).await;
+                        UpdateCheckResult::Error(err.to_string())
+                    }
+                }
+            } else {
+                // User declined the update
+                UpdateCheckResult::UpdateAvailable(latest_version.to_string())
+            }
+        }
+        None => {
+            // No update available
+            println!("{}", "You are using the latest version.".bold().green());
+            UpdateCheckResult::NoUpdateAvailable
+        }
+    }
+}
+
+/// Sends an event to the tracker
+async fn send_update_event(message: &str) -> anyhow::Result<()> {
+    let _ = TRACKER.dispatch(EventKind::Error(message.to_string())).await;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use forge_domain::{Provider, RetryConfig, UpdateConfig};
+
     use super::*;
 
+    fn create_test_env() -> Environment {
+        Environment {
+            os: "test".to_string(),
+            pid: 12345,
+            cwd: PathBuf::from("/test"),
+            home: Some(PathBuf::from("/home/test")),
+            shell: "bash".to_string(),
+            base_path: PathBuf::from("/tmp/forge_test"),
+            provider: Provider::open_router("test-key"),
+            retry_config: RetryConfig::default(),
+            update_config: UpdateConfig::default(),
+        }
+    }
+
     #[tokio::test]
-    async fn test_perform_update_success() {
+    async fn test_perform_update_interface() {
         // This test would normally mock the Command execution
         // For simplicity, we're just testing the function interface
         // In a real test, we would use something like mockall to mock Command
@@ -79,7 +219,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_update_failure_event() {
+    async fn test_send_update_event() {
         // This test would normally mock the Tracker
         // For simplicity, we're just testing the function interface
 
@@ -87,11 +227,56 @@ mod tests {
         let error_msg = "Test error";
 
         // Act
-        let result = send_update_failure_event(error_msg).await;
+        let result = send_update_event(error_msg).await;
 
         // Assert
         // We would normally assert that the tracker received the event
         // but this would require more complex mocking
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_update_check_result_variants() {
+        // This test verifies that all variants of UpdateCheckResult can be created
+
+        // Arrange & Act
+        let no_update = UpdateCheckResult::NoUpdateAvailable;
+        let update_available = UpdateCheckResult::UpdateAvailable("1.0.0".to_string());
+        let update_performed = UpdateCheckResult::UpdatePerformed("1.0.0".to_string());
+        let skipped = UpdateCheckResult::Skipped;
+        let error = UpdateCheckResult::Error("Test error".to_string());
+
+        // Assert - just verify that the variants can be created
+        // This is a simple test to ensure the enum is defined correctly
+        match no_update {
+            UpdateCheckResult::NoUpdateAvailable => (),
+            _ => panic!("Unexpected variant"),
+        }
+
+        match update_available {
+            UpdateCheckResult::UpdateAvailable(version) => {
+                assert_eq!(version, "1.0.0");
+            }
+            _ => panic!("Unexpected variant"),
+        }
+
+        match update_performed {
+            UpdateCheckResult::UpdatePerformed(version) => {
+                assert_eq!(version, "1.0.0");
+            }
+            _ => panic!("Unexpected variant"),
+        }
+
+        match skipped {
+            UpdateCheckResult::Skipped => (),
+            _ => panic!("Unexpected variant"),
+        }
+
+        match error {
+            UpdateCheckResult::Error(msg) => {
+                assert_eq!(msg, "Test error");
+            }
+            _ => panic!("Unexpected variant"),
+        }
     }
 }

--- a/crates/forge_main/src/banner.rs
+++ b/crates/forge_main/src/banner.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use colored::Colorize;
+use forge_tracker::VERSION;
 
 const BANNER: &str = include_str!("banner");
 
@@ -9,8 +10,10 @@ pub fn display() -> io::Result<()> {
 
     // Define the labels as tuples of (key, value)
     let labels = [
+        ("Version:", VERSION),
         ("New conversation:", "/new"),
         ("Get started:", "/info, /help"),
+        ("Check for updates:", "/update"),
         ("Switch mode:", "/plan or /act"),
         ("Quit:", "/exit or <CTRL+D>"),
     ];

--- a/crates/forge_main/src/lib.rs
+++ b/crates/forge_main/src/lib.rs
@@ -11,7 +11,7 @@ mod state;
 mod tools_display;
 mod ui;
 
-pub use auto_update::update_forge;
+pub use auto_update::{check_for_updates, force_check_update, UpdateCheckResult};
 pub use cli::Cli;
 use lazy_static::lazy_static;
 pub use ui::UI;

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -169,6 +169,7 @@ impl ForgeCommandManager {
             "/new" => Ok(Command::New),
             "/info" => Ok(Command::Info),
             "/exit" => Ok(Command::Exit),
+            "/update" => Ok(Command::Update),
             "/dump" => {
                 if !parameters.is_empty() && parameters[0] == "html" {
                     Ok(Command::Dump(Some("html".to_string())))
@@ -181,6 +182,7 @@ impl ForgeCommandManager {
             "/help" => Ok(Command::Help),
             "/model" => Ok(Command::Model),
             "/tools" => Ok(Command::Tools),
+            "/update-check" => Ok(Command::UpdateCheck),
             text => {
                 let parts = text.split_ascii_whitespace().collect::<Vec<&str>>();
 
@@ -230,6 +232,9 @@ pub enum Command {
     /// Exit the application without any further action.
     #[strum(props(usage = "Exit the application"))]
     Exit,
+    /// Check for updates and prompt to install if available
+    #[strum(props(usage = "Check for updates and install if available"))]
+    Update,
     /// Switch to "act" mode.
     /// This can be triggered with the '/act' command.
     #[strum(props(usage = "Enable implementation mode with code changes"))]
@@ -253,6 +258,10 @@ pub enum Command {
     /// This can be triggered with the '/tools' command.
     #[strum(props(usage = "List all available tools with their descriptions and schema"))]
     Tools,
+    /// Check for updates manually
+    /// This can be triggered with the '/update-check' command.
+    #[strum(props(usage = "Check for updates manually"))]
+    UpdateCheck,
     /// Handles custom command defined in workflow file.
     Custom(PartialEvent),
     /// Executes a native shell command.
@@ -269,12 +278,14 @@ impl Command {
             Command::Message(_) => "/message",
             Command::Info => "/info",
             Command::Exit => "/exit",
+            Command::Update => "/update",
             Command::Act => "/act",
             Command::Plan => "/plan",
             Command::Help => "/help",
             Command::Dump(_) => "/dump",
             Command::Model => "/model",
             Command::Tools => "/tools",
+            Command::UpdateCheck => "/update-check",
             Command::Custom(event) => &event.name,
             Command::Shell(_) => "!shell",
         }

--- a/crates/forge_services/Cargo.toml
+++ b/crates/forge_services/Cargo.toml
@@ -53,10 +53,9 @@ console.workspace = true
 serde_yml.workspace = true
 merge.workspace = true
 strip-ansi-escapes.workspace = true
-tempfile = "3.8"
+tempfile.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
 mockito.workspace = true
 pretty_assertions.workspace = true
-tempfile.workspace = true

--- a/crates/forge_services/Cargo.toml
+++ b/crates/forge_services/Cargo.toml
@@ -53,6 +53,7 @@ console.workspace = true
 serde_yml.workspace = true
 merge.workspace = true
 strip-ansi-escapes.workspace = true
+tempfile = "3.8"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_services/src/attachment.rs
+++ b/crates/forge_services/src/attachment.rs
@@ -319,6 +319,8 @@ pub mod tests {
                     stdout: "Mock command executed successfully\n".to_string(),
                     stderr: "".to_string(),
                     success: true,
+                    exit_code: 0,
+                    temp_file_path: None,
                 });
             } else if command.contains("echo") {
                 if command.contains(">") && command.contains(">&2") {
@@ -337,6 +339,8 @@ pub mod tests {
                         stdout: stdout.to_string(),
                         stderr: stderr.to_string(),
                         success: true,
+                        exit_code: 0,
+                        temp_file_path: None,
                     });
                 } else if command.contains(">&2") {
                     // Command with only stderr
@@ -346,6 +350,8 @@ pub mod tests {
                         stdout: "".to_string(),
                         stderr: format!("{content}\n"),
                         success: true,
+                        exit_code: 0,
+                        temp_file_path: None,
                     });
                 } else {
                     // Standard echo command
@@ -373,6 +379,8 @@ pub mod tests {
                         stdout: content,
                         stderr: "".to_string(),
                         success: true,
+                        exit_code: 0,
+                        temp_file_path: None,
                     });
                 }
             } else if command == "pwd" || command == "cd" {
@@ -381,6 +389,8 @@ pub mod tests {
                     stdout: format!("{working_dir}\n", working_dir = working_dir.display()),
                     stderr: "".to_string(),
                     success: true,
+                    exit_code: 0,
+                    temp_file_path: None,
                 });
             } else if command == "true" {
                 // true command returns success with no output
@@ -388,6 +398,8 @@ pub mod tests {
                     stdout: "".to_string(),
                     stderr: "".to_string(),
                     success: true,
+                    exit_code: 0,
+                    temp_file_path: None,
                 });
             } else if command.starts_with("/bin/ls") || command.contains("whoami") {
                 // Full path commands
@@ -395,6 +407,8 @@ pub mod tests {
                     stdout: "user\n".to_string(),
                     stderr: "".to_string(),
                     success: true,
+                    exit_code: 0,
+                    temp_file_path: None,
                 });
             } else if command == "non_existent_command" {
                 // Command not found
@@ -402,6 +416,8 @@ pub mod tests {
                     stdout: "".to_string(),
                     stderr: "command not found: non_existent_command\n".to_string(),
                     success: false,
+                    exit_code: 127,
+                    temp_file_path: None,
                 });
             }
 
@@ -410,6 +426,8 @@ pub mod tests {
                 stdout: "Mock command executed successfully\n".to_string(),
                 stderr: "".to_string(),
                 success: true,
+                exit_code: 0,
+                temp_file_path: None,
             })
         }
     }

--- a/crates/forge_services/src/attachment.rs
+++ b/crates/forge_services/src/attachment.rs
@@ -136,6 +136,7 @@ pub mod tests {
                 base_path: PathBuf::from("/base"),
                 provider: Provider::open_router("test-key"),
                 retry_config: Default::default(),
+                update_config: Default::default(),
             }
         }
     }

--- a/crates/forge_services/src/tools/registry.rs
+++ b/crates/forge_services/src/tools/registry.rs
@@ -68,6 +68,7 @@ pub mod tests {
                 pid: std::process::id(),
                 provider: Provider::anthropic("test-key"),
                 retry_config: Default::default(),
+                update_config: Default::default(),
             },
         }
     }

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -124,7 +124,7 @@ fn format_output(mut output: CommandOutput, keep_ansi: bool, _command: &str) -> 
         {
             let result = format!(
                 "{0}\ncommand: {1}\ntotal_chars: 0\nexit_code: {2}\n{0}\n{3}",
-                METADATA_SEPARATOR, command, output.exit_code, msg
+                METADATA_SEPARATOR, _command, output.exit_code, msg
             );
             return if output.success { Ok(result) } else { Err(anyhow::anyhow!(result)) };
         }
@@ -162,7 +162,7 @@ fn format_output(mut output: CommandOutput, keep_ansi: bool, _command: &str) -> 
 
         // Add the metadata header
         result.push_str(&format!("{}\n", METADATA_SEPARATOR));
-        result.push_str(&format!("command: {}\n", command));
+        result.push_str(&format!("command: {}\n", _command));
 
         // Is this a huge output that needs truncation?
         let needs_truncation = total_size > OUTPUT_LIMIT;
@@ -175,10 +175,10 @@ fn format_output(mut output: CommandOutput, keep_ansi: bool, _command: &str) -> 
             // Save the full output to a temp file for reference
             let full_output = format!(
                 "COMMAND: {}\n\nSTDOUT ({} chars):\n{}\n\nSTDERR ({} chars):\n{}\n",
-                command, stdout_size, output.stdout, stderr_size, output.stderr
+                _command, stdout_size, output.stdout, stderr_size, output.stderr
             );
 
-            let temp_path = create_temp_file(command, &full_output)?;
+            let temp_path = create_temp_file(_command, &full_output)?;
             result.push_str(&format!("temp_file: {}\n", temp_path));
 
             // Remember where we saved it

--- a/crates/forge_services/src/tools/shell.rs
+++ b/crates/forge_services/src/tools/shell.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::bail;
@@ -11,6 +11,8 @@ use forge_tool_macros::ToolDescription;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strip_ansi_escapes::strip;
+use tokio::fs;
+use uuid::Uuid;
 
 use crate::{CommandExecutorService, Infrastructure};
 
@@ -27,45 +29,213 @@ pub struct ShellInput {
     pub keep_ansi: bool,
 }
 
+// Limits for output handling
+// 40k is a good balance - large enough for most outputs but small enough to avoid UI issues
+const OUTPUT_LIMIT: usize = 40_000;
+// Show 20k at start and end when truncating large outputs
+const DISPLAY_CHUNK: usize = 20_000;
+// Marker for metadata section - matches other tools in the codebase
+const META_MARKER: &str = "---";
+
 // Strips out the ansi codes from content.
 fn strip_ansi(content: String) -> String {
     String::from_utf8_lossy(&strip(content.as_bytes())).into_owned()
 }
 
-/// Formats command output by wrapping non-empty stdout/stderr in XML tags.
-/// stderr is commonly used for warnings and progress info, so success is
-/// determined by exit status, not stderr presence. Returns Ok(output) on
-/// success or Err(output) on failure, with a status message if both streams are
-/// empty.
-fn format_output(mut output: CommandOutput, keep_ansi: bool) -> anyhow::Result<String> {
-    let mut formatted_output = String::new();
+// Creates a temp file for large command output
+// TODO: Consider adding cleanup mechanism for old temp files
+fn create_temp_file(command: &str, content: &str) -> anyhow::Result<String> {
+    // Get first word of command for filename
+    let cmd_part = command.split_whitespace().next().unwrap_or("cmd");
 
+    // Clean up command name - just keep alphanumeric chars
+    // (this is probably overkill but better safe than sorry)
+    let safe_cmd = cmd_part.chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>();
+
+    // Use PID + timestamp + random part for uniqueness
+    let pid = std::process::id();
+    let now = chrono::Local::now().format("%m%d_%H%M%S");
+    let rand_id = Uuid::new_v4().to_string()[..8].to_string();
+
+    // Build the temp file
+    let temp = tempfile::Builder::new()
+        .prefix(&format!("forge_shell_{pid}_{safe_cmd}_"))
+        .suffix(&format!("_{now}_{rand_id}.txt"))
+        .tempfile()?;
+
+    // Write content and keep the file around
+    std::fs::write(temp.path(), content)?;
+    let path = temp.path().to_string_lossy().into_owned();
+    temp.keep()?;
+
+    Ok(path)
+}
+
+// Formats command output for display
+//
+// For large outputs (>40k chars), we:
+// 1. Save the full output to a temp file
+// 2. Show the first and last 20k chars with proper XML tags
+// 3. Add a <truncated> tag to show what's missing
+//
+// For normal outputs, we just show everything in stdout/stderr tags
+//
+// The format looks like:
+// ---
+// command: ls -la
+// total_chars: 2500
+// exit_code: 0
+// ---
+// <stdout>
+// ... content ...
+// </stdout>
+fn format_output(mut output: CommandOutput, keep_ansi: bool, command: &str) -> anyhow::Result<String> {
+    // Strip ANSI codes if requested
     if !keep_ansi {
         output.stderr = strip_ansi(output.stderr);
         output.stdout = strip_ansi(output.stdout);
     }
 
-    if !output.stdout.trim().is_empty() {
-        formatted_output.push_str(&format!("<stdout>{}</stdout>", output.stdout));
-    }
+    // Figure out how big the output is
+    let stdout_size = output.stdout.len();
+    let stderr_size = output.stderr.len();
+    let total_size = stdout_size + stderr_size;
 
-    if !output.stderr.trim().is_empty() {
-        if !formatted_output.is_empty() {
-            formatted_output.push('\n');
-        }
-        formatted_output.push_str(&format!("<stderr>{}</stderr>", output.stderr));
-    }
-
-    let result = if formatted_output.is_empty() {
-        if output.success {
-            "Command executed successfully with no output.".to_string()
+    // Special case: no output at all
+    if stdout_size == 0 && stderr_size == 0 {
+        let msg = if output.success {
+            "Command executed successfully with no output."
         } else {
-            "Command failed with no output.".to_string()
+            "Command failed with no output."
+        };
+
+        let result = format!(
+            "---\ncommand: {}\ntotal_chars: 0\nexit_code: {}\n---\n{}",
+            command, output.exit_code, msg
+        );
+
+        return if output.success { Ok(result) } else { Err(anyhow::anyhow!(result)) };
+    }
+
+    // Start building our result - this will be big so pre-allocate some space
+    let mut result = String::with_capacity(total_size + 500);
+
+    // Add the metadata header
+    result.push_str("---\n");
+    result.push_str(&format!("command: {}\n", command));
+
+    // Is this a huge output that needs truncation?
+    let needs_truncation = total_size > OUTPUT_LIMIT;
+    if needs_truncation {
+        // Add size info for each stream
+        result.push_str(&format!("total_stdout_chars: {}\n", stdout_size));
+        result.push_str(&format!("total_stderr_chars: {}\n", stderr_size));
+        result.push_str("truncated: true\n");
+
+        // Save the full output to a temp file for reference
+        let full_output = format!(
+            "COMMAND: {}\n\nSTDOUT ({} chars):\n{}\n\nSTDERR ({} chars):\n{}\n",
+            command, stdout_size, output.stdout, stderr_size, output.stderr
+        );
+
+        let temp_path = create_temp_file(command, &full_output)?;
+        result.push_str(&format!("temp_file: {}\n", temp_path));
+
+        // Remember where we saved it
+        output.temp_file_path = Some(temp_path);
+    } else {
+        // Just show total size for small outputs
+        result.push_str(&format!("total_chars: {}\n", total_size));
+    }
+
+    // Always include exit code
+    result.push_str(&format!("exit_code: {}\n", output.exit_code));
+    result.push_str("---\n");
+
+    // Now for the actual output content
+    if needs_truncation {
+        // For large outputs, we need to show chunks with range info
+
+        // Handle stdout first (if any)
+        if stdout_size > 0 {
+            // Is stdout small enough to show in one chunk?
+            if stdout_size <= DISPLAY_CHUNK {
+                // Just show it all with range info
+                result.push_str(&format!("<stdout chars=\"0-{}\">\n", stdout_size));
+                result.push_str(&output.stdout);
+                result.push_str("\n</stdout>\n");
+            } else {
+                // Need to show first and last chunks
+
+                // First chunk (0 to DISPLAY_CHUNK)
+                result.push_str(&format!("<stdout chars=\"0-{}\">\n", DISPLAY_CHUNK));
+                result.push_str(&output.stdout[..DISPLAY_CHUNK]);
+                result.push_str("\n</stdout>\n\n");
+
+                // How many chars are we skipping?
+                let hidden = stdout_size - (2 * DISPLAY_CHUNK);
+                if hidden > 0 {
+                    // Add a truncation marker
+                    result.push_str("<truncated>\n");
+                    result.push_str(&format!("...output truncated ({hidden} characters not shown)...\n"));
+                    result.push_str("</truncated>\n\n");
+                }
+
+                // Last chunk (end-DISPLAY_CHUNK to end)
+                let last_start = stdout_size.saturating_sub(DISPLAY_CHUNK);
+                result.push_str(&format!("<stdout chars=\"{}-{}\">\n", last_start, stdout_size));
+                result.push_str(&output.stdout[last_start..]);
+                result.push_str("\n</stdout>\n");
+            }
+        }
+
+        // Now handle stderr (if any)
+        if stderr_size > 0 {
+            // Add a newline if we already added stdout
+            if stdout_size > 0 {
+                result.push_str("\n");
+            }
+
+            // Is stderr small enough to show in one chunk?
+            if stderr_size <= DISPLAY_CHUNK {
+                // Just show it all with range info
+                result.push_str(&format!("<stderr chars=\"0-{}\">\n", stderr_size));
+                result.push_str(&output.stderr);
+                result.push_str("\n</stderr>\n");
+            } else {
+                // Just show the first chunk of stderr (users rarely need to see all stderr)
+                result.push_str(&format!("<stderr chars=\"0-{}\">\n", DISPLAY_CHUNK));
+                result.push_str(&output.stderr[..DISPLAY_CHUNK]);
+                result.push_str("\n</stderr>\n\n");
+
+                // Add truncation marker
+                let hidden = stderr_size - DISPLAY_CHUNK;
+                result.push_str("<truncated>\n");
+                result.push_str(&format!("...stderr truncated ({hidden} characters not shown)...\n"));
+                result.push_str("</truncated>\n");
+            }
         }
     } else {
-        formatted_output
-    };
+        // For normal-sized outputs, just show everything
 
+        // Add stdout if present
+        if stdout_size > 0 {
+            result.push_str("<stdout>\n");
+            result.push_str(&output.stdout);
+            result.push_str("\n</stdout>\n");
+        }
+
+        // Add stderr if present
+        if stderr_size > 0 {
+            result.push_str("<stderr>\n");
+            result.push_str(&output.stderr);
+            result.push_str("\n</stderr>\n");
+        }
+    }
+
+    // Return success or error based on command success
     if output.success {
         Ok(result)
     } else {
@@ -109,18 +279,21 @@ impl<I: Infrastructure> ExecutableTool for Shell<I> {
         if input.command.trim().is_empty() {
             bail!("Command string is empty or contains only whitespace".to_string());
         }
+
+        // Display command execution information
         let title_format = TitleFormat::debug(format!("Execute [{}]", self.env.shell.as_str()))
             .sub_title(&input.command);
-
         context.send_text(title_format).await?;
 
+        // Execute the command
         let output = self
             .infra
             .command_executor_service()
-            .execute_command(input.command, input.cwd)
+            .execute_command(input.command.clone(), input.cwd)
             .await?;
 
-        format_output(output, input.keep_ansi)
+        // Format the output with proper structure
+        format_output(output, input.keep_ansi, &input.command)
     }
 }
 
@@ -434,23 +607,106 @@ mod tests {
             stdout: "\x1b[32mSuccess\x1b[0m".to_string(),
             stderr: "\x1b[31mWarning\x1b[0m".to_string(),
             success: true,
+            exit_code: 0,
+            temp_file_path: None,
         };
-        let preserved = format_output(ansi_output, true).unwrap();
-        assert_eq!(
-            preserved,
-            "<stdout>\x1b[32mSuccess\x1b[0m</stdout>\n<stderr>\x1b[31mWarning\x1b[0m</stderr>"
-        );
+        let preserved = format_output(ansi_output, true, "test_command").unwrap();
+        assert!(preserved.contains("\x1b[32mSuccess\x1b[0m"));
+        assert!(preserved.contains("\x1b[31mWarning\x1b[0m"));
 
         // Test with keep_ansi = false (should strip ANSI codes)
         let ansi_output = CommandOutput {
             stdout: "\x1b[32mSuccess\x1b[0m".to_string(),
             stderr: "\x1b[31mWarning\x1b[0m".to_string(),
             success: true,
+            exit_code: 0,
+            temp_file_path: None,
         };
-        let stripped = format_output(ansi_output, false).unwrap();
-        assert_eq!(
-            stripped,
-            "<stdout>Success</stdout>\n<stderr>Warning</stderr>"
-        );
+        let stripped = format_output(ansi_output, false, "test_command").unwrap();
+        assert!(stripped.contains("Success"));
+        assert!(stripped.contains("Warning"));
+        assert!(!stripped.contains("\x1b[32m"));
+    }
+
+    #[test]
+    fn test_large_output_handling() {
+        // Create a large output
+        let large_stdout = "A".repeat(30_000);
+        let large_stderr = "B".repeat(15_000);
+
+        let large_output = CommandOutput {
+            stdout: large_stdout,
+            stderr: large_stderr,
+            success: true,
+            exit_code: 0,
+            temp_file_path: None,
+        };
+
+        let result = format_output(large_output, true, "find /").unwrap();
+
+        // Check that the output contains the expected elements
+        assert!(result.contains("---"));
+        assert!(result.contains("command: find /"));
+        assert!(result.contains("exit_code: 0"));
+        assert!(result.contains("total_stdout_chars: 30000"));
+        assert!(result.contains("total_stderr_chars: 15000"));
+        assert!(result.contains("truncated: true"));
+        assert!(result.contains("temp_file:"));
+
+        // Check that the output contains the truncated sections
+        assert!(result.contains("<stdout chars=\"0-20000\">"));
+        assert!(result.contains("<stdout chars=\"10000-30000\">"));
+        assert!(result.contains("<stderr chars=\"0-20000\">"));
+        assert!(result.contains("<truncated>"));
+
+        // Verify the temp file exists and contains the full output
+        let temp_file_line = result.lines()
+            .find(|line| line.starts_with("temp_file:"))
+            .unwrap();
+        let temp_file_path = temp_file_line.split_once(": ").unwrap().1;
+
+        assert!(Path::new(temp_file_path).exists());
+
+        // Clean up the temp file
+        let _ = std::fs::remove_file(temp_file_path);
+    }
+
+    #[test]
+    fn test_empty_output_handling() {
+        // Test with empty output
+        let empty_output = CommandOutput {
+            stdout: "".to_string(),
+            stderr: "".to_string(),
+            success: true,
+            exit_code: 0,
+            temp_file_path: None,
+        };
+
+        let result = format_output(empty_output, true, "echo").unwrap();
+
+        // Check that the output contains the expected elements
+        assert!(result.contains("---"));
+        assert!(result.contains("command: echo"));
+        assert!(result.contains("total_chars: 0"));
+        assert!(result.contains("exit_code: 0"));
+        assert!(result.contains("Command executed successfully with no output"));
+
+        // Test with failed command
+        let failed_output = CommandOutput {
+            stdout: "".to_string(),
+            stderr: "".to_string(),
+            success: false,
+            exit_code: 1,
+            temp_file_path: None,
+        };
+
+        let result = format_output(failed_output, true, "false").unwrap_err().to_string();
+
+        // Check that the output contains the expected elements
+        assert!(result.contains("---"));
+        assert!(result.contains("command: false"));
+        assert!(result.contains("total_chars: 0"));
+        assert!(result.contains("exit_code: 1"));
+        assert!(result.contains("Command failed with no output"));
     }
 }

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_html_content.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_html_content.snap
@@ -2,7 +2,12 @@
 source: crates/forge_services/src/tools/fetch.rs
 expression: normalized_result
 ---
-Contents of http://127.0.0.1:PORT/test.html:
+---
+URL: http://127.0.0.1:PORT/test.html
+total_chars: 37
+start_char: 0
+end_char: 37
+---
 Test Title
 ==========
 

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_raw_content.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_raw_content.snap
@@ -1,7 +1,13 @@
 ---
 source: crates/forge_services/src/tools/fetch.rs
+assertion_line: 352
 expression: normalized_result
 ---
+---
+URL: http://127.0.0.1:PORT/test.txt
+total_chars: 24
+start_char: 0
+end_char: 24
+---
 Content type text/plain cannot be simplified to markdown, but here is the raw content:
-Contents of http://127.0.0.1:PORT/test.txt:
 This is raw text content

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -1,6 +1,11 @@
 variables:
   mode: ACT
 
+# Update configuration
+updates:
+  check_frequency: "daily"
+  auto_update: false
+
 # Define model anchors with simpler, purpose-based names
 models:
   # Role-based model definitions - easy to swap implementation
@@ -56,7 +61,7 @@ agents:
       <current_time>{{current_time}}</current_time>
       Only create new plans or update existing ones.
       Do not modify, create, or delete any code files.
-      
+
     ephemeral: false
     tools:
       - forge_tool_fs_read


### PR DESCRIPTION
## Description
This PR implements the once-daily update prompts feature. Instead of auto-updating on exit, Forge now prompts users once daily at startup with configuration options in forge.yaml.

## Changes
- Added `update-informer` crate for handling update checks
- Added `UpdateFrequency` enum for better type safety
- Added configuration in `forge.yaml` with `check_frequency` and `auto_update` settings
- Moved update check from exit to startup
- Added `/update` command for manual update checks
- Added colored output for version information
- Added restart prompt after updating
- Improved error handling and reporting

## Commands
- `/update` - Check for updates and install if available
- Configuration in forge.yaml:
  ```yaml
  updates:
    check_frequency: "daily"  # Options: "hourly", "daily", "weekly", "never"
    auto_update: false        # Whether to update automatically without prompting.

## Example Usage

```
ACT forge feat/improve-fetch-performance [0.1.0/claude-3.7-sonnet/0]❯ /update

⏺ [16:13:02.044] Checking for updates...

Forge Update Available
Current version: 0.1.0   Latest: 0.2.3

Would you like to update now? [y/N]:
> Yes

Installing update...
Update completed successfully!

Restart Forge to apply the update? [Y/n]:
> Yes

```


/fixed #711 
/claim #711