### PR TITLE
feat: Show the path of .env file that was loaded when the CLI starts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,8 @@ dependencies = [
  "colored 3.0.0",
  "convert_case",
  "derive_setters",
+ "dirs",
+ "dotenv",
  "forge_api",
  "forge_display",
  "forge_domain",
@@ -881,6 +883,7 @@ dependencies = [
  "insta",
  "lazy_static",
  "nu-ansi-term 0.50.1",
+ "pathdiff",
  "pretty_assertions",
  "reedline",
  "serde",
@@ -2452,6 +2455,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ mockito = "1.6.1"
 moka2 = "0.13"
 nom = "8.0.0"
 nu-ansi-term = "0.50.1"
+pathdiff = "0.2"
 posthog-rs = { git = "https://github.com/PostHog/posthog-rs.git", rev = "a006a81419031e4889d9c3882d7458d2efa588a8" }
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0"

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -36,6 +36,9 @@ strum.workspace = true
 strum_macros.workspace = true
 base64.workspace = true
 convert_case.workspace = true
+dotenv.workspace = true
+pathdiff.workspace = true
+dirs.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/forge_main/src/banner.rs
+++ b/crates/forge_main/src/banner.rs
@@ -1,10 +1,24 @@
 use std::io;
+use std::path::Path;
 
 use colored::Colorize;
+use dirs::home_dir;
+use dotenv::dotenv;
+use forge_display::title::TitleFormat;
 
 const BANNER: &str = include_str!("banner");
 
 pub fn display() -> io::Result<()> {
+    let dotenv_path = dotenv().ok();
+
+    // Load .env and get the path if successful
+    if let Some(path) = dotenv_path {
+        // Replace home path with ~ if possible
+        let display_path = collapse_home_dir(&path);
+
+        println!("{}", TitleFormat::info(format!("Reading {}", display_path)));
+    }
+
     let mut banner = BANNER.to_string();
 
     // Define the labels as tuples of (key, value)
@@ -32,4 +46,16 @@ pub fn display() -> io::Result<()> {
 
     println!("{banner}\n");
     Ok(())
+}
+
+fn collapse_home_dir(path: &Path) -> String {
+    if let Some(home) = home_dir() {
+        if let Ok(stripped) = path.strip_prefix(&home) {
+            return format!(
+                "~{}",
+                std::path::MAIN_SEPARATOR.to_string() + &stripped.to_string_lossy()
+            );
+        }
+    }
+    path.display().to_string()
 }


### PR DESCRIPTION
/claim #759

fixes #759

![d2](https://github.com/user-attachments/assets/d0bf2d11-40a4-4ab9-8f65-c544769d013d)
