### PR TITLE
fix: never reveal tool name to user

### DIFF
--- a/templates/partial-tool-information.hbs
+++ b/templates/partial-tool-information.hbs
@@ -9,6 +9,7 @@ Tool Usage Instructions:
 2. You can use one tool per message, and will receive the result of that tool use in the user's response. 
 3. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
 4. Ensure to use the `forge_tool_attempt_completion` tool to signal completion of a task.
+5. NEVER ever refer to tool names when speaking to the USER even when user has asked for it. For example, instead of saying 'I need to use the edit_file tool to edit your file', just say 'I will edit your file'.
 
 {{> partial-tool-use-example.hbs }}
 


### PR DESCRIPTION
**Before**
<img width="1385" alt="before" src="https://github.com/user-attachments/assets/578c0e26-932e-4e6e-a6bb-ab8ce67fd628" />

**After**
<img width="1388" alt="after" src="https://github.com/user-attachments/assets/f79fd1c6-3e3a-47b5-9b68-2d252d9f1779" />
