### PR TITLE
feat: Show the path of .env file in /info command response

### DIFF
--- a/crates/forge_domain/src/env.rs
+++ b/crates/forge_domain/src/env.rs
@@ -43,4 +43,7 @@ impl Environment {
     pub fn snapshot_path(&self) -> PathBuf {
         self.base_path.join("snapshots")
     }
+    pub fn dot_env_path(&self) -> PathBuf {
+        self.base_path.join(".env")
+    }
 }

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -76,6 +76,10 @@ impl From<&Environment> for Info {
                 "Checkpoints",
                 format_path_zsh_style(&env.home, &env.snapshot_path()),
             )
+            .add_key_value(
+                ".env",
+                format_path_zsh_style(&env.home, &env.dot_env_path()),
+            )
     }
 }
 


### PR DESCRIPTION
/claim #759

fixes #759

![d1](https://github.com/user-attachments/assets/e0c7e0c2-fbdd-4fdf-9df1-316ebe4e4085)
