### PR TITLE
fix: compaction spinner updates and interruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "colored 3.0.0",
  "indicatif",
  "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -463,7 +463,7 @@ impl<F: API> UI<F> {
                 }
                 result = &mut compaction_future => {
                     self.spinner.stop(None)?;
-                    return result.map(|res| Some(res));
+                    return result.map(Some);
                 }
             }
         }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -443,20 +443,11 @@ impl<F: API> UI<F> {
         &mut self,
         stream: &mut (impl StreamExt<Item = Result<AgentMessage<ChatResponse>>> + Unpin),
     ) -> Result<()> {
-        // Set up a tokio interval to update the spinner every second
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
-
         loop {
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
                     self.spinner.stop(None)?;
                     return Ok(());
-                }
-                _ = interval.tick() => {
-                    // Update the spinner with elapsed time
-                    if let Err(e) = self.spinner.update_time() {
-                        tracing::warn!("Failed to update spinner time: {}", e);
-                    }
                 }
                 maybe_message = stream.next() => {
                     match maybe_message {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -455,7 +455,7 @@ impl<F: API> UI<F> {
         conversation_id: &ConversationId,
     ) -> Result<Option<CompactionResult>> {
         let compaction_future = self.api.compact_conversation(conversation_id);
-        
+
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
                 self.spinner.stop(None)?;
@@ -463,7 +463,7 @@ impl<F: API> UI<F> {
             }
             result = compaction_future => {
                 self.spinner.stop(None)?;
-                result.map(|res| Some(res))
+                result.map(Some)
             }
         }
     }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use forge_api::{
-    AgentMessage, ChatRequest, ChatResponse, CompactionResult, Conversation, ConversationId, Event,
-    Model, ModelId, API,
+    AgentMessage, ChatRequest, ChatResponse, Conversation, ConversationId, Event, Model, ModelId,
+    API,
 };
 use forge_display::{MarkdownFormat, TitleFormat};
 use forge_fs::ForgeFS;
@@ -181,107 +181,105 @@ impl<F: API> UI<F> {
         self.init_conversation().await?;
 
         // Get initial input from file or prompt
-        let mut input = match &self.cli.command {
+        let mut command = match &self.cli.command {
             Some(path) => self.console.upload(path).await?,
             None => self.prompt().await?,
         };
 
         loop {
-            match input {
-                Command::Compact => {
-                    self.spinner.start(Some("Compacting"))?;
-                    let conversation_id = self.init_conversation().await?;
-
-                    match self.handle_compaction(&conversation_id).await {
-                        Ok(Some(compaction_result)) => {
-                            // Calculate percentage reduction
-                            let token_reduction = compaction_result.token_reduction_percentage();
-                            let message_reduction =
-                                compaction_result.message_reduction_percentage();
-
-                            let content = TitleFormat::action(format!(
-"Context size reduced by {token_reduction:.1}% (tokens), {message_reduction:.1}% (messages)"
-))
-                            .to_string();
-                            self.writeln(content)?;
-                        }
-                        Ok(None) => {
-                            // interrupted by user so no-op.
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                }
-                Command::Dump(format) => {
-                    self.handle_dump(format).await?;
-                }
-                Command::New => {
-                    self.handle_new().await?;
-                }
-                Command::Info => {
-                    let info = Info::from(&self.state).extend(Info::from(&self.api.environment()));
-                    self.writeln(info)?;
-                }
-                Command::Message(ref content) => {
-                    self.spinner.start(None)?;
-                    let chat_result = self.chat(content.clone()).await;
-                    if let Err(err) = chat_result {
-                        tokio::spawn(
-                            TRACKER.dispatch(forge_tracker::EventKind::Error(format!("{err:?}"))),
-                        );
-                        error!(error = ?err, "Chat request failed");
-
-                        self.writeln(TitleFormat::error(format!("{err:?}")))?;
-                    }
-                }
-                Command::Act => {
-                    self.handle_mode_change(Mode::Act).await?;
-                }
-                Command::Plan => {
-                    self.handle_mode_change(Mode::Plan).await?;
-                }
-                Command::Help => {
-                    let info = Info::from(self.command.as_ref());
-                    self.writeln(info)?;
-                }
-                Command::Tools => {
-                    use crate::tools_display::format_tools;
-                    let tools = self.api.tools().await;
-                    let output = format_tools(&tools);
-                    self.writeln(output)?;
-                }
-                Command::Exit => {
-                    update_forge().await;
-
-                    break;
-                }
-
-                Command::Custom(event) => {
-                    if let Err(e) = self.dispatch_event(event.into()).await {
-                        self.writeln(
-                            TitleFormat::error("Failed to execute the command")
-                                .sub_title(e.to_string()),
-                        )?;
-                    }
-                }
-                Command::Model => {
-                    self.handle_model_selection().await?;
-                }
-                Command::Shell(ref command) => {
-                    // Execute the shell command using the existing infrastructure
-                    // Get the working directory from the environment service instead of std::env
-                    let cwd = self.api.environment().cwd;
-
-                    // Execute the command
-                    let _ = self.api.execute_shell_command(command, cwd).await;
-                }
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = self.on_command(command) => {}
             }
 
+            self.spinner.stop(None)?;
+
             // Centralized prompt call at the end of the loop
-            input = self.prompt().await?;
+            command = self.prompt().await?;
+        }
+    }
+
+    async fn on_command(&mut self, command: Command) -> anyhow::Result<()> {
+        match command {
+            Command::Compact => {
+                self.handle_compaction().await?;
+            }
+            Command::Dump(format) => {
+                self.handle_dump(format).await?;
+            }
+            Command::New => {
+                self.handle_new().await?;
+            }
+            Command::Info => {
+                let info = Info::from(&self.state).extend(Info::from(&self.api.environment()));
+                self.writeln(info)?;
+            }
+            Command::Message(ref content) => {
+                self.spinner.start(None)?;
+                let chat_result = self.chat(content.clone()).await;
+                if let Err(err) = chat_result {
+                    tokio::spawn(
+                        TRACKER.dispatch(forge_tracker::EventKind::Error(format!("{err:?}"))),
+                    );
+                    error!(error = ?err, "Chat request failed");
+
+                    self.writeln(TitleFormat::error(format!("{err:?}")))?;
+                }
+            }
+            Command::Act => {
+                self.handle_mode_change(Mode::Act).await?;
+            }
+            Command::Plan => {
+                self.handle_mode_change(Mode::Plan).await?;
+            }
+            Command::Help => {
+                let info = Info::from(self.command.as_ref());
+                self.writeln(info)?;
+            }
+            Command::Tools => {
+                use crate::tools_display::format_tools;
+                let tools = self.api.tools().await;
+                let output = format_tools(&tools);
+                self.writeln(output)?;
+            }
+            Command::Exit => {
+                update_forge().await;
+
+                return Ok(());
+            }
+
+            Command::Custom(event) => {
+                if let Err(e) = self.dispatch_event(event.into()).await {
+                    self.writeln(
+                        TitleFormat::error("Failed to execute the command")
+                            .sub_title(e.to_string()),
+                    )?;
+                }
+            }
+            Command::Model => {
+                self.handle_model_selection().await?;
+            }
+            Command::Shell(ref command) => {
+                // Execute the shell command using the existing infrastructure
+                // Get the working directory from the environment service instead of std::env
+                let cwd = self.api.environment().cwd;
+
+                // Execute the command
+                let _ = self.api.execute_shell_command(command, cwd).await;
+            }
         }
 
+        Ok(())
+    }
+
+    async fn handle_compaction(&mut self) -> Result<(), anyhow::Error> {
+        self.spinner.start(Some("Compacting"))?;
+        let conversation_id = self.init_conversation().await?;
+        let compaction_result = self.api.compact_conversation(&conversation_id).await?;
+        let token_reduction = compaction_result.token_reduction_percentage();
+        let message_reduction = compaction_result.message_reduction_percentage();
+        let content = TitleFormat::action(format!("Context size reduced by {token_reduction:.1}% (tokens), {message_reduction:.1}% (messages)"));
+        self.writeln(content)?;
         Ok(())
     }
 
@@ -450,49 +448,23 @@ impl<F: API> UI<F> {
         }
     }
 
-    async fn handle_compaction(
-        &mut self,
-        conversation_id: &ConversationId,
-    ) -> Result<Option<CompactionResult>> {
-        let compaction_future = self.api.compact_conversation(conversation_id);
-
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                self.spinner.stop(None)?;
-                Ok(None)
-            }
-            result = compaction_future => {
-                self.spinner.stop(None)?;
-                result.map(Some)
-            }
-        }
-    }
-
     async fn handle_chat_stream(
         &mut self,
         stream: &mut (impl StreamExt<Item = Result<AgentMessage<ChatResponse>>> + Unpin),
     ) -> Result<()> {
-        loop {
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(message) => self.handle_chat_response(message)?,
+                Err(err) => {
                     self.spinner.stop(None)?;
-                    return Ok(());
-                }
-                maybe_message = stream.next() => {
-                    match maybe_message {
-                        Some(Ok(message)) => self.handle_chat_response(message)?,
-                        Some(Err(err)) => {
-                            self.spinner.stop(None)?;
-                            return Err(err);
-                        }
-                        None => {
-                            self.spinner.stop(None)?;
-                            return Ok(())
-                        },
-                    }
+                    return Err(err);
                 }
             }
         }
+
+        self.spinner.stop(None)?;
+
+        Ok(())
     }
 
     /// Modified version of handle_dump that supports HTML format

--- a/crates/forge_spinner/Cargo.toml
+++ b/crates/forge_spinner/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 colored.workspace = true
+tokio.workspace = true
 indicatif = "0.17.11"
 rand = "0.8.5"

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -123,7 +123,9 @@ impl SpinnerManager {
         }
 
         // Tracker task will be dropped here.
-        if let Some(a) = self.tracker.take() { drop(a) }
+        if let Some(a) = self.tracker.take() {
+            drop(a)
+        }
         self.tracker = None;
         self.start_time = None;
         self.message = None;

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+use tokio::task::JoinHandle;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -11,6 +12,7 @@ pub struct SpinnerManager {
     spinner: Option<ProgressBar>,
     start_time: Option<Instant>,
     message: Option<String>,
+    tracker: Option<JoinHandle<()>>,
 }
 
 impl SpinnerManager {
@@ -71,29 +73,36 @@ impl SpinnerManager {
 
         self.spinner = Some(pb);
 
-        Ok(())
-    }
+        // Clone the necessary components for the tracker task
+        let spinner_clone = self.spinner.clone();
+        let start_time_clone = self.start_time;
+        let message_clone = self.message.clone();
 
-    /// Update the spinner with the current elapsed time
-    pub fn update_time(&mut self) -> Result<()> {
-        if let (Some(start_time), Some(message), Some(spinner)) =
-            (self.start_time, self.message.as_ref(), &mut self.spinner)
-        {
-            let elapsed = start_time.elapsed();
-            let seconds = elapsed.as_secs();
+        // Spwan tracker to keep the track of time in sec.
+        self.tracker = Some(tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
+            loop {
+                interval.tick().await;
+                // Update the spinner with the current elapsed time
+                if let (Some(spinner), Some(start_time), Some(message)) =
+                    (&spinner_clone, start_time_clone, &message_clone)
+                {
+                    let elapsed = start_time.elapsed();
+                    let seconds = elapsed.as_secs();
 
-            // Create a new message with the elapsed time
-            let updated_message = format!(
-                "{} {}s · {}",
-                message.green().bold(),
-                seconds,
-                "Ctrl+C to interrupt".white().dimmed()
-            );
+                    // Create a new message with the elapsed time
+                    let updated_message = format!(
+                        "{} {}s · {}",
+                        message.green().bold(),
+                        seconds,
+                        "Ctrl+C to interrupt".white().dimmed()
+                    );
 
-            // Update the spinner's message
-            // No need to call tick() as we're using enable_steady_tick
-            spinner.set_message(updated_message);
-        }
+                    // Update the spinner's message
+                    spinner.set_message(updated_message);
+                }
+            }
+        }));
 
         Ok(())
     }
@@ -113,6 +122,8 @@ impl SpinnerManager {
             println!("{message}");
         }
 
+        // Tracker task will be dropped here.
+        self.tracker = None;
         self.start_time = None;
         self.message = None;
         Ok(())

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -123,6 +123,7 @@ impl SpinnerManager {
         }
 
         // Tracker task will be dropped here.
+        self.tracker.take().map(|tracker| drop(tracker));
         self.tracker = None;
         self.start_time = None;
         self.message = None;

--- a/crates/forge_spinner/src/lib.rs
+++ b/crates/forge_spinner/src/lib.rs
@@ -1,10 +1,10 @@
 use std::time::Instant;
-use tokio::task::JoinHandle;
 
 use anyhow::Result;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::seq::SliceRandom;
+use tokio::task::JoinHandle;
 
 /// Manages spinner functionality for the UI
 #[derive(Default)]
@@ -123,7 +123,7 @@ impl SpinnerManager {
         }
 
         // Tracker task will be dropped here.
-        self.tracker.take().map(|tracker| drop(tracker));
+        if let Some(a) = self.tracker.take() { drop(a) }
         self.tracker = None;
         self.start_time = None;
         self.message = None;


### PR DESCRIPTION
This PR fixes issue #769: Spinner '/compact' is stuck at 0 seconds.

## Problem
When running the '/compact' command, the spinner shows a timer that should be updated every second, but it stays at 0 seconds throughout the operation.

## Solution
- Created a dedicated tokio task in the SpinnerManager to track and update the elapsed time every 500ms
- Modified the spinner management to properly handle updates during long-running operations
- Added proper handling of CTRL+C interruptions during compaction operations
- Ensured the tracker task is properly dropped when stopping the spinner
- Refactored the compaction handling in UI to gracefully handle both successful completions and interruptions

## Implementation Details
- The spinner now shows the correct elapsed time during compaction operations
- Users can interrupt the compaction process with CTRL+C
- Fixed potential resource leaks by ensuring background tasks are properly cleaned up

/claim #769 
/closes #769