### PR TITLE
fix: include tool description in schema

### DIFF
--- a/crates/forge_domain/src/snapshots/forge_domain__tool_usage__tests__tool_usage_prompt_to_string.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__tool_usage__tests__tool_usage_prompt_to_string.snap
@@ -3,4 +3,4 @@ source: crates/forge_domain/src/tool_usage.rs
 expression: prompt
 snapshot_kind: text
 ---
-{"name":"forge_tool_mango","arguments":{"param1":{"description":"This is parameter 1","type":"string","is_required":true},"param2":{"description":"This is parameter 2","type":["string","null"],"is_required":false}}}
+<tool>{"name":"forge_tool_mango","description":"This is a mango tool","arguments":{"param1":{"description":"This is parameter 1","type":"string","is_required":true},"param2":{"description":"This is parameter 2","type":["string","null"],"is_required":false}}}</tool>

--- a/crates/forge_domain/src/tool_usage.rs
+++ b/crates/forge_domain/src/tool_usage.rs
@@ -59,9 +59,13 @@ impl Display for ToolUsagePrompt<'_> {
                 })
                 .collect::<BTreeMap<_, _>>();
 
-            let schema = Schema { name: tool.name.as_str().to_string(), arguments: parameters };
+            let schema = Schema {
+                name: tool.name.as_str().to_string(),
+                arguments: parameters,
+                description: tool.description.clone(),
+            };
 
-            writeln!(f, "{schema}")?;
+            writeln!(f, "<tool>{schema}</tool>")?;
         }
 
         Ok(())
@@ -71,6 +75,7 @@ impl Display for ToolUsagePrompt<'_> {
 #[derive(Serialize)]
 struct Schema {
     name: String,
+    description: String,
     arguments: BTreeMap<String, Parameter>,
 }
 


### PR DESCRIPTION
This PR enhances the tool usage schema by adding tool descriptions and improving the output format.

### Key Improvements

- Adds tool description field to the Schema struct to expose tool descriptions in the LLM prompt
- Wraps tool schema JSON in <tool> tags for better parsing and readability
- Updates the corresponding snapshot tests to reflect these changes

These changes improve the information available to LLM models about each tool, leading to better tool selection and usage.