### PR TITLE
fix(domain): ensure workflow model updates agent compaction configurations

### DIFF
--- a/crates/forge_display/src/markdown.rs
+++ b/crates/forge_display/src/markdown.rs
@@ -19,8 +19,7 @@ impl MarkdownFormat {
         let compound_style = CompoundStyle::new(Some(Color::Cyan), None, Attribute::Bold.into());
         skin.inline_code = compound_style.clone();
 
-        let mut codeblock_style = CompoundStyle::new(None, None, Default::default());
-        codeblock_style.add_attr(Attribute::Dim);
+        let codeblock_style = CompoundStyle::new(None, None, Default::default());
 
         skin.code_block = LineStyle::new(codeblock_style, Default::default());
 


### PR DESCRIPTION
## Summary

This PR addresses an issue with model configuration inheritance in workflows. Previously, when a workflow specified a model, it would update agent models but not properly initialize compaction configurations for agents that didn't have them already. This fix ensures all agents receive consistent model configurations for both regular operation and compaction.

## Changes

- **fix(domain)**: Ensure workflow models are applied to agent compact configurations
  - Added initialization of Compact objects for agents when only a workflow model is provided
  - Updated existing compact models to use the workflow model when specified
  - Added tests to verify proper inheritance behavior

- **fix(display)**: Simplify codeblock style initialization in MarkdownFormat
  - Removed unnecessary mutable style object and attribute modification