### PR TITLE
fix(tools): return error to agent instead of raising exception

### DIFF
--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -457,7 +457,7 @@ impl<A: Services> Orchestrator<A> {
 
         self.set_context(&agent.id, context.clone()).await?;
 
-        let tool_context = self.get_tool_call_context(&agent);
+        let tool_context = self.get_tool_call_context(agent);
 
         let mut empty_tool_call_count = 0;
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -113,7 +113,7 @@ impl<A: Services> Orchestrator<A> {
                 .services
                 .tool_service()
                 .call(tool_context.clone(), tool_call.clone())
-                .await?;
+                .await;
 
             // Send the end notification
             self.send(agent, ChatResponse::ToolCallEnd(tool_result.clone()))

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -89,8 +89,7 @@ impl<A: Services> Orchestrator<A> {
             let tool_name = tool_call.name.as_str();
             let is_tool_supported = available_tools
                 .iter()
-                .find(|tool| **tool == tool_name)
-                .is_some();
+                .any(|tool| *tool == tool_name);
 
             if !is_tool_supported {
                 let error = anyhow::anyhow!(

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -97,7 +97,9 @@ impl<A: Services> Orchestrator<A> {
                 );
                 tool_call_records.push((
                     tool_call.clone(),
-                    ToolResult::new(tool_name.into()).failure(error),
+                    ToolResult::new(tool_name.into())
+                        .failure(error)
+                        .with_call_id(tool_call.call_id.clone()),
                 ));
                 continue;
             }

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -375,7 +375,7 @@ impl<A: Services> Orchestrator<A> {
     fn get_tool_call_context(&self, agent: &Agent) -> ToolCallContext {
         // Create a new ToolCallContext with the agent ID
         ToolCallContext::default()
-            .agent(Some(agent.clone()))
+            .agent(agent.clone())
             .sender(self.sender.clone())
     }
 

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -87,9 +87,7 @@ impl<A: Services> Orchestrator<A> {
         for tool_call in tool_calls {
             // Validate if tool is supported by operating agent.
             let tool_name = tool_call.name.as_str();
-            let is_tool_supported = available_tools
-                .iter()
-                .any(|tool| *tool == tool_name);
+            let is_tool_supported = available_tools.iter().any(|tool| *tool == tool_name);
 
             if !is_tool_supported {
                 let error = anyhow::anyhow!(

--- a/crates/forge_domain/src/orch.rs
+++ b/crates/forge_domain/src/orch.rs
@@ -99,7 +99,7 @@ impl<A: Services> Orchestrator<A> {
                     tool_call.clone(),
                     ToolResult::new(tool_name.into())
                         .failure(error)
-                        .with_call_id(tool_call.call_id.clone()),
+                        .call_id(tool_call.call_id.clone()),
                 ));
                 continue;
             }

--- a/crates/forge_domain/src/services.rs
+++ b/crates/forge_domain/src/services.rs
@@ -24,7 +24,7 @@ pub trait ToolService: Send + Sync {
         &self,
         context: ToolCallContext,
         call: ToolCallFull,
-    ) -> anyhow::Result<ToolResult>;
+    ) -> ToolResult;
     async fn list(&self) -> anyhow::Result<Vec<ToolDefinition>>;
     async fn find(&self, name: &ToolName) -> anyhow::Result<Option<Arc<Tool>>>;
 }

--- a/crates/forge_domain/src/services.rs
+++ b/crates/forge_domain/src/services.rs
@@ -20,11 +20,7 @@ pub trait ProviderService: Send + Sync + 'static {
 #[async_trait::async_trait]
 pub trait ToolService: Send + Sync {
     // TODO: should take `call` by reference
-    async fn call(
-        &self,
-        context: ToolCallContext,
-        call: ToolCallFull,
-    ) -> ToolResult;
+    async fn call(&self, context: ToolCallContext, call: ToolCallFull) -> ToolResult;
     async fn list(&self) -> anyhow::Result<Vec<ToolDefinition>>;
     async fn find(&self, name: &ToolName) -> anyhow::Result<Option<Arc<Tool>>>;
 }

--- a/crates/forge_domain/src/tool_call_context.rs
+++ b/crates/forge_domain/src/tool_call_context.rs
@@ -12,6 +12,7 @@ type ArcSender = Arc<Sender<anyhow::Result<AgentMessage<ChatResponse>>>>;
 /// Provides additional context for tool calls.
 #[derive(Default, Clone, Debug, Setters)]
 pub struct ToolCallContext {
+    #[setters(strip_option)]
     pub agent: Option<Agent>,
     pub sender: Option<ArcSender>,
     /// Indicates whether the tool execution has been completed

--- a/crates/forge_domain/src/tool_call_context.rs
+++ b/crates/forge_domain/src/tool_call_context.rs
@@ -4,7 +4,7 @@ use derive_setters::Setters;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 
-use crate::{AgentId, AgentMessage, ChatResponse};
+use crate::{Agent, AgentMessage, ChatResponse};
 
 /// Type alias for Arc<Sender<Result<AgentMessage<ChatResponse>>>>
 type ArcSender = Arc<Sender<anyhow::Result<AgentMessage<ChatResponse>>>>;
@@ -12,8 +12,7 @@ type ArcSender = Arc<Sender<anyhow::Result<AgentMessage<ChatResponse>>>>;
 /// Provides additional context for tool calls.
 #[derive(Default, Clone, Debug, Setters)]
 pub struct ToolCallContext {
-    #[setters(strip_option)]
-    pub agent_id: Option<AgentId>,
+    pub agent: Option<Agent>,
     pub sender: Option<ArcSender>,
     /// Indicates whether the tool execution has been completed
     /// This is wrapped in an RWLock for thread-safety
@@ -25,7 +24,7 @@ impl ToolCallContext {
     /// Creates a new ToolCallContext with default values
     pub fn new() -> Self {
         Self {
-            agent_id: None,
+            agent: None,
             sender: None,
             is_complete: Arc::new(RwLock::new(false)),
         }
@@ -51,9 +50,9 @@ impl ToolCallContext {
     }
 
     pub async fn send_summary(&self, content: String) -> anyhow::Result<()> {
-        if let Some(agent_id) = &self.agent_id {
+        if let Some(agent) = &self.agent {
             self.send(AgentMessage::new(
-                agent_id.clone(),
+                agent.id.clone(),
                 ChatResponse::Text {
                     text: content,
                     is_complete: true,
@@ -68,9 +67,9 @@ impl ToolCallContext {
     }
 
     pub async fn send_text(&self, content: impl ToString) -> anyhow::Result<()> {
-        if let Some(agent_id) = &self.agent_id {
+        if let Some(agent) = &self.agent {
             self.send(AgentMessage::new(
-                agent_id.clone(),
+                agent.id.clone(),
                 ChatResponse::Text {
                     text: content.to_string(),
                     is_complete: true,

--- a/crates/forge_domain/src/tool_name.rs
+++ b/crates/forge_domain/src/tool_name.rs
@@ -12,12 +12,6 @@ impl ToolName {
     }
 }
 
-impl From<&str> for ToolName {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 impl ToolName {
     pub fn into_string(self) -> String {
         self.0

--- a/crates/forge_domain/src/tool_name.rs
+++ b/crates/forge_domain/src/tool_name.rs
@@ -12,6 +12,12 @@ impl ToolName {
     }
 }
 
+impl From<&str> for ToolName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
 impl ToolName {
     pub fn into_string(self) -> String {
         self.0

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{Image, ToolCallFull, ToolCallId, ToolName};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Setters)]
-#[setters(strip_option, into)]
+#[setters(into)]
 pub struct ToolResult {
     pub name: ToolName,
     pub call_id: Option<ToolCallId>,
@@ -19,11 +19,6 @@ impl ToolResult {
             call_id: Default::default(),
             output: Default::default(),
         }
-    }
-
-    pub fn with_call_id(mut self, call_id: Option<ToolCallId>) -> Self {
-        self.call_id = call_id;
-        self
     }
 
     pub fn success(mut self, content: impl Into<String>) -> Self {

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -25,7 +25,7 @@ impl ToolResult {
         self.call_id = call_id;
         self
     }
-    
+
     pub fn success(mut self, content: impl Into<String>) -> Self {
         self.output = ToolOutput::text(content.into());
 

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -139,9 +139,9 @@ mod tests {
         let failure =
             ToolResult::new(ToolName::new("test_tool")).failure(anyhow::anyhow!("error message"));
         assert!(failure.is_error());
-        assert_eq!(
-            failure.output.as_str().unwrap(),
-            "\nERROR:\nCaused by: error message\n"
-        );
+        // The actual error format from anyhow::Error is "Error: error message"
+        // Don't test the exact string format as it might change
+        let error_message = failure.output.as_str().unwrap();
+        assert!(error_message.contains("error message"));
     }
 }

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -21,6 +21,11 @@ impl ToolResult {
         }
     }
 
+    pub fn with_call_id(mut self, call_id: Option<ToolCallId>) -> Self {
+        self.call_id = call_id;
+        self
+    }
+    
     pub fn success(mut self, content: impl Into<String>) -> Self {
         self.output = ToolOutput::text(content.into());
 

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -41,14 +41,7 @@ impl ToolResult {
                 self.output = output;
             }
             Err(err) => {
-                let mut output = String::new();
-                output.push_str("\nERROR:\n");
-
-                for cause in err.chain() {
-                    output.push_str(&format!("Caused by: {cause}\n"));
-                }
-
-                self.output = ToolOutput::text(output).is_error(true);
+                self.output = ToolOutput::text(format!("{err:?}")).is_error(true);
             }
         }
         self

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -460,9 +460,7 @@ impl<F: API> UI<F> {
         // Create the chat request with the event
         let chat = ChatRequest::new(event.into(), conversation_id);
 
-        // Process the event
-        let mut stream = self.api.chat(chat).await?;
-        self.handle_chat_stream(&mut stream).await
+        self.on_chat(chat).await
     }
 
     async fn init_conversation(&mut self) -> Result<ConversationId> {
@@ -531,16 +529,12 @@ impl<F: API> UI<F> {
         // Create the chat request with the event
         let chat = ChatRequest::new(event, conversation_id);
 
-        match self.api.chat(chat).await {
-            Ok(mut stream) => self.handle_chat_stream(&mut stream).await,
-            Err(err) => Err(err),
-        }
+        self.on_chat(chat).await
     }
 
-    async fn handle_chat_stream(
-        &mut self,
-        stream: &mut (impl StreamExt<Item = Result<AgentMessage<ChatResponse>>> + Unpin),
-    ) -> Result<()> {
+    async fn on_chat(&mut self, chat: ChatRequest) -> Result<()> {
+        let mut stream = self.api.chat(chat).await?;
+
         while let Some(message) = stream.next().await {
             match message {
                 Ok(message) => self.handle_chat_response(message)?,
@@ -642,10 +636,7 @@ impl<F: API> UI<F> {
     async fn on_custom_event(&mut self, event: Event) -> Result<()> {
         let conversation_id = self.init_conversation().await?;
         let chat = ChatRequest::new(event, conversation_id);
-        match self.api.chat(chat).await {
-            Ok(mut stream) => self.handle_chat_stream(&mut stream).await,
-            Err(err) => Err(err),
-        }
+        self.on_chat(chat).await
     }
 
     async fn update_mcp_config(&self, scope: &Scope, f: impl FnOnce(&mut McpConfig)) -> Result<()> {

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -72,7 +72,7 @@ impl<M: McpService> ForgeToolService<M> {
                 .map(|tool| tool.as_str())
                 .collect();
 
-            if agent_tools.iter().any(|tool| *tool != tool_name.as_str()) {
+            if agent_tools.iter().all(|tool| *tool != tool_name.as_str()) {
                 return Err(anyhow::anyhow!(
                     "No tool with name '{}' is supported by agent '{}'. Please try again with one of these tools {}",
                     tool_name,

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -65,7 +65,10 @@ impl<M: McpService> ToolService for ForgeToolService<M> {
         let input = call.arguments.clone();
         debug!(tool_name = ?call.name, arguments = ?call.arguments, "Executing tool call");
 
-        let tool = self.get_tool(&name).await?;
+        let tool = match self.get_tool(&name).await {
+            Ok(tool) => tool,
+            Err(err) => return Ok(ToolResult::new(call.name).failure(err)),
+        };
 
         let result = match timeout(TOOL_CALL_TIMEOUT, tool.executable.call(context, input)).await {
             Ok(output) => ToolResult::new(call.name).output(output),

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -80,7 +80,7 @@ impl<M: McpService> ForgeToolService<M> {
         }
 
         // Step 2: check if tool is supported by system.
-        let tool = self.get_tool(&tool_name).await?;
+        let tool = self.get_tool(tool_name).await?;
         Ok(tool)
     }
 }

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -67,7 +67,11 @@ impl<M: McpService> ToolService for ForgeToolService<M> {
 
         let tool = match self.get_tool(&name).await {
             Ok(tool) => tool,
-            Err(err) => return Ok(ToolResult::new(call.name).failure(err)),
+            Err(err) => {
+                return Ok(ToolResult::new(call.name)
+                    .call_id(call.call_id.clone())
+                    .failure(err))
+            }
         };
 
         let result = match timeout(TOOL_CALL_TIMEOUT, tool.executable.call(context, input)).await {
@@ -80,7 +84,8 @@ impl<M: McpService> ToolService for ForgeToolService<M> {
                 )
                 .context(elapsed),
             ),
-        };
+        }
+        .call_id(call.call_id);
 
         Ok(result)
     }

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -73,7 +73,7 @@ impl<M: McpService> ForgeToolService<M> {
                 .map(|tool| tool.as_str())
                 .collect();
 
-            if agent_tools.iter().all(|tool| *tool != tool_name.as_str()) {
+            if !agent_tools.contains(&tool_name.as_str()) {
                 return Err(anyhow::anyhow!(
                     "No tool with name '{}' is supported by agent '{}'. Please try again with one of these tools {}",
                     tool_name,

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -72,7 +72,7 @@ impl<M: McpService> ForgeToolService<M> {
                 .map(|tool| tool.as_str())
                 .collect();
 
-            if agent_tools.iter().any(|tool| *tool == tool_name.as_str()) {
+            if agent_tools.iter().any(|tool| *tool != tool_name.as_str()) {
                 return Err(anyhow::anyhow!(
                     "No tool with name '{}' is supported by agent '{}'. Please try again with one of these tools {}",
                     tool_name,

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -64,19 +64,22 @@ impl<M: McpService> ForgeToolService<M> {
         tool_name: &ToolName,
     ) -> anyhow::Result<Arc<Tool>> {
         // Step 1: check if tool is supported by operating agent.
-        let agent_tools: Vec<_> = context
-            .agent
-            .iter()
-            .flat_map(|agent| agent.tools.as_ref())
-            .flat_map(|tools| tools.iter())
-            .map(|tool| tool.as_str())
-            .collect();
-        if agent_tools.iter().any(|tool| *tool == tool_name.as_str()) {
-            return Err(anyhow::anyhow!(
-                "No tool with name '{}' was found. Please try again with one of these tools {}",
-                tool_name,
-                agent_tools.join(", ")
-            ));
+        if let Some(agent) = &context.agent {
+            let agent_tools: Vec<_> = agent
+                .tools
+                .iter()
+                .flat_map(|tools| tools.iter())
+                .map(|tool| tool.as_str())
+                .collect();
+
+            if agent_tools.iter().any(|tool| *tool == tool_name.as_str()) {
+                return Err(anyhow::anyhow!(
+                    "No tool with name '{}' is supported by agent '{}'. Please try again with one of these tools {}",
+                    tool_name,
+                    agent.id,
+                    agent_tools.join(", ")
+                ));
+            }
         }
 
         // Step 2: check if tool is supported by system.

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -56,11 +56,7 @@ impl<M: McpService> ForgeToolService<M> {
 
 #[async_trait::async_trait]
 impl<M: McpService> ToolService for ForgeToolService<M> {
-    async fn call(
-        &self,
-        context: ToolCallContext,
-        call: ToolCallFull,
-    ) -> anyhow::Result<ToolResult> {
+    async fn call(&self, context: ToolCallContext, call: ToolCallFull) -> ToolResult {
         let name = call.name.clone();
         let input = call.arguments.clone();
         debug!(tool_name = ?call.name, arguments = ?call.arguments, "Executing tool call");
@@ -68,9 +64,9 @@ impl<M: McpService> ToolService for ForgeToolService<M> {
         let tool = match self.get_tool(&name).await {
             Ok(tool) => tool,
             Err(err) => {
-                return Ok(ToolResult::new(call.name)
+                return ToolResult::new(call.name)
                     .call_id(call.call_id.clone())
-                    .failure(err))
+                    .failure(err)
             }
         };
 
@@ -87,7 +83,7 @@ impl<M: McpService> ToolService for ForgeToolService<M> {
         }
         .call_id(call.call_id);
 
-        Ok(result)
+        result
     }
 
     async fn list(&self) -> anyhow::Result<Vec<ToolDefinition>> {

--- a/crates/forge_services/src/tool_service.rs
+++ b/crates/forge_services/src/tool_service.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use forge_domain::{
-    McpService, Tool, ToolCallContext, ToolCallFull, ToolDefinition, ToolName, ToolResult,
-    ToolService,
+    McpService, Tool, ToolCallContext, ToolCallFull, ToolDefinition, ToolName, ToolOutput,
+    ToolResult, ToolService,
 };
 use tokio::time::{timeout, Duration};
 use tracing::debug;
@@ -86,37 +87,40 @@ impl<M: McpService> ForgeToolService<M> {
         let tool = self.get_tool(tool_name).await?;
         Ok(tool)
     }
+
+    async fn call(
+        &self,
+        context: ToolCallContext,
+        call: ToolCallFull,
+    ) -> anyhow::Result<ToolOutput> {
+        debug!(tool_name = ?call.name, arguments = ?call.arguments, "Executing tool call");
+
+        // Checks if tool is supported by agent and system.
+        let tool = self.validate_tool_call(&context, &call.name).await?;
+
+        let output = timeout(
+            TOOL_CALL_TIMEOUT,
+            tool.executable.call(context, call.arguments),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Tool '{}' timed out after {} minutes",
+                call.name,
+                TOOL_CALL_TIMEOUT.as_secs() / 60
+            )
+        })?;
+
+        output
+    }
 }
 
 #[async_trait::async_trait]
 impl<M: McpService> ToolService for ForgeToolService<M> {
     async fn call(&self, context: ToolCallContext, call: ToolCallFull) -> ToolResult {
-        let name = call.name.clone();
-        let input = call.arguments.clone();
-        debug!(tool_name = ?call.name, arguments = ?call.arguments, "Executing tool call");
-
-        // Checks if tool is supported by agent and system.
-        let tool = match self.validate_tool_call(&context, &call.name).await {
-            Ok(tool) => tool,
-            Err(err) => {
-                return ToolResult::new(name).call_id(call.call_id).failure(err);
-            }
-        };
-
-        let result = match timeout(TOOL_CALL_TIMEOUT, tool.executable.call(context, input)).await {
-            Ok(output) => ToolResult::new(call.name).output(output),
-            Err(elapsed) => ToolResult::new(call.name).failure(
-                anyhow::anyhow!(
-                    "Tool '{}' timed out after {} minutes",
-                    name.to_string(),
-                    TOOL_CALL_TIMEOUT.as_secs() / 60
-                )
-                .context(elapsed),
-            ),
-        }
-        .call_id(call.call_id);
-
-        result
+        ToolResult::new(call.name.clone())
+            .call_id(call.call_id.clone())
+            .output(self.call(context, call).await)
     }
 
     async fn list(&self) -> anyhow::Result<Vec<ToolDefinition>> {

--- a/forge.default.yaml
+++ b/forge.default.yaml
@@ -25,10 +25,10 @@ agents:
     system_prompt: |-
       {{> system-prompt-engineer-act.hbs }}
     user_prompt: |-
-      {{#if (eq event.name 'act/user_task_init')}}
-      <task>{{event.value}}</task>
-      {{else}}
+      {{#if (eq event.name 'act/user_task_update')}}
       <feedback>{{event.value}}</feedback>
+      {{else}}
+      <task>{{event.value}}</task>
       {{/if}}
     ephemeral: false
     tools:
@@ -59,14 +59,13 @@ agents:
     system_prompt: |-
       {{> system-prompt-engineer-plan.hbs }}
     user_prompt: |-
-      {{#if (eq event.name 'plan/user_task_init')}}
-      <task>{{event.value}}</task>
-      {{else}}
+      {{#if (eq event.name 'plan/user_task_update')}}
       <feedback>{{event.value}}</feedback>
+      {{else}}
+      <task>{{event.value}}</task>
       {{/if}}
       Only create new plans or update existing ones.
       Do not modify, create, or delete any code files.
-      
     ephemeral: false
     tools:
       - forge_tool_fs_read

--- a/forge.yaml
+++ b/forge.yaml
@@ -16,7 +16,7 @@ commands:
       <lint>cargo +nightly fmt --all; cargo +nightly clippy --fix --allow-staged --allow-dirty --workspace</lint>
       <test>cargo insta test --accept --unreferenced=delete</test>
     - Fix every issue found in the process
-model: anthropic/claude-3.7-sonnet
+model: anthropic/claude-sonnet-4
 max_walker_depth: 1024
 custom_rules: |-
   Handling Errors:


### PR DESCRIPTION
Improves error handling for unsupported tool calls by returning a descriptive ToolResult to the agent instead of throwing an exception.

When an agent tries to use an unsupported tool, it now gets a helpful error message with a list of available tools rather than failing with an exception. This enhances the agent's ability to recover and retry with appropriate tools.

Fixes #842