### PR TITLE
fix(domain): resolve serde deserialization errors for conversation loading

### DIFF
--- a/crates/forge_domain/src/agent.rs
+++ b/crates/forge_domain/src/agent.rs
@@ -173,60 +173,60 @@ pub struct Agent {
     pub id: AgentId,
 
     // The language model ID to be used by this agent
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub model: Option<ModelId>,
 
     // Human-readable description of the agent's purpose
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub description: Option<String>,
 
     // Template for the system prompt provided to the agent
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub system_prompt: Option<Template<SystemContext>>,
 
     // Template for the user prompt provided to the agent
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub user_prompt: Option<Template<EventContext>>,
 
     /// Suggests if the agent needs to maintain its state for the lifetime of
     /// the program.    
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub ephemeral: Option<bool>,
 
     /// Tools that the agent can use    
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub tools: Option<Vec<ToolName>>,
 
     // The transforms feature has been removed
     /// Used to specify the events the agent is interested in    
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = merge_subscription)]
     pub subscribe: Option<Vec<String>>,
 
     /// Maximum number of turns the agent can take    
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub max_turns: Option<u64>,
 
     /// Maximum depth to which the file walker should traverse for this agent
     /// If not provided, the maximum possible depth will be used
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub max_walker_depth: Option<usize>,
 
     /// Configuration for automatic context compaction
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub compact: Option<Compact>,
 
     /// A set of custom rules that the agent should follow
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[merge(strategy = crate::merge::option)]
     pub custom_rules: Option<String>,
 

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -107,15 +107,15 @@ pub enum Role {
 #[derive(Clone, Debug, Deserialize, Serialize, Setters, Default, PartialEq)]
 #[setters(into, strip_option)]
 pub struct Context {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub messages: Vec<ContextMessage>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<ToolDefinition>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<Temperature>,
 }
 

--- a/crates/forge_domain/src/conversation.rs
+++ b/crates/forge_domain/src/conversation.rs
@@ -42,6 +42,7 @@ pub struct Conversation {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentState {
     pub turn_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<Context>,
     /// holds the events that are waiting to be processed
     pub queue: VecDeque<Event>,

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -465,6 +465,23 @@ impl<F: API> UI<F> {
         self.handle_chat_stream(&mut stream).await
     }
 
+    /// Load a conversation from a dump file if specified in the CLI
+    async fn load_conversation(&mut self) -> Result<Option<ConversationId>> {
+        if let Some(ref path) = self.cli.conversation {
+            let conversation: Conversation =
+                serde_json::from_str(ForgeFS::read_to_string(path.as_os_str()).await?.as_str())
+                    .context("Failed to parse Conversation")?;
+
+            let conversation_id = conversation.id.clone();
+            self.state.conversation_id = Some(conversation_id.clone());
+            self.update_model(conversation.main_model()?);
+            self.api.upsert_conversation(conversation).await?;
+            Ok(Some(conversation_id))
+        } else {
+            Ok(None)
+        }
+    }
+
     async fn init_conversation(&mut self) -> Result<ConversationId> {
         match self.state.conversation_id {
             Some(ref id) => Ok(id.clone()),
@@ -473,16 +490,7 @@ impl<F: API> UI<F> {
                 let workflow = self.init_state().await?;
 
                 // We need to try and get the conversation ID first before fetching the model
-                if let Some(ref path) = self.cli.conversation {
-                    let conversation: Conversation = serde_json::from_str(
-                        ForgeFS::read_to_string(path.as_os_str()).await?.as_str(),
-                    )
-                    .context("Failed to parse Conversation")?;
-
-                    let conversation_id = conversation.id.clone();
-                    self.state.conversation_id = Some(conversation_id.clone());
-                    self.update_model(conversation.main_model()?);
-                    self.api.upsert_conversation(conversation).await?;
+                if let Some(conversation_id) = self.load_conversation().await? {
                     Ok(conversation_id)
                 } else {
                     let conversation = self.api.init_conversation(workflow).await?;
@@ -558,7 +566,12 @@ impl<F: API> UI<F> {
 
     /// Modified version of handle_dump that supports HTML format
     async fn on_dump(&mut self, format: Option<String>) -> Result<()> {
-        if let Some(conversation_id) = self.state.conversation_id.clone() {
+        if let Some(conversation_id) = self
+            .state
+            .conversation_id
+            .clone()
+            .or(self.load_conversation().await?)
+        {
             let conversation = self.api.conversation(&conversation_id).await?;
             if let Some(conversation) = conversation {
                 let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S");


### PR DESCRIPTION
## Summary

Fixes serde deserialization errors that occurred when loading previously saved conversations by adding missing `#[serde(default)]` attributes to optional fields across domain structures. This ensures backward compatibility when loading conversations that may be missing certain fields in their serialized format.

## Changes

### Core Fixes
- **Agent struct**: Added `#[serde(default)]` to all optional fields (model, description, system_prompt, user_prompt, ephemeral, tools, subscribe, max_turns, max_walker_depth, compact, custom_rules)
- **Context struct**: Added `#[serde(default)]` to optional collection and configuration fields (messages, tools, tool_choice, max_tokens, temperature)
- **AgentState struct**: Added `#[serde(default)]` to optional context field

## Problem Solved

- **Deserialization errors**: Fixed crashes when loading conversations with missing optional fields in their JSON representation
- **`/dump` command failures**: Resolved issues with the dump command when working with loaded conversations
- **Backward compatibility**: Ensured existing saved conversations can be loaded without errors

## Technical Details

The `#[serde(default)]` attribute ensures that when deserializing from JSON/YAML, if a field is missing, serde will use the field type's `Default` implementation instead of failing with a deserialization error. This is crucial for:

1. **Optional fields**: Fields wrapped in `Option<T>` will default to `None`
2. **Collections**: Empty `Vec` and similar collections will use their default empty state
3. **Configuration fields**: Missing configuration options will use sensible defaults

---

<img width="733" alt="image" src="https://github.com/user-attachments/assets/e85539c4-450d-48e0-8b4c-8f8db34f83e2" />