### PR TITLE
fix: standardize error output using eprintln instead of println

### DIFF
--- a/crates/forge_display/src/diff.rs
+++ b/crates/forge_display/src/diff.rs
@@ -71,7 +71,7 @@ mod tests {
         let old = "Hello World\nThis is a test\nThird line\nFourth line";
         let new = "Hello World\nThis is a modified test\nNew line\nFourth line";
         let diff = DiffFormat::format(old, new);
-        println!("\nColor Output Test:\n{diff}");
+        eprintln!("\nColor Output Test:\n{diff}");
     }
 
     #[test]

--- a/crates/forge_inte/tests/api_spec.rs
+++ b/crates/forge_inte/tests/api_spec.rs
@@ -78,7 +78,7 @@ impl Fixture {
             let response = self.get_model_response().await;
 
             if check_response(&response) {
-                println!(
+                eprintln!(
                     "[{}] Successfully checked response in {} attempts",
                     self.model,
                     attempt + 1
@@ -87,7 +87,7 @@ impl Fixture {
             }
 
             if attempt < MAX_RETRIES - 1 {
-                println!("[{}] Attempt {}/{}", self.model, attempt + 1, MAX_RETRIES);
+                eprintln!("[{}] Attempt {}/{}", self.model, attempt + 1, MAX_RETRIES);
             }
         }
         Err(format!(
@@ -103,7 +103,7 @@ macro_rules! generate_model_test {
         #[tokio::test]
         async fn test_find_cat_name() {
             if !should_run_api_tests() {
-                println!(
+                eprintln!(
                     "Skipping API test for {} as RUN_API_TESTS is not set to 'true'",
                     $model
                 );

--- a/crates/forge_main/src/input.rs
+++ b/crates/forge_main/src/input.rs
@@ -48,7 +48,7 @@ impl Console {
                     match self.command.parse(&text) {
                         Ok(command) => return Ok(command),
                         Err(e) => {
-                            println!("{}", TitleFormat::error(e.to_string()));
+                            eprintln!("{}", TitleFormat::error(e.to_string()));
                         }
                     }
                 }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -163,8 +163,7 @@ impl<F: API> UI<F> {
         match self.run_inner().await {
             Ok(_) => {}
             Err(error) => {
-                self.writeln(TitleFormat::error(format!("{error:?}")))
-                    .unwrap();
+                eprintln!("{}", TitleFormat::error(format!("{error:?}")));
             }
         }
     }
@@ -211,7 +210,8 @@ impl<F: API> UI<F> {
                             tokio::spawn(
                                 TRACKER.dispatch(forge_tracker::EventKind::Error(format!("{error:?}"))),
                             );
-                            self.writeln(TitleFormat::error(format!("{error:?}")))?;
+                            self.spinner.stop(None)?;
+                            eprintln!("{}", TitleFormat::error(format!("{error:?}")));
                         },
                     }
                 }

--- a/crates/forge_provider/src/forge_provider/provider.rs
+++ b/crates/forge_provider/src/forge_provider/provider.rs
@@ -129,10 +129,10 @@ impl ForgeProvider {
                             Some(Err(Error::InvalidStatusCode(status.as_u16())).with_context(
                                 || match body {
                                     Some(body) => {
-                                        format!("Invalid status code: {status} Reason: {body}")
+                                        format!("{status} Reason: {body}")
                                     }
                                     None => {
-                                        format!("Invalid status code: {status} Reason: [Unknown]")
+                                        format!("{status} Reason: [Unknown]")
                                     }
                                 },
                             ))

--- a/crates/forge_services/src/tools/fs/fs_read.rs
+++ b/crates/forge_services/src/tools/fs/fs_read.rs
@@ -256,11 +256,6 @@ mod test {
         // Read the file directly
         let content = tokio::fs::read_to_string(path).await.unwrap();
 
-        // Display a message - just for testing
-        let title = "Read";
-        let message = TitleFormat::debug(title).sub_title(path.display().to_string());
-        println!("{message}");
-
         // Assert the content matches
         assert_eq!(content, test_content);
     }
@@ -408,7 +403,6 @@ mod test {
                 if start_char == 0 && end_char == 0 {
                     // For probe requests (when end = start = 0), return info about a large file
                     // This will trigger the auto-limiting behavior
-                    println!("Probe request detected, returning large file info");
                     return Ok((
                         "".to_string(),
                         forge_fs::FileInfo::new(0, 0, 50_000), // Simulate a large file (50k chars)
@@ -416,7 +410,6 @@ mod test {
                 } else if start_char == 0 && end_char == 39999 {
                     // This is the expected auto-limit range that should be requested for large
                     // files
-                    println!("Auto-limit range request detected: 0-39999");
                     return Err(anyhow::anyhow!(
                         "Auto-limit detected: start={}, end={}",
                         start_char,
@@ -425,7 +418,6 @@ mod test {
                 }
 
                 // For any other range requests, return an identifying error
-                println!("Unexpected range request: {}-{}", start_char, end_char);
                 Err(anyhow::anyhow!(
                     "Unexpected range_read called with start={}, end={}",
                     start_char,
@@ -511,16 +503,11 @@ mod test {
         // to fail
         assert!(result.is_err());
 
-        // Print the error message for debugging purposes
-        let err_msg = result.unwrap_err().to_string();
-        println!("Error message: {err_msg}");
-
         // Verify that our auto-limit was applied (should be 0-39999)
         let range_call = tracking_infra.get_last_range_call();
         assert!(range_call.is_some(), "Range read should have been called");
 
         if let Some((start, end)) = range_call {
-            println!("Tracked range call: {start:?} to {end:?}");
             assert_eq!(start, Some(0), "Auto-limit should start at character 0");
             assert_eq!(
                 end,

--- a/crates/forge_services/src/tools/registry.rs
+++ b/crates/forge_services/src/tools/registry.rs
@@ -286,14 +286,14 @@ pub mod tests {
     fn test_tool_description_length() {
         const MAX_DESCRIPTION_LENGTH: usize = 1024;
 
-        println!("\nTool description lengths:");
+        eprintln!("\nTool description lengths:");
 
         let mut any_exceeded = false;
         let stub = Arc::new(stub());
         let registry = ToolRegistry::new(stub.clone());
         for tool in registry.tools() {
             let desc_len = tool.definition.description.len();
-            println!(
+            eprintln!(
                 "{:?}: {} chars {}",
                 tool.definition.name,
                 desc_len,


### PR DESCRIPTION
## Improved Error Handling and Console Output

This PR standardizes the application's error handling by replacing println with eprintln for error messages and logging information. This ensures all diagnostic output is properly directed to stderr, improving application output and log management.

- Streamlines console output by directing errors to stderr consistently
- Removes unnecessary debug output (particularly in fs_read tests)
- Simplifies error formatting in forge_provider module

These changes make the application's logging more consistent and follow Rust best practices for console output management.