### PR TITLE
fix: make name and command_or_url required in McpAddArgs

### DIFF
--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -106,10 +106,10 @@ pub struct McpAddArgs {
     pub env: Vec<String>,
 
     /// Name of the server
-    pub name: Option<String>,
+    pub name: String,
 
     /// URL or command for the MCP server
-    pub command_or_url: Option<String>,
+    pub command_or_url: String,
 
     /// Additional arguments to pass to the server
     #[arg(short = 'a', long = "args")]

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -230,18 +230,16 @@ impl<F: API> UI<F> {
         match subcommand {
             TopLevelCommand::Mcp(mcp_command) => match mcp_command.command {
                 McpCommand::Add(add) => {
-                    let name = add.name.context("Server name is required")?;
+                    let name = add.name;
                     let scope: Scope = add.scope.into();
                     // Create the appropriate server type based on transport
                     let server = match add.transport {
                         Transport::Stdio => McpServerConfig::new_stdio(
-                            add.command_or_url.clone().unwrap_or_default(),
+                            add.command_or_url.clone(),
                             add.args.clone(),
                             Some(parse_env(add.env.clone())),
                         ),
-                        Transport::Sse => {
-                            McpServerConfig::new_sse(add.command_or_url.clone().unwrap_or_default())
-                        }
+                        Transport::Sse => McpServerConfig::new_sse(add.command_or_url.clone()),
                     };
                     // Command/URL already set in the constructor
 


### PR DESCRIPTION
Change the type of name and command_or_url fields from Option<String> to String in McpAddArgs struct, removing unnecessary unwrap_or_default() calls and context checks in the UI implementation.