### PR TITLE
fix: handle UTF-8 character boundaries in SearchTerm processing (#888)

### DIFF
--- a/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_chinese.snap
+++ b/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_chinese.snap
@@ -1,0 +1,125 @@
+---
+source: crates/forge_main/src/completer/search_term.rs
+expression: results
+---
+[
+    TermSpec {
+        input: "@[你好 @世界 测试@",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            1,
+        ),
+        pos: 1,
+    },
+    TermSpec {
+        input: "@你[好 @世界 测试@",
+        output: Some(
+            "你",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            4,
+        ),
+        pos: 4,
+    },
+    TermSpec {
+        input: "@你好[ @世界 测试@",
+        output: Some(
+            "你好",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            7,
+        ),
+        pos: 7,
+    },
+    TermSpec {
+        input: "@你好 [@世界 测试@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 8,
+    },
+    TermSpec {
+        input: "@你好 @[世界 测试@",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            9,
+        ),
+        span_end: Some(
+            9,
+        ),
+        pos: 9,
+    },
+    TermSpec {
+        input: "@你好 @世[界 测试@",
+        output: Some(
+            "世",
+        ),
+        span_start: Some(
+            9,
+        ),
+        span_end: Some(
+            12,
+        ),
+        pos: 12,
+    },
+    TermSpec {
+        input: "@你好 @世界[ 测试@",
+        output: Some(
+            "世界",
+        ),
+        span_start: Some(
+            9,
+        ),
+        span_end: Some(
+            15,
+        ),
+        pos: 15,
+    },
+    TermSpec {
+        input: "@你好 @世界 [测试@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 16,
+    },
+    TermSpec {
+        input: "@你好 @世界 测[试@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 19,
+    },
+    TermSpec {
+        input: "@你好 @世界 测试[@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 22,
+    },
+    TermSpec {
+        input: "@你好 @世界 测试@[",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            23,
+        ),
+        span_end: Some(
+            23,
+        ),
+        pos: 23,
+    },
+]

--- a/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_chinese_with_spaces.snap
+++ b/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_chinese_with_spaces.snap
@@ -1,0 +1,92 @@
+---
+source: crates/forge_main/src/completer/search_term.rs
+expression: results
+---
+[
+    TermSpec {
+        input: "@[中 文 @测试",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            1,
+        ),
+        pos: 1,
+    },
+    TermSpec {
+        input: "@中[ 文 @测试",
+        output: Some(
+            "中",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            4,
+        ),
+        pos: 4,
+    },
+    TermSpec {
+        input: "@中 [文 @测试",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 5,
+    },
+    TermSpec {
+        input: "@中 文[ @测试",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 8,
+    },
+    TermSpec {
+        input: "@中 文 [@测试",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 9,
+    },
+    TermSpec {
+        input: "@中 文 @[测试",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            10,
+        ),
+        span_end: Some(
+            10,
+        ),
+        pos: 10,
+    },
+    TermSpec {
+        input: "@中 文 @测[试",
+        output: Some(
+            "测",
+        ),
+        span_start: Some(
+            10,
+        ),
+        span_end: Some(
+            13,
+        ),
+        pos: 13,
+    },
+    TermSpec {
+        input: "@中 文 @测试[",
+        output: Some(
+            "测试",
+        ),
+        span_start: Some(
+            10,
+        ),
+        span_end: Some(
+            16,
+        ),
+        pos: 16,
+    },
+]

--- a/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_emoji.snap
+++ b/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_emoji.snap
@@ -1,0 +1,120 @@
+---
+source: crates/forge_main/src/completer/search_term.rs
+expression: results
+---
+[
+    TermSpec {
+        input: "@[🚀 @🌟 emoji@",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            1,
+        ),
+        pos: 1,
+    },
+    TermSpec {
+        input: "@🚀[ @🌟 emoji@",
+        output: Some(
+            "🚀",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            5,
+        ),
+        pos: 5,
+    },
+    TermSpec {
+        input: "@🚀 [@🌟 emoji@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 6,
+    },
+    TermSpec {
+        input: "@🚀 @[🌟 emoji@",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            7,
+        ),
+        span_end: Some(
+            7,
+        ),
+        pos: 7,
+    },
+    TermSpec {
+        input: "@🚀 @🌟[ emoji@",
+        output: Some(
+            "🌟",
+        ),
+        span_start: Some(
+            7,
+        ),
+        span_end: Some(
+            11,
+        ),
+        pos: 11,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 [emoji@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 12,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 e[moji@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 13,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 em[oji@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 14,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 emo[ji@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 15,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 emoj[i@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 16,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 emoji[@",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 17,
+    },
+    TermSpec {
+        input: "@🚀 @🌟 emoji@[",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            18,
+        ),
+        span_end: Some(
+            18,
+        ),
+        pos: 18,
+    },
+]

--- a/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_mixed_chinese_english.snap
+++ b/crates/forge_main/src/completer/snapshots/forge_main__completer__search_term__tests__marker_based_search_mixed_chinese_english.snap
@@ -1,0 +1,204 @@
+---
+source: crates/forge_main/src/completer/search_term.rs
+expression: results
+---
+[
+    TermSpec {
+        input: "@[hello @世界 test@中文",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            1,
+        ),
+        pos: 1,
+    },
+    TermSpec {
+        input: "@h[ello @世界 test@中文",
+        output: Some(
+            "h",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            2,
+        ),
+        pos: 2,
+    },
+    TermSpec {
+        input: "@he[llo @世界 test@中文",
+        output: Some(
+            "he",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            3,
+        ),
+        pos: 3,
+    },
+    TermSpec {
+        input: "@hel[lo @世界 test@中文",
+        output: Some(
+            "hel",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            4,
+        ),
+        pos: 4,
+    },
+    TermSpec {
+        input: "@hell[o @世界 test@中文",
+        output: Some(
+            "hell",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            5,
+        ),
+        pos: 5,
+    },
+    TermSpec {
+        input: "@hello[ @世界 test@中文",
+        output: Some(
+            "hello",
+        ),
+        span_start: Some(
+            1,
+        ),
+        span_end: Some(
+            6,
+        ),
+        pos: 6,
+    },
+    TermSpec {
+        input: "@hello [@世界 test@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 7,
+    },
+    TermSpec {
+        input: "@hello @[世界 test@中文",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            8,
+        ),
+        span_end: Some(
+            8,
+        ),
+        pos: 8,
+    },
+    TermSpec {
+        input: "@hello @世[界 test@中文",
+        output: Some(
+            "世",
+        ),
+        span_start: Some(
+            8,
+        ),
+        span_end: Some(
+            11,
+        ),
+        pos: 11,
+    },
+    TermSpec {
+        input: "@hello @世界[ test@中文",
+        output: Some(
+            "世界",
+        ),
+        span_start: Some(
+            8,
+        ),
+        span_end: Some(
+            14,
+        ),
+        pos: 14,
+    },
+    TermSpec {
+        input: "@hello @世界 [test@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 15,
+    },
+    TermSpec {
+        input: "@hello @世界 t[est@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 16,
+    },
+    TermSpec {
+        input: "@hello @世界 te[st@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 17,
+    },
+    TermSpec {
+        input: "@hello @世界 tes[t@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 18,
+    },
+    TermSpec {
+        input: "@hello @世界 test[@中文",
+        output: None,
+        span_start: None,
+        span_end: None,
+        pos: 19,
+    },
+    TermSpec {
+        input: "@hello @世界 test@[中文",
+        output: Some(
+            "",
+        ),
+        span_start: Some(
+            20,
+        ),
+        span_end: Some(
+            20,
+        ),
+        pos: 20,
+    },
+    TermSpec {
+        input: "@hello @世界 test@中[文",
+        output: Some(
+            "中",
+        ),
+        span_start: Some(
+            20,
+        ),
+        span_end: Some(
+            23,
+        ),
+        pos: 23,
+    },
+    TermSpec {
+        input: "@hello @世界 test@中文[",
+        output: Some(
+            "中文",
+        ),
+        span_start: Some(
+            20,
+        ),
+        span_end: Some(
+            26,
+        ),
+        pos: 26,
+    },
+]


### PR DESCRIPTION
## Problem
The `SearchTerm::process()` method panics when processing input containing multi-byte UTF-8 characters (e.g., Chinese characters) due to incorrect string slicing at non-character boundaries.

**Error example:**

<img width="762" alt="Snipaste_2025-06-03_20-08-08" src="https://github.com/user-attachments/assets/b8c31ba6-4391-4119-86b3-7e53db5cef17" />

## Solution
- Properly use `char_indices()` for all string indexing operations
- Ensure string slicing only occurs at valid character boundaries
- Maintain correct mapping between character positions and byte indices

## Test Case

<img width="1065" alt="Snipaste_2025-06-03_21-18-59" src="https://github.com/user-attachments/assets/5866949c-a9fd-469f-ab36-567a770658ba" />


fixes #888 
This fix ensures the search term completer works correctly with international characters.