### PR TITLE
Refactor FSReadInput and FileInfo to use line-based ranges instead of character-based

### DIFF
--- a/crates/forge_domain/src/tool_input.rs
+++ b/crates/forge_domain/src/tool_input.rs
@@ -58,15 +58,15 @@ pub struct FSReadInput {
     /// The path of the file to read, always provide absolute paths.
     pub path: String,
 
-    /// Optional start position in characters (0-based). If provided, reading
-    /// will start from this character position.
+    /// Optional start line number (1-based). If provided, reading
+    /// will start from this line.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_char: Option<u64>,
+    pub start_line: Option<u64>,
 
-    /// Optional end position in characters (inclusive). If provided, reading
-    /// will end at this character position.
+    /// Optional end line number (inclusive). If provided, reading
+    /// will end at this line.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_char: Option<u64>,
+    pub end_line: Option<u64>,
     /// One sentence explanation as to why this tool is being used, and how it
     /// contributes to the goal.
     #[serde(default)]

--- a/crates/forge_fs/src/file_info.rs
+++ b/crates/forge_fs/src/file_info.rs
@@ -1,34 +1,34 @@
 /// Information about a file or file range read operation
 #[derive(Debug, Clone, PartialEq)]
 pub struct FileInfo {
-    /// Starting character position of the read operation
-    pub start_char: u64,
+    /// Starting line number of the read operation (1-based)
+    pub start_line: u64,
 
-    /// Ending character position of the read operation
-    pub end_char: u64,
+    /// Ending line number of the read operation (1-based, inclusive)
+    pub end_line: u64,
 
-    /// Total number of characters in the file
-    pub total_chars: u64,
+    /// Total number of lines in the file
+    pub total_lines: u64,
 }
 
 impl FileInfo {
     /// Creates a new FileInfo with the specified parameters
-    pub fn new(start_char: u64, end_char: u64, total_chars: u64) -> Self {
-        Self { start_char, end_char, total_chars }
+    pub fn new(start_line: u64, end_line: u64, total_lines: u64) -> Self {
+        Self { start_line, end_line, total_lines }
     }
 
     /// Returns true if this represents a partial file read
     pub fn is_partial(&self) -> bool {
-        self.start_char > 0 || self.end_char < self.total_chars
+        self.start_line > 1 || self.end_line < self.total_lines
     }
 
     /// Returns the percentage of the file that was read (0.0 to 1.0)
     pub fn percent_read(&self) -> f64 {
-        if self.total_chars == 0 {
+        if self.total_lines == 0 {
             return 0.0;
         }
 
-        let chars_read = self.end_char - self.start_char;
-        chars_read as f64 / self.total_chars as f64
+        let lines_read = self.end_line - self.start_line + 1;
+        lines_read as f64 / self.total_lines as f64
     }
 }

--- a/crates/forge_fs/src/read_range.rs
+++ b/crates/forge_fs/src/read_range.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -7,16 +6,18 @@ use crate::error::Error;
 use crate::file_info::FileInfo;
 
 impl crate::ForgeFS {
-    /// Reads a specific range of characters from a file.
+    /// Reads a specific range of lines from a file.
     ///
     /// Returns a tuple containing:
-    /// - The file content as a UTF-8 string.
-    /// - FileInfo containing metadata about the read operation including
-    ///   character positions.
-    pub async fn read_range_utf8<T: AsRef<Path>>(
+    /// - The file content as a UTF-8 string for the specified line range.
+    /// - FileInfo containing metadata about the read operation.
+    ///
+    /// Line numbers are 1-based. If start_line is None, defaults to line 1.
+    /// If end_line is None, defaults to the last line of the file.
+    pub async fn read_range_lines_utf8<T: AsRef<Path>>(
         path: T,
-        start_char: u64,
-        end_char: u64,
+        start_line: Option<u64>,
+        end_line: Option<u64>,
     ) -> Result<(String, FileInfo)> {
         let path_ref = path.as_ref();
 
@@ -36,53 +37,53 @@ impl crate::ForgeFS {
             .await
             .with_context(|| format!("Failed to read file content from {}", path_ref.display()))?;
 
-        let total_chars = content.chars().count() as u64;
+        let lines: Vec<&str> = content.lines().collect();
+        let total_lines = lines.len() as u64;
 
-        // Validate and normalize the character range
-        let (start_pos, end_pos) =
-            Self::validate_char_range_bounds(total_chars, start_char, end_char)?;
-        let info = FileInfo::new(start_pos, end_pos, total_chars);
-
-        // Return empty result for empty ranges
-        if start_pos == end_pos {
+        if total_lines == 0 {
+            let info = FileInfo::new(1, 1, 0);
             return Ok((String::new(), info));
         }
 
-        // Extract the requested character range
-        let result_content = if start_pos == 0 && end_pos == total_chars {
-            content // Return the full content if requesting the entire file
+        // Validate and normalize line numbers (1-based)
+        let actual_start_line = start_line.unwrap_or(1);
+        let actual_end_line = end_line.unwrap_or(total_lines);
+
+        // Validate the line range
+        Self::validate_line_range_bounds(total_lines, actual_start_line, actual_end_line)?;
+
+        // Extract the requested lines (convert to 0-based indexing)
+        let start_idx = (actual_start_line - 1) as usize;
+        let end_idx = actual_end_line as usize;
+
+        let result_content = if start_idx < lines.len() {
+            let end_idx = std::cmp::min(end_idx, lines.len());
+            lines[start_idx..end_idx].join("\n")
         } else {
-            content
-                .chars()
-                .skip(start_pos as usize)
-                .take((end_pos - start_pos) as usize)
-                .collect()
+            String::new()
         };
+
+        let info = FileInfo::new(actual_start_line, actual_end_line, total_lines);
 
         Ok((result_content, info))
     }
 
-    // Validate the requested range and ensure it falls within the file's character
-    // count
-    fn validate_char_range_bounds(
-        total_chars: u64,
-        start_pos: u64,
-        end_pos: u64,
-    ) -> Result<(u64, u64)> {
+    /// Validates the requested line range and ensures it falls within the
+    /// file's line count
+    fn validate_line_range_bounds(total_lines: u64, start_line: u64, end_line: u64) -> Result<()> {
         // Check if start is beyond file size
-        if start_pos > total_chars {
-            return Err(Error::StartBeyondFileSize { start: start_pos, total: total_chars }.into());
+        if start_line > total_lines && total_lines > 0 {
+            return Err(
+                Error::StartBeyondFileSize { start: start_line, total: total_lines }.into(),
+            );
         }
-
-        // Cap end position at file size
-        let end_pos = cmp::min(end_pos, total_chars);
 
         // Check if start is greater than end
-        if start_pos > end_pos {
-            return Err(Error::StartGreaterThanEnd { start: start_pos, end: end_pos }.into());
+        if start_line > end_line {
+            return Err(Error::StartGreaterThanEnd { start: start_line, end: end_line }.into());
         }
 
-        Ok((start_pos, end_pos))
+        Ok(())
     }
 }
 
@@ -100,62 +101,65 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_read_range_utf8() -> Result<()> {
-        let content = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    async fn test_read_range_lines_utf8() -> Result<()> {
+        let content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
         let file = create_test_file(content).await?;
 
-        // Test reading a range of characters
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 10, 20).await?;
-
-        assert_eq!(result, "ABCDEFGHIJ", "Range 10-20 should be ABCDEFGHIJ");
-        assert_eq!(info.start_char, 10);
-        assert_eq!(info.end_char, 20);
-        assert_eq!(info.total_chars, content.len() as u64);
-
-        // Test reading from start
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 0, 5).await?;
-
-        assert_eq!(result, "01234", "Range 0-5 should be 01234");
-        assert_eq!(info.start_char, 0);
-        assert_eq!(info.end_char, 5);
-
-        // Test reading to end
-        let total_chars = content.chars().count() as u64;
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 50, total_chars).await?;
+        // Test reading a range of lines
+        let (result, info) =
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(2), Some(4)).await?;
 
         assert_eq!(
-            result, "opqrstuvwxyz",
-            "Range 50-end should be opqrstuvwxyz"
+            result, "Line 2\nLine 3\nLine 4",
+            "Lines 2-4 should be returned"
         );
-        assert_eq!(info.start_char, 50);
-        assert_eq!(info.end_char, info.total_chars);
+        assert_eq!(info.start_line, 2);
+        assert_eq!(info.end_line, 4);
+        assert_eq!(info.total_lines, 5);
+
+        // Test reading from start
+        let (result, info) =
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(1), Some(2)).await?;
+
+        assert_eq!(result, "Line 1\nLine 2", "Lines 1-2 should be returned");
+        assert_eq!(info.start_line, 1);
+        assert_eq!(info.end_line, 2);
+
+        // Test reading to end
+        let (result, info) =
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(4), None).await?;
+
+        assert_eq!(result, "Line 4\nLine 5", "Lines 4-end should be returned");
+        assert_eq!(info.start_line, 4);
+        assert_eq!(info.end_line, 5);
 
         // Test reading entire file
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 0, total_chars).await?;
+        let (result, info) = crate::ForgeFS::read_range_lines_utf8(file.path(), None, None).await?;
 
         assert_eq!(
             result, content,
             "Reading entire file should match original content"
         );
-        assert_eq!(info.start_char, 0);
-        assert_eq!(info.end_char, info.total_chars);
+        assert_eq!(info.start_line, 1);
+        assert_eq!(info.end_line, 5);
 
-        // Test empty range
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 10, 10).await?;
+        // Test single line
+        let (result, info) =
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(3), Some(3)).await?;
 
-        assert_eq!(result, "", "Empty range should return empty string");
-        assert_eq!(info.start_char, 10);
-        assert_eq!(info.end_char, 10);
+        assert_eq!(result, "Line 3", "Single line should be returned");
+        assert_eq!(info.start_line, 3);
+        assert_eq!(info.end_line, 3);
 
         // Test invalid ranges
         assert!(
-            crate::ForgeFS::read_range_utf8(file.path(), 20, 10)
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(4), Some(2))
                 .await
                 .is_err(),
             "Start > end should error"
         );
         assert!(
-            crate::ForgeFS::read_range_utf8(file.path(), 1000, total_chars)
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(10), Some(12))
                 .await
                 .is_err(),
             "Start beyond file size should error"
@@ -165,20 +169,51 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_utf8_boundary_handling() -> Result<()> {
-        let content = "Hello 世界! こんにちは! Привет!";
+    async fn test_empty_file() -> Result<()> {
+        let content = "";
+        let file = create_test_file(content).await?;
+
+        let (result, info) = crate::ForgeFS::read_range_lines_utf8(file.path(), None, None).await?;
+
+        assert_eq!(result, "", "Empty file should return empty string");
+        assert_eq!(info.start_line, 1);
+        assert_eq!(info.end_line, 1);
+        assert_eq!(info.total_lines, 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_single_line_file() -> Result<()> {
+        let content = "Single line without newline";
+        let file = create_test_file(content).await?;
+
+        let (result, info) = crate::ForgeFS::read_range_lines_utf8(file.path(), None, None).await?;
+
+        assert_eq!(result, content, "Single line file should return the line");
+        assert_eq!(info.start_line, 1);
+        assert_eq!(info.end_line, 1);
+        assert_eq!(info.total_lines, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_utf8_content() -> Result<()> {
+        let content = "Hello 世界!\nこんにちは!\nПривет!";
         let file = create_test_file(content).await?;
 
         // Test reading a range that includes multi-byte characters
-        let (result, info) = crate::ForgeFS::read_range_utf8(file.path(), 6, 8).await?;
+        let (result, info) =
+            crate::ForgeFS::read_range_lines_utf8(file.path(), Some(1), Some(2)).await?;
 
-        // Character-based indexing should handle multi-byte characters correctly
         assert_eq!(
-            result, "世界",
-            "Should read exactly the multi-byte characters"
+            result, "Hello 世界!\nこんにちは!",
+            "Should handle UTF-8 correctly"
         );
-        assert_eq!(info.start_char, 6);
-        assert_eq!(info.end_char, 8);
+        assert_eq!(info.start_line, 1);
+        assert_eq!(info.end_line, 2);
+        assert_eq!(info.total_lines, 3);
 
         Ok(())
     }

--- a/crates/forge_infra/src/fs_read.rs
+++ b/crates/forge_infra/src/fs_read.rs
@@ -27,12 +27,12 @@ impl FsReadService for ForgeFileReadService {
         forge_fs::ForgeFS::read(path).await
     }
 
-    async fn range_read_utf8(
+    async fn range_read_lines_utf8(
         &self,
         path: &Path,
-        start_char: u64,
-        end_char: u64,
+        start_line: Option<u64>,
+        end_line: Option<u64>,
     ) -> Result<(String, forge_fs::FileInfo)> {
-        forge_fs::ForgeFS::read_range_utf8(path, start_char, end_char).await
+        forge_fs::ForgeFS::read_range_lines_utf8(path, start_line, end_line).await
     }
 }

--- a/crates/forge_services/src/infra.rs
+++ b/crates/forge_services/src/infra.rs
@@ -22,26 +22,24 @@ pub trait FsReadService: Send + Sync {
     /// Returns the file content as raw bytes.
     async fn read(&self, path: &Path) -> anyhow::Result<Vec<u8>>;
 
-    /// Reads a specific character range from a file at the specified path.
-    /// Returns the file content within the range as a UTF-8 string along with
-    /// metadata.
+    /// Reads a specific line range from a file at the specified path.
+    /// Returns the file content within the line range as a UTF-8 string along
+    /// with metadata.
     ///
-    /// - start_char specifies the starting character position (0-based,
-    ///   inclusive).
-    /// - end_char specifies the ending character position (inclusive).
-    /// - Both start_char and end_char are inclusive bounds.
+    /// - start_line specifies the starting line number (1-based, inclusive).
+    /// - end_line specifies the ending line number (inclusive).
     /// - Binary files are automatically detected and rejected.
     ///
     /// Returns a tuple containing the file content and FileInfo with metadata
     /// about the read operation:
-    /// - FileInfo.start_char: starting character position
-    /// - FileInfo.end_char: ending character position
-    /// - FileInfo.total_chars: total character count in file
-    async fn range_read_utf8(
+    /// - FileInfo.start_line: starting line number
+    /// - FileInfo.end_line: ending line number
+    /// - FileInfo.total_lines: total line count in file
+    async fn range_read_lines_utf8(
         &self,
         path: &Path,
-        start_char: u64,
-        end_char: u64,
+        start_line: Option<u64>,
+        end_line: Option<u64>,
     ) -> anyhow::Result<(String, forge_fs::FileInfo)>;
 }
 

--- a/crates/forge_services/src/tools/fetch.rs
+++ b/crates/forge_services/src/tools/fetch.rs
@@ -171,7 +171,6 @@ impl<F: Infrastructure> ExecutableTool for Fetch<F> {
         // Build metadata with all required fields in a single fluent chain
         let metadata = Metadata::default()
             .add("URL", url)
-            .add("total_chars", original_length)
             .add("start_char", "0")
             .add("end_char", end.to_string())
             .add("context", prefix)

--- a/crates/forge_services/src/tools/fs/fs_find.rs
+++ b/crates/forge_services/src/tools/fs/fs_find.rs
@@ -219,7 +219,6 @@ impl<F: Infrastructure> FSFind<F> {
             .add("path", input.path)
             .add_optional("regex", input.regex)
             .add_optional("file_pattern", input.file_pattern)
-            .add("total_chars", matches.len())
             .add("start_char", 0);
 
         let truncated_result = Clipper::from_start(max_char_limit).clip(&matches);

--- a/crates/forge_services/src/tools/fs/fs_write.rs
+++ b/crates/forge_services/src/tools/fs/fs_write.rs
@@ -114,7 +114,7 @@ impl<F: Infrastructure> ExecutableTool for FSWrite<F> {
         } else {
             writeln!(result, "operation: CREATE")?;
         }
-        writeln!(result, "total_chars: {}", input.content.len())?;
+
         if let Some(warning) = syntax_warning {
             writeln!(result, "Warning: {}", &warning.to_string())?;
         }

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_deep_directory_creation.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_deep_directory_creation.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/level1/level2/level3/deep.txt
 operation: CREATE
-total_chars: 31
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_invalid_rust.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_invalid_rust.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_output
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/test.rs
 operation: CREATE
-total_chars: 20
 Warning: Syntax error found in file with extension rs. Hint: Please retry in raw mode without HTML-encoding angle brackets.
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_single_directory_creation.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_single_directory_creation.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/new_dir/test.txt
 operation: CREATE
-total_chars: 23
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_success.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_success.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_output
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/test.txt
 operation: CREATE
-total_chars: 13
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_valid_rust.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_valid_rust.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_output
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/test.rs
 operation: CREATE
-total_chars: 25
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_with_different_separators.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_with_different_separators.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/dir_a/dir_b/file.txt
 operation: CREATE
-total_chars: 23
 ---

--- a/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_with_overwrite.snap
+++ b/crates/forge_services/src/tools/fs/snapshots/forge_services__tools__fs__fs_write__test__fs_write_with_overwrite.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/forge_services/src/tools/fs/fs_write.rs
 expression: normalized_msg
+snapshot_kind: text
 ---
 ---
 path: [TEMP_DIR]/test_overwrite.txt
 operation: OVERWRITE
-total_chars: 11
 ---
 1        |-Original content
     1    |+New content

--- a/crates/forge_services/src/tools/patch.rs
+++ b/crates/forge_services/src/tools/patch.rs
@@ -249,7 +249,6 @@ impl<F: Infrastructure> ExecutableTool for ApplyPatchJson<F> {
 
         writeln!(result, "---")?;
         writeln!(result, "path: {}", path.display())?;
-        writeln!(result, "total_chars: {}", current_content.len())?;
 
         // Check for syntax errors
         if let Some(warning) = syn::validate(path, &current_content).map(|e| e.to_string()) {

--- a/crates/forge_services/src/tools/registry.rs
+++ b/crates/forge_services/src/tools/registry.rs
@@ -105,11 +105,11 @@ pub mod tests {
             unimplemented!()
         }
 
-        async fn range_read_utf8(
+        async fn range_read_lines_utf8(
             &self,
             _path: &Path,
-            _start_char: u64,
-            _end_char: u64,
+            _start_line: Option<u64>,
+            _end_line: Option<u64>,
         ) -> anyhow::Result<(String, forge_fs::FileInfo)> {
             unimplemented!()
         }

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_html_content.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_html_content.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/forge_services/src/tools/fetch.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 URL: http://127.0.0.1:PORT/test.html
-total_chars: 37
 start_char: 0
 end_char: 37
 context: 

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_large_content_minimal.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_large_content_minimal.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/forge_services/src/tools/fetch.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 URL: http://127.0.0.1:PORT/large.txt
-total_chars: 102
 start_char: 0
 end_char: 102
 context: Content type text/plain cannot be simplified to markdown; Raw content provided instead

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_raw_content.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__fetch__tests__fetch_raw_content.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/forge_services/src/tools/fetch.rs
 expression: normalized_result
+snapshot_kind: text
 ---
 ---
 URL: http://127.0.0.1:PORT/test.txt
-total_chars: 24
 start_char: 0
 end_char: 24
 context: Content type text/plain cannot be simplified to markdown; Raw content provided instead


### PR DESCRIPTION
- Updated FSReadInput struct to replace start_char and end_char with start_line and end_line.
- Modified FileInfo struct to reflect line-based metadata, including start_line, end_line, and total_lines.
- Refactored read_range_utf8 function to read lines instead of characters, adjusting validation and extraction logic accordingly.
- Updated tests to validate line-based reading functionality and ensure correct behavior with various line ranges.
- Adjusted FsReadService trait and its implementations to support line-based reading.
- Removed character-related metadata from various output formats and snapshots.
