### PR TITLE
refactor: use XML to format tool output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "forge_display",
  "forge_domain",
  "forge_stream",
+ "forge_template",
  "forge_walker",
  "futures",
  "handlebars",

--- a/crates/forge_app/Cargo.toml
+++ b/crates/forge_app/Cargo.toml
@@ -26,6 +26,7 @@ console.workspace = true
 derive_more.workspace = true
 tempfile.workspace = true
 strum.workspace = true
+forge_template.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -49,9 +49,9 @@ impl ExecutionResult {
             (Tools::ForgeToolFsCreate(input), ExecutionResult::FsCreate(output)) => {
                 let mut elm = if let Some(before) = output.previous {
                     let diff = forge_display::DiffFormat::format(&before, &input.content);
-                    Element::new("file_diff").text(diff)
+                    Element::new("file_diff").cdata(diff)
                 } else {
-                    Element::new("file_content").text(&input.content)
+                    Element::new("file_content").cdata(&input.content)
                 };
 
                 elm = elm

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -35,22 +35,17 @@ impl ExecutionResult {
         match self {
             ExecutionResult::FsRead(out) => {
                 if let Some(Tools::ForgeToolFsRead(input)) = input {
-                    let is_explicit_range = input.start_line.is_some() | input.end_line.is_some();
-                    let is_range_relevant = is_explicit_range || truncation_path.is_some();
-
-                    let mut metadata = FrontMatter::default().add("path", input.path);
-
-                    if is_range_relevant {
-                        metadata = metadata
-                            .add("start_line", out.start_line)
-                            .add("end_line", out.end_line)
-                            .add("total_lines", out.total_lines);
-                    }
-
                     match &out.content {
-                        Content::File(content) => Ok(forge_domain::ToolOutput::text(format!(
-                            "{metadata}{content}"
-                        ))),
+                        Content::File(content) => {
+                            let start = out.start_line;
+                            let end = out.end_line;
+                            let total = out.total_lines;
+
+                            let tool = format!(
+                                r#"<file lines="{start}-{end}" total-lines="{total}">{content}</file>"#
+                            );
+                            Ok(forge_domain::ToolOutput::text(tool))
+                        }
                     }
                 } else {
                     unreachable!()

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -41,7 +41,7 @@ impl ExecutionResult {
                         .attr("start-line", out.start_line)
                         .attr("end-line", out.end_line)
                         .attr("total-lines", content.lines().count())
-                        .text(content);
+                        .cdata(content);
 
                     Ok(forge_domain::ToolOutput::text(elm))
                 }
@@ -59,7 +59,7 @@ impl ExecutionResult {
                     .attr("total-lines", input.content.lines().count());
 
                 if let Some(warning) = output.warning {
-                    elm = elm.append(Element::new("warning").text(warning));
+                    elm = elm.append(Element::new("warning").cdata(warning));
                 }
 
                 Ok(forge_domain::ToolOutput::text(elm))
@@ -375,6 +375,29 @@ mod tests {
             start_line: 1,
             end_line: 2,
             total_lines: 2,
+        });
+
+        let input = Tools::ForgeToolFsRead(FSRead {
+            path: "/home/user/test.txt".to_string(),
+            start_line: None,
+            end_line: None,
+            explanation: Some("Test explanation".to_string()),
+        });
+
+        let env = fixture_environment();
+
+        let actual = fixture.into_tool_output(input, None, &env).unwrap();
+
+        insta::assert_snapshot!(to_value(actual));
+    }
+
+      #[test]
+    fn test_fs_read_basic_special_chars() {
+        let fixture = ExecutionResult::FsRead(ReadOutput {
+            content: Content::File("struct Foo<T>{ name: T }".to_string()),
+            start_line: 1,
+            end_line: 1,
+            total_lines: 1,
         });
 
         let input = Tools::ForgeToolFsRead(FSRead {

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -66,15 +66,17 @@ impl ExecutionResult {
             }
             (Tools::ForgeToolFsRemove(input), ExecutionResult::FsRemove(output)) => {
                 let display_path = display_path(env, Path::new(&input.path))?;
-                if output.completed {
-                    Ok(forge_domain::ToolOutput::text(format!(
-                        "Successfully removed file: {display_path}"
-                    )))
+                let elm = if output.completed {
+                    Element::new("file_removed")
+                        .attr("path", display_path)
+                        .attr("status", "success")
                 } else {
-                    Ok(forge_domain::ToolOutput::text(format!(
-                        "File not found or already removed: {display_path}"
-                    )))
-                }
+                    Element::new("file_removed")
+                        .attr("path", display_path)
+                        .attr("status", "not_found")
+                };
+
+                Ok(forge_domain::ToolOutput::text(elm))
             }
             (Tools::ForgeToolFsSearch(input), ExecutionResult::FsSearch(output)) => {
                 match output {

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -391,7 +391,7 @@ mod tests {
         insta::assert_snapshot!(to_value(actual));
     }
 
-      #[test]
+    #[test]
     fn test_fs_read_basic_special_chars() {
         let fixture = ExecutionResult::FsRead(ReadOutput {
             content: Content::File("struct Foo<T>{ name: T }".to_string()),

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use forge_display::DiffFormat;
 use forge_domain::{Environment, Tools};
+use forge_template::Element;
 
 use crate::front_matter::FrontMatter;
 use crate::truncation::FETCH_MAX_LENGTH;
@@ -37,14 +38,14 @@ impl ExecutionResult {
                 if let Some(Tools::ForgeToolFsRead(input)) = input {
                     match &out.content {
                         Content::File(content) => {
-                            let start = out.start_line;
-                            let end = out.end_line;
-                            let total = out.total_lines;
+                            let elm = Element::new("file_content")
+                                .attr("path", input.path)
+                                .attr("start-line", out.start_line)
+                                .attr("end-line", out.end_line)
+                                .attr("total-lines", content.lines().count())
+                                .text(content);
 
-                            let tool = format!(
-                                r#"<file lines="{start}-{end}" total-lines="{total}">{content}</file>"#
-                            );
-                            Ok(forge_domain::ToolOutput::text(tool))
+                            Ok(forge_domain::ToolOutput::text(elm))
                         }
                     }
                 } else {

--- a/crates/forge_app/src/execution_result.rs
+++ b/crates/forge_app/src/execution_result.rs
@@ -59,7 +59,7 @@ impl ExecutionResult {
                     .attr("total-lines", input.content.lines().count());
 
                 if let Some(warning) = output.warning {
-                    elm = elm.append(Element::new("warning").cdata(warning));
+                    elm = elm.append(Element::new("warning").text(warning));
                 }
 
                 Ok(forge_domain::ToolOutput::text(elm))

--- a/crates/forge_app/src/services.rs
+++ b/crates/forge_app/src/services.rs
@@ -59,15 +59,9 @@ pub struct FsRemoveOutput {
 }
 
 #[derive(Debug, derive_more::From)]
-pub struct FsUndoOutput(String);
-
-impl FsUndoOutput {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-    pub fn into_inner(self) -> String {
-        self.0
-    }
+pub struct FsUndoOutput {
+    pub before_undo: String,
+    pub after_undo: String,
 }
 
 #[async_trait::async_trait]

--- a/crates/forge_app/src/services.rs
+++ b/crates/forge_app/src/services.rs
@@ -7,17 +7,20 @@ use forge_domain::{
     ToolCallContext, ToolCallFull, ToolDefinition, ToolName, ToolResult, Workflow,
 };
 
+#[derive(Debug)]
 pub struct ShellOutput {
     pub output: CommandOutput,
     pub shell: String,
 }
 
+#[derive(Debug)]
 pub struct PatchOutput {
     pub warning: Option<String>,
     pub before: String,
     pub after: String,
 }
 
+#[derive(Debug)]
 pub struct ReadOutput {
     pub content: Content,
     pub start_line: u64,
@@ -25,20 +28,24 @@ pub struct ReadOutput {
     pub total_lines: u64,
 }
 
+#[derive(Debug)]
 pub enum Content {
     File(String),
 }
 
+#[derive(Debug)]
 pub struct SearchResult {
     pub matches: Vec<String>,
 }
 
+#[derive(Debug)]
 pub struct FetchOutput {
     pub content: String,
     pub code: u16,
     pub context: String,
 }
 
+#[derive(Debug)]
 pub struct FsCreateOutput {
     pub path: String,
     // Set when the file already exists
@@ -46,11 +53,12 @@ pub struct FsCreateOutput {
     pub warning: Option<String>,
 }
 
+#[derive(Debug)]
 pub struct FsRemoveOutput {
     pub completed: bool,
 }
 
-#[derive(derive_more::From)]
+#[derive(Debug, derive_more::From)]
 pub struct FsUndoOutput(String);
 
 impl FsUndoOutput {

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__follow_up_no_question.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__follow_up_no_question.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-User interrupted the selection
+<interrupted>No feedback provided</interrupted>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__follow_up_with_question.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__follow_up_with_question.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-Which file would you like to edit?
+<feedback>Which file would you like to edit?</feedback>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/new_file.txt" total-lines="1">Hello, world!</file_content>
+<file_content path="/home/user/new_file.txt" total-lines="1"><![CDATA[Hello, world!]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/new_file.txt" total-lines="1"><![CDATA[Hello, world!]]></file_content>
+<file_content path="/home/user/new_file.txt" total_lines="1"><![CDATA[Hello, world!]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_basic.snap
@@ -2,8 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/new_file.txt
-operation: CREATE
-total_chars: 13
----
+<file_content path="/home/user/new_file.txt" total-lines="1">Hello, world!</file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
@@ -2,6 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_diff path="/home/user/existing_file.txt" total-lines="1">1        |-Old content
+<file_diff path="/home/user/existing_file.txt" total-lines="1"><![CDATA[1        |-Old content
     1    |+New content for the file
-</file_diff>
+]]></file_diff>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
@@ -2,6 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_diff path="/home/user/existing_file.txt" total-lines="1"><![CDATA[1        |-Old content
+<file_diff path="/home/user/existing_file.txt" total_lines="1"><![CDATA[1        |-Old content
     1    |+New content for the file
 ]]></file_diff>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_overwrite.snap
@@ -2,8 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/existing_file.txt
-operation: OVERWRITE
-total_chars: 24
----
+<file_diff path="/home/user/existing_file.txt" total-lines="1">1        |-Old content
+    1    |+New content for the file
+</file_diff>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
@@ -2,9 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/file_with_warning.txt
-operation: CREATE
-total_chars: 20
-Warning: File created in non-standard location
----
+<file_content path="/home/user/file_with_warning.txt" total-lines="1">Content with warning<warning>File created in non-standard location</warning></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/file_with_warning.txt" total-lines="1">Content with warning<warning>File created in non-standard location</warning></file_content>
+<file_content path="/home/user/file_with_warning.txt" total-lines="1">Content with warning<warning><![CDATA[File created in non-standard location]]></warning></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/file_with_warning.txt" total-lines="1"><![CDATA[Content with warning]]><warning>File created in non-standard location</warning></file_content>
+<file_content path="/home/user/file_with_warning.txt" total_lines="1"><![CDATA[Content with warning]]><warning>File created in non-standard location</warning></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_create_with_warning.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/file_with_warning.txt" total-lines="1">Content with warning<warning><![CDATA[File created in non-standard location]]></warning></file_content>
+<file_content path="/home/user/file_with_warning.txt" total-lines="1"><![CDATA[Content with warning]]><warning>File created in non-standard location</warning></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_patch_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_patch_basic.snap
@@ -2,10 +2,7 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/test.txt
-total_chars: 29
----
-1        |-Hello world
+<file_diff path="/home/user/test.txt" total_lines="2"><![CDATA[1        |-Hello world
     1    |+Hello universe
 2   2    | This is a test
+]]></file_diff>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_patch_with_warning.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_patch_with_warning.snap
@@ -2,11 +2,7 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/large_file.txt
-total_chars: 20
-warning: Large file modification
----
-1   1    | line1
+<file_diff path="/home/user/large_file.txt" total_lines="3"><![CDATA[1   1    | line1
     2    |+new line
 2   3    | line2
+]]><warning>Large file modification</warning></file_diff>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
@@ -2,5 +2,5 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/test.txt" start-line="1" end-line="2" total-lines="2"><![CDATA[Hello, world!
+<file_content path="/home/user/test.txt" start_line="1" end_line="2" total_lines="2"><![CDATA[Hello, world!
 This is a test file.]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
@@ -2,5 +2,5 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/test.txt" start-line="1" end-line="2" total-lines="2">Hello, world!
-This is a test file.</file_content>
+<file_content path="/home/user/test.txt" start-line="1" end-line="2" total-lines="2"><![CDATA[Hello, world!
+This is a test file.]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
@@ -2,8 +2,5 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/test.txt
----
-Hello, world!
-This is a test file.
+<file lines="1-2" total-lines="2">Hello, world!
+This is a test file.</file>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic.snap
@@ -2,5 +2,5 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file lines="1-2" total-lines="2">Hello, world!
-This is a test file.</file>
+<file_content path="/home/user/test.txt" start-line="1" end-line="2" total-lines="2">Hello, world!
+This is a test file.</file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic_special_chars.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic_special_chars.snap
@@ -1,0 +1,5 @@
+---
+source: crates/forge_app/src/execution_result.rs
+expression: to_value(actual)
+---
+<file_content path="/home/user/test.txt" start-line="1" end-line="1" total-lines="1"><![CDATA[struct Foo<T>{ name: T }]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic_special_chars.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_basic_special_chars.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/test.txt" start-line="1" end-line="1" total-lines="1"><![CDATA[struct Foo<T>{ name: T }]]></file_content>
+<file_content path="/home/user/test.txt" start_line="1" end_line="1" total_lines="1"><![CDATA[struct Foo<T>{ name: T }]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
@@ -2,6 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file lines="2-3" total-lines="5">Line 1
+<file_content path="/home/user/test.txt" start-line="2" end-line="3" total-lines="3">Line 1
 Line 2
-Line 3</file>
+Line 3</file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
@@ -2,12 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/test.txt
-start_line: 2
-end_line: 3
-total_lines: 5
----
-Line 1
+<file lines="2-3" total-lines="5">Line 1
 Line 2
-Line 3
+Line 3</file>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
@@ -2,6 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/test.txt" start-line="2" end-line="3" total-lines="3"><![CDATA[Line 1
+<file_content path="/home/user/test.txt" start_line="2" end_line="3" total_lines="3"><![CDATA[Line 1
 Line 2
 Line 3]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_explicit_range.snap
@@ -2,6 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/test.txt" start-line="2" end-line="3" total-lines="3">Line 1
+<file_content path="/home/user/test.txt" start-line="2" end-line="3" total-lines="3"><![CDATA[Line 1
 Line 2
-Line 3</file_content>
+Line 3]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/large_file.txt" start-line="1" end-line="100" total-lines="1"><![CDATA[Truncated content]]></file_content>
+<file_content path="/home/user/large_file.txt" start_line="1" end_line="100" total_lines="1"><![CDATA[Truncated content]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file lines="1-100" total-lines="200">Truncated content</file>
+<file_content path="/home/user/large_file.txt" start-line="1" end-line="100" total-lines="1">Truncated content</file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-<file_content path="/home/user/large_file.txt" start-line="1" end-line="100" total-lines="1">Truncated content</file_content>
+<file_content path="/home/user/large_file.txt" start-line="1" end-line="100" total-lines="1"><![CDATA[Truncated content]]></file_content>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_read_with_truncation_path.snap
@@ -2,10 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
----
-path: /home/user/large_file.txt
-start_line: 1
-end_line: 100
-total_lines: 200
----
-Truncated content
+<file lines="1-100" total-lines="200">Truncated content</file>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_remove_not_found.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_remove_not_found.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-File not found or already removed: /home/user/nonexistent_file.txt
+<file_removed path="/home/user/nonexistent_file.txt" status="not_found"></file_removed>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_remove_success.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_remove_success.snap
@@ -2,4 +2,4 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-Successfully removed file: /home/user/file_to_delete.txt
+<file_removed path="/home/user/file_to_delete.txt" status="success"></file_removed>

--- a/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_undo_success.snap
+++ b/crates/forge_app/src/snapshots/forge_app__execution_result__tests__fs_undo_success.snap
@@ -2,4 +2,6 @@
 source: crates/forge_app/src/execution_result.rs
 expression: to_value(actual)
 ---
-Successfully undid last operation on path: File reverted successfully
+<file_diff path="/home/user/test.txt" status="restored"><![CDATA[1        |-ABC
+    1    |+PQR
+]]></file_diff>

--- a/crates/forge_app/src/tool_registry.rs
+++ b/crates/forge_app/src/tool_registry.rs
@@ -177,7 +177,7 @@ impl<S: Services> ToolRegistry<S> {
         let truncation_path = out.to_create_temp(self.services.as_ref()).await?;
         let env = self.services.environment_service().get_environment();
 
-        out.into_tool_output(Some(tool_input), truncation_path, &env)
+        out.into_tool_output(tool_input, truncation_path, &env)
     }
 
     async fn call_mcp_tool(

--- a/crates/forge_app/src/tool_registry.rs
+++ b/crates/forge_app/src/tool_registry.rs
@@ -457,7 +457,7 @@ async fn send_read_context(
     // Add range info if relevant
     if is_range_relevant {
         // Add range info for explicit ranges or truncated files
-        subtitle.push_str(&format!(" ({range_info})"));
+        subtitle.push_str(&format!(" [{range_info}]"));
     }
     let message = TitleFormat::debug(title).sub_title(subtitle);
     ctx.send_text(message).await?;

--- a/crates/forge_domain/src/shell.rs
+++ b/crates/forge_domain/src/shell.rs
@@ -1,4 +1,5 @@
 /// Output from a command execution
+#[derive(Debug)]
 pub struct CommandOutput {
     pub command: String,
     pub stdout: String,

--- a/crates/forge_domain/src/tool_result.rs
+++ b/crates/forge_domain/src/tool_result.rs
@@ -66,10 +66,10 @@ pub struct ToolOutput {
 }
 
 impl ToolOutput {
-    pub fn text(tool: String) -> Self {
+    pub fn text(tool: impl ToString) -> Self {
         ToolOutput {
             is_error: Default::default(),
-            values: vec![ToolValue::Text(tool)],
+            values: vec![ToolValue::Text(tool.to_string())],
         }
     }
 

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_asymmetric_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_asymmetric_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: asymmetric truncation test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_boundary_no_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_boundary_no_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: boundary truncation test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_large_content_with_temp_file.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_large_content_with_temp_file.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: large content generation

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_mixed_content_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_mixed_content_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: mixed content test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_multiline_line_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_multiline_line_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: generate many lines

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_single_line_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_single_line_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: single line truncation test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_stderr_only_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_stderr_only_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: stderr truncation test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_stdout_only_truncation.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__format_output_stdout_only_truncation.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&actual)"
-snapshot_kind: text
 ---
 ---
 command: stdout truncation test

--- a/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__test_shell_pwd.snap
+++ b/crates/forge_services/src/tools/snapshots/forge_services__tools__shell__tests__test_shell_pwd.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/forge_services/src/tools/shell.rs
 expression: "TempDir::normalize(&result.into_string())"
-snapshot_kind: text
 ---
 ---
 command: pwd

--- a/crates/forge_template/src/element.rs
+++ b/crates/forge_template/src/element.rs
@@ -37,6 +37,11 @@ impl Element {
         self
     }
 
+    pub fn cdata(mut self, text: impl ToString) -> Self {
+        self.text = Some(format!("<![CDATA[{}]]>", text.to_string()));
+        self
+    }
+
     pub fn attr(mut self, key: impl ToString, value: impl ToString) -> Self {
         self.attr.push((key.to_string(), value.to_string()));
         self

--- a/crates/forge_template/src/element.rs
+++ b/crates/forge_template/src/element.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 pub struct Element {
     pub name: String,
     pub attr: Vec<(String, String)>,
@@ -102,9 +104,9 @@ where
     }
 }
 
-impl ToString for Element {
-    fn to_string(&self) -> String {
-        self.render()
+impl Display for Element {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.render())
     }
 }
 

--- a/crates/forge_template/src/element.rs
+++ b/crates/forge_template/src/element.rs
@@ -102,6 +102,12 @@ where
     }
 }
 
+impl ToString for Element {
+    fn to_string(&self) -> String {
+        self.render()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
- **refactor: update output formatting in execution results and snapshots**
- **feat: integrate forge_template for enhanced file content representation in execution results**
- **fix: update `into_tool_output` call to remove unnecessary `Option` wrapper for tool input**
- **refactor: enhance ExecutionResult and related structs for improved output representation**
