### PR TITLE
fix: use XML based format for attachments

### DIFF
--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_recursion::async_recursion;
 use derive_setters::Setters;
 use forge_domain::*;
+use forge_template::Element;
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
@@ -286,7 +287,14 @@ impl<S: AgentService> Orchestrator<S> {
                 ctx.add_message(match attachment.content {
                     AttachmentContent::Image(image) => ContextMessage::Image(image),
                     AttachmentContent::FileContent(content) => {
-                        ContextMessage::user(content, model_id.clone().into())
+                        let elm = Element::new("file_content")
+                            .attr("path", attachment.path)
+                            .attr("start_line", 1)
+                            .attr("end_line", content.lines().count())
+                            .attr("total_lines", content.lines().count())
+                            .cdata(content);
+
+                        ContextMessage::user(elm, model_id.clone().into())
                     }
                 })
             });

--- a/crates/forge_app/src/tool_registry.rs
+++ b/crates/forge_app/src/tool_registry.rs
@@ -46,7 +46,7 @@ impl<S: Services> ToolRegistry<S> {
                     .read(input.path.clone(), input.start_line, input.end_line)
                     .await?;
                 let env = self.services.environment_service().get_environment();
-                let display_path = display_path(&env, Path::new(&input.path))?;
+                let display_path = display_path(&env, Path::new(&input.path));
                 let is_truncated = output.total_lines > output.end_line;
 
                 send_read_context(
@@ -181,7 +181,7 @@ impl<S: Services> ToolRegistry<S> {
         let truncation_path = out.to_create_temp(self.services.as_ref()).await?;
         let env = self.services.environment_service().get_environment();
 
-        out.into_tool_output(tool_input, truncation_path, &env)
+        Ok(out.into_tool_output(tool_input, truncation_path, &env))
     }
 
     async fn call_with_timeout<F, Fut>(
@@ -333,7 +333,7 @@ async fn send_fs_patch_context<S: Services>(
 ) -> anyhow::Result<()> {
     let env = services.environment_service().get_environment();
 
-    let display_path = display_path(&env, Path::new(&path))?;
+    let display_path = display_path(&env, Path::new(&path));
     // Generate diff between old and new content
     let diff =
         console::strip_ansi_codes(&DiffFormat::format(&output.before, &output.after)).to_string();
@@ -356,7 +356,7 @@ async fn send_fs_remove_context<S: Services>(
     service: &S,
 ) -> anyhow::Result<()> {
     let env = service.environment_service().get_environment();
-    let display_path = display_path(&env, Path::new(path))?;
+    let display_path = display_path(&env, Path::new(path));
 
     let message = TitleFormat::debug("Remove").sub_title(&display_path);
 
@@ -372,7 +372,7 @@ async fn send_fs_search_context<S: Services>(
     output: &Option<SearchResult>,
 ) -> anyhow::Result<()> {
     let env = services.environment_service().get_environment();
-    let formatted_dir = display_path(&env, Path::new(&input.path))?;
+    let formatted_dir = display_path(&env, Path::new(&input.path));
 
     let title = match (&input.regex, &input.file_pattern) {
         (Some(regex), Some(pattern)) => {
@@ -402,7 +402,7 @@ async fn send_write_context<S: Services>(
     services: &S,
 ) -> anyhow::Result<()> {
     let env = services.environment_service().get_environment();
-    let formatted_path = display_path(&env, Path::new(&out.path))?;
+    let formatted_path = display_path(&env, Path::new(&out.path));
     let new_content = services
         .fs_read_service()
         .read(path.to_string(), None, None)

--- a/crates/forge_app/src/utils.rs
+++ b/crates/forge_app/src/utils.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use forge_domain::Environment;
 
-pub fn display_path(env: &Environment, path: &Path) -> anyhow::Result<String> {
+pub fn display_path(env: &Environment, path: &Path) -> String {
     // Get the current working directory
     let cwd = env.cwd.as_path();
 
@@ -21,8 +21,8 @@ pub fn display_path(env: &Environment, path: &Path) -> anyhow::Result<String> {
 /// * `cwd` - The current working directory path
 ///
 /// # Returns
-/// * `Ok(String)` with a formatted path string
-fn format_display_path(path: &Path, cwd: &Path) -> anyhow::Result<String> {
+/// * A formatted path string
+fn format_display_path(path: &Path, cwd: &Path) -> String {
     // Try to create a relative path for display if possible
     let display_path = if path.starts_with(cwd) {
         match path.strip_prefix(cwd) {
@@ -34,8 +34,8 @@ fn format_display_path(path: &Path, cwd: &Path) -> anyhow::Result<String> {
     };
 
     if display_path.is_empty() {
-        Ok(".".to_string())
+        ".".to_string()
     } else {
-        Ok(display_path)
+        display_path
     }
 }

--- a/crates/forge_services/src/attachment.rs
+++ b/crates/forge_services/src/attachment.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -8,44 +7,12 @@ use forge_domain::{Attachment, AttachmentContent, Image};
 
 use crate::{FsReadService, Infrastructure};
 
-const MAX_LINES: u64 = 500;
-
 #[derive(Clone)]
 pub struct ForgeChatRequest<F> {
     infra: Arc<F>,
 }
 
 impl<F: Infrastructure> ForgeChatRequest<F> {
-    async fn generate_image_content(
-        path: &Path,
-        img_format: String,
-        infra: &impl FsReadService,
-    ) -> anyhow::Result<Image> {
-        let bytes = infra.read(path).await?;
-
-        Ok(Image::new_bytes(bytes, img_format))
-    }
-
-    async fn generate_text_content(
-        path: &Path,
-        infra: &impl FsReadService,
-    ) -> anyhow::Result<String> {
-        let (content, file_info) = infra.range_read_utf8(path, 1, MAX_LINES).await?;
-        let mut response = String::new();
-        writeln!(response, "---")?;
-        writeln!(response, "path: {}", path.display())?;
-
-        writeln!(response, "start_line: {}", file_info.start_line)?;
-        writeln!(response, "end_line: {}", file_info.end_line)?;
-        writeln!(response, "total_lines: {}", file_info.total_lines)?;
-
-        writeln!(response, "---")?;
-
-        writeln!(response, "{}", &content)?;
-
-        Ok(response)
-    }
-
     pub fn new(infra: Arc<F>) -> Self {
         Self { infra }
     }
@@ -85,13 +52,14 @@ impl<F: Infrastructure> ForgeChatRequest<F> {
             _ => None,
         });
 
+        //NOTE: Attachments should not be truncated since they are provided by the user
         let content = match mime_type {
-            Some(mime_type) => AttachmentContent::Image(
-                Self::generate_image_content(&path, mime_type, self.infra.file_read_service())
-                    .await?,
-            ),
+            Some(mime_type) => AttachmentContent::Image(Image::new_bytes(
+                self.infra.file_read_service().read(&path).await?,
+                mime_type,
+            )),
             None => AttachmentContent::FileContent(
-                Self::generate_text_content(&path, self.infra.file_read_service()).await?,
+                self.infra.file_read_service().read_utf8(&path).await?,
             ),
         };
 

--- a/crates/forge_services/src/attachment.rs
+++ b/crates/forge_services/src/attachment.rs
@@ -547,9 +547,6 @@ pub mod tests {
 
         // Check that the content contains our original text and has range information
         assert!(attachment.content.contains("This is a text file content"));
-        assert!(attachment.content.contains("start_line:"));
-        assert!(attachment.content.contains("end_line:"));
-        assert!(attachment.content.contains("total_lines:"));
     }
 
     #[tokio::test]
@@ -703,8 +700,5 @@ pub mod tests {
 
         // Check that the content contains our original text and has range information
         assert!(attachment.content.contains("Some content"));
-        assert!(attachment.content.contains("start_line:"));
-        assert!(attachment.content.contains("end_line:"));
-        assert!(attachment.content.contains("total_lines:"));
     }
 }

--- a/forge.yaml
+++ b/forge.yaml
@@ -1,5 +1,5 @@
 variables:
-  mode: ACT
+  mode: PLAN
 commands:
 - name: fixme
   description: Looks for all the fixme comments in the code and attempts to fix them


### PR DESCRIPTION
- **refactor: simplify return types in tool output functions and update display_path function**
- **refactor: update attachment handling to avoid truncation and simplify content generation**
