### PR TITLE
refactor add output logs

### DIFF
--- a/crates/forge_app/src/fmt_input.rs
+++ b/crates/forge_app/src/fmt_input.rs
@@ -5,23 +5,23 @@ use forge_domain::{Environment, Tools};
 
 use crate::utils::display_path;
 
-pub enum Content {
+pub enum InputFormat {
     Title(TitleFormat),
     Summary(String),
 }
 
-impl From<TitleFormat> for Content {
+impl From<TitleFormat> for InputFormat {
     fn from(title: TitleFormat) -> Self {
-        Content::Title(title)
+        InputFormat::Title(title)
     }
 }
 
-pub trait InputTitle {
-    fn to_content(&self, env: &Environment) -> Content;
+pub trait FormatInput {
+    fn to_content(&self, env: &Environment) -> InputFormat;
 }
 
-impl InputTitle for Tools {
-    fn to_content(&self, env: &Environment) -> Content {
+impl FormatInput for Tools {
+    fn to_content(&self, env: &Environment) -> InputFormat {
         let display_path_for = |path: &str| display_path(env, Path::new(path));
 
         match self {
@@ -79,7 +79,7 @@ impl InputTitle for Tools {
             Tools::ForgeToolFollowup(input) => TitleFormat::debug("Follow-up")
                 .sub_title(&input.question)
                 .into(),
-            Tools::ForgeToolAttemptCompletion(input) => Content::Summary(input.result.clone()),
+            Tools::ForgeToolAttemptCompletion(input) => InputFormat::Summary(input.result.clone()),
         }
     }
 }
@@ -92,13 +92,13 @@ mod tests {
     use forge_domain::{Environment, FSRead, FSWrite, Shell, Tools};
     use pretty_assertions::assert_eq;
 
-    use super::{Content, InputTitle};
+    use super::{FormatInput, InputFormat};
 
-    impl Content {
+    impl InputFormat {
         pub fn render(&self, with_timestamp: bool) -> String {
             match self {
-                Content::Title(title) => title.render(with_timestamp),
-                Content::Summary(summary) => summary.clone(),
+                InputFormat::Title(title) => title.render(with_timestamp),
+                InputFormat::Summary(summary) => summary.clone(),
             }
         }
     }

--- a/crates/forge_app/src/lib.rs
+++ b/crates/forge_app/src/lib.rs
@@ -4,7 +4,7 @@ mod app;
 mod compact;
 mod error;
 mod execution_result;
-mod input_title;
+mod fmt_input;
 mod mcp_executor;
 mod orch;
 mod retry;

--- a/crates/forge_app/src/tool_executor.rs
+++ b/crates/forge_app/src/tool_executor.rs
@@ -5,7 +5,7 @@ use forge_domain::{ToolCallContext, ToolCallFull, ToolOutput, Tools};
 
 use crate::error::Error;
 use crate::execution_result::ExecutionResult;
-use crate::input_title::{Content, InputTitle};
+use crate::fmt_input::{FormatInput, InputFormat};
 use crate::{
     EnvironmentService, FollowUpService, FsCreateService, FsPatchService, FsReadService,
     FsRemoveService, FsSearchService, FsUndoService, NetFetchService, Services, ShellService,
@@ -110,8 +110,8 @@ impl<S: Services> ToolExecutor<S> {
         let tool_input = Tools::try_from(input).map_err(Error::CallArgument)?;
         let env = self.services.environment_service().get_environment();
         match tool_input.to_content(&env) {
-            Content::Title(title) => context.send_text(title).await?,
-            Content::Summary(summary) => context.send_summary(summary).await?,
+            InputFormat::Title(title) => context.send_text(title).await?,
+            InputFormat::Summary(summary) => context.send_summary(summary).await?,
         };
 
         // Send tool call information

--- a/crates/forge_provider/src/forge_provider/provider.rs
+++ b/crates/forge_provider/src/forge_provider/provider.rs
@@ -153,7 +153,7 @@ impl ForgeProvider {
                             Some(Err(error).with_context(|| format!("Http Status: {status_code}")))
                         }
                         error => {
-                            debug!(error = %error, "Failed to receive chat completion event");
+                            tracing::error!(error = ?error, "Failed to receive chat completion event");
                             Some(Err(error.into()))
                         }
                     },


### PR DESCRIPTION
- **refactor: introduce InputFormat enum and update ToolExecutor to use fmt_input module**
- **fix: replace debug logging with error logging for chat completion event failure**
