### PR TITLE
fix(compaction): handle parallel tool calls in context compaction

### DIFF
--- a/crates/forge_domain/src/compaction_strategy.rs
+++ b/crates/forge_domain/src/compaction_strategy.rs
@@ -130,8 +130,8 @@ fn find_sequence_preserving_last_n(
         }
     }
 
-    if messages.get(end).is_some_and(|msg| msg.has_tool_result()) {
-        if messages
+    if messages.get(end).is_some_and(|msg| msg.has_tool_result())
+        && messages
             .get(end.saturating_add(1))
             .is_some_and(|msg| msg.has_tool_result())
         {
@@ -143,7 +143,6 @@ fn find_sequence_preserving_last_n(
             }
             end = adjusted_end.saturating_sub(1);
         }
-    }
 
     // Return the sequence only if it has at least one message
     if end >= start {
@@ -309,15 +308,15 @@ mod tests {
         assert_eq!(actual, expected);
 
         let actual = seq("sutrtrtrra", 3);
-        let expected = "s[utrtr]trra";  
+        let expected = "s[utrtr]trra";
         assert_eq!(actual, expected);
 
-         let actual = seq("sutrrtrrtrra", 5);
-        let expected = "s[utrr]trrtrra";  
+        let actual = seq("sutrrtrrtrra", 5);
+        let expected = "s[utrr]trrtrra";
         assert_eq!(actual, expected);
 
         let actual = seq("sutrrrrrra", 2);
-        let expected = "s[u]trrrrrra";  
+        let expected = "s[u]trrrrrra";
         assert_eq!(actual, expected);
 
         // Conversation patterns

--- a/crates/forge_domain/src/compaction_strategy.rs
+++ b/crates/forge_domain/src/compaction_strategy.rs
@@ -109,7 +109,7 @@ fn find_sequence_preserving_last_n(
     }
 
     // Use saturating subtraction to prevent potential overflow
-    let end = length.saturating_sub(max_retention).saturating_sub(1);
+    let mut end = length.saturating_sub(max_retention).saturating_sub(1);
 
     // Ensure we have at least two messages to create a meaningful summary
     // If start > end or end is invalid, don't compact
@@ -127,6 +127,21 @@ fn find_sequence_preserving_last_n(
         } else {
             // Otherwise reduce end by 1
             return Some((start, end.saturating_sub(1)));
+        }
+    }
+
+    if messages.get(end).is_some_and(|msg| msg.has_tool_result()) {
+        if messages
+            .get(end.saturating_add(1))
+            .is_some_and(|msg| msg.has_tool_result())
+        {
+            // If the last message is a tool result and the next one is also a tool result,
+            // we need to adjust the end.
+            let mut adjusted_end = end;
+            while adjusted_end >= start && (messages[adjusted_end].has_tool_result()) {
+                adjusted_end = adjusted_end.saturating_sub(1);
+            }
+            end = adjusted_end.saturating_sub(1);
         }
     }
 
@@ -286,6 +301,23 @@ mod tests {
 
         let actual = seq("sutrtrtra", 2);
         let expected = "s[utrtr]tra";
+        assert_eq!(actual, expected);
+
+        // Parallel tool calls
+        let actual = seq("sutrtrtrra", 2);
+        let expected = "s[utrtr]trra";
+        assert_eq!(actual, expected);
+
+        let actual = seq("sutrtrtrra", 3);
+        let expected = "s[utrtr]trra";  
+        assert_eq!(actual, expected);
+
+         let actual = seq("sutrrtrrtrra", 5);
+        let expected = "s[utrr]trrtrra";  
+        assert_eq!(actual, expected);
+
+        let actual = seq("sutrrrrrra", 2);
+        let expected = "s[u]trrrrrra";  
         assert_eq!(actual, expected);
 
         // Conversation patterns

--- a/crates/forge_domain/src/compaction_strategy.rs
+++ b/crates/forge_domain/src/compaction_strategy.rs
@@ -138,7 +138,7 @@ fn find_sequence_preserving_last_n(
         // If the last message is a tool result and the next one is also a tool result,
         // we need to adjust the end.
         let mut adjusted_end = end;
-        while adjusted_end >= start && (messages[adjusted_end].has_tool_result()) {
+        while adjusted_end >= start && messages[adjusted_end].has_tool_result() {
             adjusted_end = adjusted_end.saturating_sub(1);
         }
         end = adjusted_end.saturating_sub(1);

--- a/crates/forge_domain/src/compaction_strategy.rs
+++ b/crates/forge_domain/src/compaction_strategy.rs
@@ -134,15 +134,15 @@ fn find_sequence_preserving_last_n(
         && messages
             .get(end.saturating_add(1))
             .is_some_and(|msg| msg.has_tool_result())
-        {
-            // If the last message is a tool result and the next one is also a tool result,
-            // we need to adjust the end.
-            let mut adjusted_end = end;
-            while adjusted_end >= start && (messages[adjusted_end].has_tool_result()) {
-                adjusted_end = adjusted_end.saturating_sub(1);
-            }
-            end = adjusted_end.saturating_sub(1);
+    {
+        // If the last message is a tool result and the next one is also a tool result,
+        // we need to adjust the end.
+        let mut adjusted_end = end;
+        while adjusted_end >= start && (messages[adjusted_end].has_tool_result()) {
+            adjusted_end = adjusted_end.saturating_sub(1);
         }
+        end = adjusted_end.saturating_sub(1);
+    }
 
     // Return the sequence only if it has at least one message
     if end >= start {

--- a/crates/forge_domain/src/compaction_strategy.rs
+++ b/crates/forge_domain/src/compaction_strategy.rs
@@ -137,11 +137,10 @@ fn find_sequence_preserving_last_n(
     {
         // If the last message is a tool result and the next one is also a tool result,
         // we need to adjust the end.
-        let mut adjusted_end = end;
-        while adjusted_end >= start && messages[adjusted_end].has_tool_result() {
-            adjusted_end = adjusted_end.saturating_sub(1);
+        while end >= start && messages.get(end).is_some_and(|msg| msg.has_tool_result()) {
+            end = end.saturating_sub(1);
         }
-        end = adjusted_end.saturating_sub(1);
+        end = end.saturating_sub(1);
     }
 
     // Return the sequence only if it has at least one message

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -138,6 +138,14 @@ impl ContextMessage {
         }
     }
 
+    pub fn has_tool_result(&self) -> bool {
+        match self {
+            ContextMessage::Text(_) => false,
+            ContextMessage::Tool(_) => true,
+            ContextMessage::Image(_) => false,
+        }
+    }
+
     pub fn has_tool_call(&self) -> bool {
         match self {
             ContextMessage::Text(message) => message.tool_calls.is_some(),


### PR DESCRIPTION
This pull request enhances the context compaction strategy to correctly handle scenarios with parallel tool calls. The core improvement is in the  function, which now intelligently adjusts the compaction sequence to prevent truncation of tool results when multiple tool calls occur in parallel.

Core functionality improvements:
- **Improved Compaction Strategy:** The compaction logic now correctly identifies and preserves sequences of tool results, ensuring that no tool call information is lost during context summarization.
- **Robustness:** New tests have been added to validate the handling of various parallel tool call patterns, making the compaction process more reliable.
- **New  method:** A new helper method  has been added to  to simplify checking for tool results.