### PR TITLE
refactor: migrate walker functionality to forge_infra with new abstractions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "forge_fs",
  "forge_services",
  "forge_snaps",
+ "forge_walker",
  "inquire",
  "pretty_assertions",
  "reqwest 0.12.12",

--- a/crates/forge_infra/Cargo.toml
+++ b/crates/forge_infra/Cargo.toml
@@ -25,3 +25,4 @@ tracing.workspace = true
 backon.workspace = true
 thiserror.workspace = true
 forge_app.workspace = true
+forge_walker.workspace = true

--- a/crates/forge_infra/src/forge_infra.rs
+++ b/crates/forge_infra/src/forge_infra.rs
@@ -7,7 +7,7 @@ use forge_domain::{CommandOutput, Environment, McpServerConfig};
 use forge_fs::FileInfo as FileInfoData;
 use forge_services::{
     CommandInfra, EnvironmentInfra, FileDirectoryInfra, FileInfoInfra, FileReaderInfra,
-    FileRemoverInfra, FileWriterInfra, McpServerInfra, SnapshotInfra, UserInfra,
+    FileRemoverInfra, FileWriterInfra, McpServerInfra, SnapshotInfra, UserInfra, WalkerInfra,
 };
 
 use crate::env::ForgeEnvironmentInfra;
@@ -21,6 +21,7 @@ use crate::fs_write::ForgeFileWriteService;
 use crate::inquire::ForgeInquire;
 use crate::mcp_client::ForgeMcpClient;
 use crate::mcp_server::ForgeMcpServer;
+use crate::walker::ForgeWalkerService;
 
 #[derive(Clone)]
 pub struct ForgeInfra {
@@ -34,6 +35,7 @@ pub struct ForgeInfra {
     command_executor_service: Arc<ForgeCommandExecutorService>,
     inquire_service: Arc<ForgeInquire>,
     mcp_server: ForgeMcpServer,
+    walker_service: Arc<ForgeWalkerService>,
 }
 
 impl ForgeInfra {
@@ -57,6 +59,7 @@ impl ForgeInfra {
             )),
             inquire_service: Arc::new(ForgeInquire::new()),
             mcp_server: ForgeMcpServer,
+            walker_service: Arc::new(ForgeWalkerService::new()),
         }
     }
 }
@@ -197,5 +200,15 @@ impl McpServerInfra for ForgeInfra {
 
     async fn connect(&self, config: McpServerConfig) -> anyhow::Result<Self::Client> {
         self.mcp_server.connect(config).await
+    }
+}
+
+#[async_trait::async_trait]
+impl WalkerInfra for ForgeInfra {
+    async fn walk(
+        &self,
+        config: forge_services::WalkerConfig,
+    ) -> anyhow::Result<Vec<forge_services::WalkedFile>> {
+        self.walker_service.walk(config).await
     }
 }

--- a/crates/forge_infra/src/lib.rs
+++ b/crates/forge_infra/src/lib.rs
@@ -12,6 +12,7 @@ mod fs_write;
 mod inquire;
 mod mcp_client;
 mod mcp_server;
+mod walker;
 
 pub use executor::ForgeCommandExecutorService;
 pub use forge_infra::*;

--- a/crates/forge_infra/src/walker.rs
+++ b/crates/forge_infra/src/walker.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use forge_services::{WalkedFile, WalkerConfig};
+
+pub struct ForgeWalkerService;
+
+impl ForgeWalkerService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn walk(&self, config: WalkerConfig) -> Result<Vec<WalkedFile>> {
+        // Convert domain config to forge_walker config
+        let mut walker = if config.max_depth.is_none()
+            && config.max_breadth.is_none()
+            && config.max_file_size.is_none()
+            && config.max_files.is_none()
+            && config.max_total_size.is_none()
+            && !config.skip_binary
+        {
+            forge_walker::Walker::max_all()
+        } else {
+            forge_walker::Walker::min_all()
+        };
+
+        walker = walker.cwd(config.cwd);
+
+        if let Some(depth) = config.max_depth {
+            walker = walker.max_depth(depth);
+        }
+        if let Some(breadth) = config.max_breadth {
+            walker = walker.max_breadth(breadth);
+        }
+        if let Some(file_size) = config.max_file_size {
+            walker = walker.max_file_size(file_size);
+        }
+        if let Some(files) = config.max_files {
+            walker = walker.max_files(files);
+        }
+        if let Some(total_size) = config.max_total_size {
+            walker = walker.max_total_size(total_size);
+        }
+        walker = walker.skip_binary(config.skip_binary);
+
+        // Execute the walker and convert results
+        let files = walker.get().await?;
+        let walked_files = files
+            .into_iter()
+            .map(|f| WalkedFile { path: f.path, file_name: f.file_name, size: f.size })
+            .collect();
+
+        Ok(walked_files)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_walker_service_basic_functionality() {
+        let fixture = tempdir().unwrap();
+        std::fs::write(fixture.path().join("test.txt"), "test content").unwrap();
+
+        let service = ForgeWalkerService::new();
+        let config = WalkerConfig::conservative().cwd(fixture.path().to_path_buf());
+
+        let actual = service.walk(config).await.unwrap();
+
+        let expected = 1; // Should find the test file
+        let file_count = actual.iter().filter(|f| !f.is_dir()).count();
+        assert_eq!(file_count, expected);
+    }
+
+    #[tokio::test]
+    async fn test_walker_service_unlimited_config() {
+        let fixture = tempdir().unwrap();
+        std::fs::write(fixture.path().join("test.txt"), "test content").unwrap();
+
+        let service = ForgeWalkerService::new();
+        let config = WalkerConfig::unlimited().cwd(fixture.path().to_path_buf());
+
+        let actual = service.walk(config).await.unwrap();
+
+        let expected = 1; // Should find the test file
+        let file_count = actual.iter().filter(|f| !f.is_dir()).count();
+        assert_eq!(file_count, expected);
+    }
+}

--- a/crates/forge_services/src/discovery.rs
+++ b/crates/forge_services/src/discovery.rs
@@ -3,30 +3,30 @@ use std::sync::Arc;
 use anyhow::Result;
 use forge_app::FileDiscoveryService;
 use forge_domain::File;
-use forge_walker::Walker;
 
-use crate::EnvironmentInfra;
+use crate::{EnvironmentInfra, WalkerConfig, WalkerInfra};
 
 pub struct ForgeDiscoveryService<F> {
-    env_service: Arc<F>,
+    service: Arc<F>,
 }
 
 impl<F> ForgeDiscoveryService<F> {
-    pub fn new(env_service: Arc<F>) -> Self {
-        Self { env_service }
+    pub fn new(service: Arc<F>) -> Self {
+        Self { service }
     }
 }
 
-impl<F: EnvironmentInfra> ForgeDiscoveryService<F> {
+impl<F: EnvironmentInfra + WalkerInfra> ForgeDiscoveryService<F> {
     async fn discover_with_depth(&self, max_depth: Option<usize>) -> Result<Vec<File>> {
-        let cwd = self.env_service.get_environment().cwd.clone();
+        let cwd = self.service.get_environment().cwd.clone();
 
-        let mut walker = Walker::max_all().cwd(cwd);
-        if let Some(depth) = max_depth {
-            walker = walker.max_depth(depth);
-        }
+        let config = if let Some(depth) = max_depth {
+            WalkerConfig::unlimited().cwd(cwd).max_depth(depth)
+        } else {
+            WalkerConfig::unlimited().cwd(cwd)
+        };
 
-        let files = walker.get().await?;
+        let files = self.service.walk(config).await?;
         Ok(files
             .into_iter()
             .map(|file| File { path: file.path.clone(), is_dir: file.is_dir() })
@@ -35,7 +35,9 @@ impl<F: EnvironmentInfra> ForgeDiscoveryService<F> {
 }
 
 #[async_trait::async_trait]
-impl<F: EnvironmentInfra + Send + Sync> FileDiscoveryService for ForgeDiscoveryService<F> {
+impl<F: EnvironmentInfra + WalkerInfra + Send + Sync> FileDiscoveryService
+    for ForgeDiscoveryService<F>
+{
     async fn collect(&self, max_depth: Option<usize>) -> Result<Vec<File>> {
         self.discover_with_depth(max_depth).await
     }


### PR DESCRIPTION
## Summary

This refactoring migrates the filesystem walker functionality from forge_services to forge_infra, introducing new infrastructure abstractions that improve separation of concerns and enable better dependency injection patterns. The changes establish a cleaner architecture where infrastructure concerns are properly isolated from service logic.

## Key Changes

### Infrastructure Migration
- **Moved walker implementation** from forge_services to forge_infra as 
- **Added WalkerInfra trait** in forge_services/infra.rs for dependency injection
- **Created WalkerConfig** with conservative and unlimited preset configurations

### Service Layer Improvements  
- **Updated ForgeFsSearch** to use WalkerInfra dependency injection instead of direct forge_walker usage
- **Enhanced file discovery service** to use the new walker infrastructure
- **Improved async file operations** by replacing File::open with tokio::fs::read_to_string

### Testing Enhancements
- **Added comprehensive tests** for ForgeWalkerService with both conservative and unlimited configurations
- **Implemented MockInfra** for testing ForgeFsSearch without filesystem dependencies
- **Maintained test coverage** across all modified components

## Technical Impact

- **Better separation of concerns**: Infrastructure logic now properly separated from service logic
- **Improved testability**: Services can now be tested with mock infrastructure implementations  
- **Enhanced maintainability**: Clear dependency boundaries make the codebase easier to understand and modify

## Files Changed
- : Added walker service and updated dependencies
- : Updated to use new infrastructure abstractions
-  files: Updated dependency declarations

This refactoring maintains full backward compatibility while establishing a foundation for future infrastructure improvements.