### PR TITLE
fix: replace panic with proper error handling in API key resolution

### DIFF
--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -36,9 +36,9 @@ impl ForgeEnvironmentInfra {
 
     /// Resolves the provider key and provider from environment variables
     ///
-    /// Returns the provider configuration
-    /// Returns an error if no API key is found in the environment
-    fn resolve_provider(&self) -> anyhow::Result<Provider> {
+    /// Returns a tuple of (provider_key, provider)
+    /// Panics if no API key is found in the environment
+    fn resolve_provider(&self) -> Provider {
         let keys: [ProviderSearch; 4] = [
             ("FORGE_KEY", Box::new(Provider::antinomy)),
             ("OPENROUTER_API_KEY", Box::new(Provider::open_router)),
@@ -69,7 +69,7 @@ impl ForgeEnvironmentInfra {
                     provider
                 })
             })
-            .ok_or_else(|| anyhow::anyhow!("No API key found. Please set one of: {env_variables}"))
+            .unwrap_or_else(|| panic!("API key required. Get yours at https://app.forgecode.dev/"))
     }
 
     /// Resolves retry configuration from environment variables or returns
@@ -142,10 +142,7 @@ impl ForgeEnvironmentInfra {
             Self::dot_env(&cwd);
         }
 
-        let provider = self.resolve_provider().unwrap_or_else(|e| {
-            eprintln!("Configuration error: {e}");
-            std::process::exit(1);
-        });
+        let provider = self.resolve_provider();
         let retry_config = self.resolve_retry_config();
 
         Environment {

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -46,12 +46,6 @@ impl ForgeEnvironmentInfra {
             ("ANTHROPIC_API_KEY", Box::new(Provider::anthropic)),
         ];
 
-        let env_variables = keys
-            .iter()
-            .map(|(key, _)| *key)
-            .collect::<Vec<_>>()
-            .join(", ");
-
         keys.into_iter()
             .find_map(|(key, fun)| {
                 std::env::var(key).ok().map(|key| {

--- a/crates/forge_main/src/main.rs
+++ b/crates/forge_main/src/main.rs
@@ -1,10 +1,26 @@
 use anyhow::Result;
 use clap::Parser;
 use forge_api::ForgeAPI;
+use forge_display::TitleFormat;
 use forge_main::{Cli, UI};
+use std::panic;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Set up panic hook for better error display
+    panic::set_hook(Box::new(|panic_info| {
+        let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unexpected error occurred".to_string()
+        };
+
+        eprintln!("{}", TitleFormat::error(format!("{message}")));
+        std::process::exit(1);
+    }));
+
     // Initialize and run the UI
     let cli = Cli::parse();
     // Initialize the ForgeAPI with the restricted mode if specified

--- a/crates/forge_main/src/main.rs
+++ b/crates/forge_main/src/main.rs
@@ -1,9 +1,10 @@
+use std::panic;
+
 use anyhow::Result;
 use clap::Parser;
 use forge_api::ForgeAPI;
 use forge_display::TitleFormat;
 use forge_main::{Cli, UI};
-use std::panic;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,7 +18,7 @@ async fn main() -> Result<()> {
             "Unexpected error occurred".to_string()
         };
 
-        eprintln!("{}", TitleFormat::error(format!("{message}")));
+        eprintln!("{}", TitleFormat::error(message.to_string()));
         std::process::exit(1);
     }));
 


### PR DESCRIPTION
I've noticed that when using the forge tool, if the API key is not set via environment variables, the program directly panics.

```
thread 'main' panicked at crates/forge_infra/src/env.rs:72:32:
No API key found. Please set one of: FORGE_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I understand that this is intended to prompt the user to configure the necessary API key. However, I believe that causing the program to crash outright (panic) is not the ideal way to handle this situation.

The absence of an API key is typically an **oversight** in user configuration rather than a fundamental **program error**. A more appropriate approach would be to print a clear notification or warning message, guiding the user to configure it.

```
Configuration error: No API key found. Please set one of: FORGE_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY
```