### PR TITLE
fix: `/dump` Errors when there's no `ConversationId`

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -717,8 +717,8 @@ impl<A: API, F: Fn() -> A> UI<A, F> {
                     .context(format!("Conversation: {conversation_id} was not found"));
             }
         } else {
-            return Err(anyhow::anyhow!("Could not create dump"))
-                .context("No conversation initiated yet");
+            return Err(anyhow::anyhow!("No conversation initiated yet"))
+                .context("Could not create dump");
         }
         Ok(())
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/deaa960c-a091-4e93-95b1-e2f45e48f45b)
