### PR TITLE
fix: use `max_completion_tokens` instead of `max_tokens` for open-ai compatible providers

### DIFF
--- a/crates/forge_provider/src/forge_provider/request.rs
+++ b/crates/forge_provider/src/forge_provider/request.rs
@@ -182,6 +182,8 @@ pub struct Request {
     pub stream_options: Option<StreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<forge_app::domain::ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -281,6 +283,7 @@ impl From<Context> for Request {
             stream_options: Some(StreamOptions { include_usage: Some(true) }),
             session_id: context.conversation_id.map(|id| id.to_string()),
             reasoning: context.reasoning,
+            max_completion_tokens: Default::default(),
         }
     }
 }

--- a/crates/forge_provider/src/forge_provider/transformers/make_openai_compat.rs
+++ b/crates/forge_provider/src/forge_provider/transformers/make_openai_compat.rs
@@ -32,6 +32,10 @@ impl Transformer for MakeOpenAiCompat {
             // drop `parallel_tool_calls` field if tools are not passed to the request.
             request.parallel_tool_calls = None;
         }
+
+        // OpenAI has deprecated `max_tokens`, now it is `max_completion_tokens`.
+        request.max_completion_tokens = request.max_tokens.take();
+
         request
     }
 }
@@ -90,5 +94,15 @@ mod tests {
         let actual = transformer.transform(fixture);
         let expected = None;
         assert_eq!(actual.reasoning, expected);
+    }
+
+    #[test]
+    fn test_max_tokens_mapped_correctly() {
+        let fixture = Request::default().max_tokens(100);
+        let mut transformer = MakeOpenAiCompat;
+        let actual = transformer.transform(fixture);
+        let expected = Some(100);
+        assert_eq!(actual.max_completion_tokens, expected);
+        assert_eq!(actual.max_tokens, None);
     }
 }


### PR DESCRIPTION
fixes #1081
