### PR TITLE
docs: add project structure documentation and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Forge is an AI-enhanced terminal development environment built in Rust. It provides a comprehensive coding agent that integrates AI capabilities with your development environment. The project follows a multi-crate workspace architecture with clearly separated concerns.
+
+## Essential Commands
+
+### Building and Testing
+```bash
+# Format code
+cargo +nightly fmt --all
+
+# Run linting and fixes
+cargo +nightly clippy --fix --allow-staged --allow-dirty --workspace
+
+# Run tests with snapshots
+cargo insta test --accept --unreferenced=delete
+
+# Combined verification (format + lint)
+cargo +nightly fmt --all; cargo +nightly clippy --fix --allow-staged --allow-dirty --workspace
+```
+
+### Running the Application
+```bash
+# Build and run
+cargo run
+
+# Install and run via npm (development)
+npx forgecode@latest
+
+# Run with specific options
+cargo run -- --help
+cargo run -- --restricted  # restricted shell mode
+cargo run -- --verbose     # verbose output
+```
+
+## Architecture Overview
+
+### Crate Structure
+The project uses a workspace with specialized crates:
+
+- **forge_main**: CLI entry point and user interface
+- **forge_app**: Core application logic, agent execution, and orchestration
+- **forge_domain**: Domain models, types, and business logic
+- **forge_services**: Service layer including tool services and business operations
+- **forge_provider**: AI provider integrations (OpenAI, Anthropic, etc.)
+- **forge_infra**: Infrastructure concerns (HTTP, filesystem, execution)
+- **forge_api**: API layer and external interfaces
+- **forge_display**: Output formatting and display logic
+- **forge_fs**: Filesystem utilities and operations
+- **forge_tracker**: Analytics and tracking
+- **forge_ci**: CI/CD utilities and workflows
+
+### Key Components
+
+- **Agent System**: Multi-agent workflow execution with context management
+- **Tool Registry**: Centralized tool registration and execution (forge_services/src/tools/registry.rs)
+- **MCP Integration**: Model Context Protocol for external tool communication
+- **Provider Abstraction**: Multi-provider AI model support
+- **Context Management**: Intelligent context summarization and compaction
+
+## Development Guidelines
+
+### Error Handling
+- Use `anyhow::Result` for error handling in services and repositories
+- Create domain errors using `thiserror`
+- Never implement `From` for converting domain errors, manually convert them
+
+### Testing Standards
+- All tests follow a three-step pattern: fixture → actual → expected
+- Use `pretty_assertions::assert_eq!` for better error messages
+- Tests are co-located with source code in the same file
+- Use `insta` for snapshot testing: `cargo insta test --accept --unreferenced=delete`
+- Fixtures should be generic and reusable
+
+### Domain Types
+- Use `derive_setters` with `strip_option` and `into` attributes on struct types
+
+### Tool Development
+- Tool descriptions must be extremely detailed (see docs/tool-guidelines.md)
+- All tools must be registered in forge_services/src/tools/registry.rs
+- Tool descriptions must not exceed 1024 characters
+- Include when/when not to use, parameter meanings, and limitations
+
+## Configuration
+
+### forge.yaml
+The main configuration file supports:
+- Custom commands and rules
+- Model selection and parameters
+- Agent tool assignments
+- Temperature and context limits
+
+### Available Commands
+- `fixme`: Find and fix FIXME comments
+- `pr-description`: Update PR title and description with conventional commits
+- `check`: Run lint and test commands to verify code readiness
+
+## MCP (Model Context Protocol)
+Configure external tool integrations via `.mcp.json` or `forge mcp` CLI commands for browser automation, API interactions, and custom service connections.
+
+## Important Files
+- `forge.yaml`: Main configuration
+- `Cargo.toml`: Workspace definition
+- `crates/forge_services/src/tools/registry.rs`: Tool registration
+- `docs/tool-guidelines.md`: Tool development best practices

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Quickstart](#quickstart)
 - [Usage Examples](#usage-examples)
 - [Why Forge?](#why-forge)
+- [Project Structure](#project-structure)
 - [Command-Line Options](#command-line-options)
 - [Advanced Configuration](#advanced-configuration)
   - [Provider Configuration](#provider-configuration)
@@ -149,6 +150,66 @@ Forge is designed for developers who want to enhance their workflow with AI assi
 - **Open-source** - Transparent, extensible, and community-driven
 
 Forge helps you code faster, solve complex problems, and learn new technologies without leaving your terminal.
+
+## Project Structure
+
+Forge is built using a modular Rust workspace architecture with clearly separated concerns. Here's an overview of the key components:
+
+### Core Architecture
+
+```
+forge/
+├── crates/          # Rust workspace crates
+├── docs/           # Documentation
+├── templates/      # Handlebars templates
+├── plans/          # Development plans
+├── Cargo.toml      # Workspace configuration
+├── forge.yaml      # Main configuration file
+└── README.md       # Project documentation
+```
+
+### Key Crates
+
+#### 🎯 **Entry Point & UI**
+- **`forge_main/`** - CLI entry point, user interface, command parsing
+- **`forge_display/`** - Output formatting, markdown rendering, diff display
+
+#### 🧠 **Core Application**
+- **`forge_app/`** - Main application logic, agent execution, orchestration
+- **`forge_domain/`** - Domain models, type definitions, business logic
+
+#### 🔧 **Service Layer**
+- **`forge_services/`** - Service layer, tool services, business operations
+- **`forge_api/`** - API layer, external interfaces
+
+#### 🤖 **AI Providers**
+- **`forge_provider/`** - AI provider integrations (OpenAI, Anthropic, etc.)
+
+#### 🛠 **Infrastructure**
+- **`forge_infra/`** - Infrastructure concerns (HTTP, filesystem, execution)
+- **`forge_fs/`** - Filesystem utilities and operations
+
+#### 📊 **Monitoring & Utilities**
+- **`forge_tracker/`** - Analytics and tracking
+- **`forge_spinner/`** - Loading spinners
+- **`forge_stream/`** - Stream processing
+- **`forge_walker/`** - Directory traversal
+
+#### 🔨 **Development Tools**
+- **`forge_ci/`** - CI/CD utilities and workflows
+- **`forge_inte/`** - Integration tests
+- **`forge_snaps/`** - Snapshot testing
+- **`forge_template/`** - Template processing
+- **`forge_tool_macros/`** - Tool-related macros
+
+### Configuration Files
+
+- **`forge.yaml`** - Main configuration with agents, tools, and custom rules
+- **`Cargo.toml`** - Workspace definition and dependency management
+- **`.mcp.json`** - Model Context Protocol configuration
+- **`CLAUDE.md`** - Development guidelines for AI assistants
+
+This modular architecture ensures **separation of concerns**, making the codebase maintainable, testable, and extensible.
 
 ## Command-Line Options
 


### PR DESCRIPTION
- Add comprehensive project structure section to README.md with crate descriptions
- Create CLAUDE.md with development guidelines and architecture overview
- Organize crates by functional categories with clear explanations
- Include configuration files documentation for better developer onboarding

🤖 Generated with [Claude Code](https://claude.ai/code)