### PR TITLE
feat: patch-android.sh to support termux

### DIFF
--- a/patch-android.sh
+++ b/patch-android.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script will be removed once those android patches merge into upstream.
+# If you want local build termux forge, you need apply the changes.
+
+echo "Applying Android patches to Cargo.html for target: $TARGET..."
+
+cat <<EOF>> Cargo.toml
+
+[patch.crates-io]
+html2md = {git = "https://gitlab.com/Kanedias/html2md"}
+machineid-rs = {git = "https://github.com/shawn111/machineid-rs", branch = "termux"}
+EOF
+


### PR DESCRIPTION
I'm trying to run forge on termux, found it need some small change to fix the build issues.
I thought it is better not to impact other platforms.

I'll try add forge termux-packages, then termux users will able to pkg install forge.


- `html2md` sourced from upstream for `jni` fix.
   - `jni` crate updated from 0.19.0 to 0.21.1.
- `machineid-rs` sourced from fork for Termux changes.



Related: https://github.com/antinomyhq/forge/issues/712