### PR TITLE
fix: perform compaction sequentially.

### DIFF
--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -271,7 +271,7 @@ impl<S: AgentService> Orchestrator<S> {
         usage: &Usage,
     ) -> anyhow::Result<Option<Context>> {
         // Estimate token count for compaction decision
-        let total_tokens = usage.total_tokens.max(usage.estimated_tokens);
+        let total_tokens = usage.total_tokens.max(context.token_count());
         if agent.should_compact(context, total_tokens) {
             info!(agent_id = %agent.id, "Compaction needed");
             Compactor::new(self.services.clone())


### PR DESCRIPTION
### Parallel Compaction and Chat Request

- Assume the context is large, but not yet large enough to trigger compaction.
- The agent makes one or more tool calls, and the combined result of these calls exceeds the context limit.
- Parallel requests are made: one for compaction and one for chat.
- However, the chat request fails because it exceeds the context limit before compaction completes.
- Since the context was already large enough to fail without compaction, it will automatically fail with compaction as well.
