### PR TITLE
fix: signature is not required for summarization

### DIFF
--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -363,8 +363,6 @@ impl<S: AgentService> Orchestrator<S> {
                 })
             });
 
-        self.conversation.context = Some(context.clone());
-
         // Indicates whether the tool execution has been completed
         let mut is_complete = false;
 

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -66,9 +66,7 @@ impl ContextMessage {
                 if let Some(reasoning_details) = &message.reasoning_details {
                     for reasoning_detail in reasoning_details {
                         if let Some(text) = &reasoning_detail.text {
-                            lines.push_str(&format!(
-                                "<reasoning_detail>{text}</reasoning_detail>"
-                            ));
+                            lines.push_str(&format!("<reasoning_detail>{text}</reasoning_detail>"));
                         }
                     }
                 }

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -65,13 +65,15 @@ impl ContextMessage {
                 }
                 if let Some(reasoning_details) = &message.reasoning_details {
                     for reasoning_detail in reasoning_details {
-                        lines.push_str(&format!(
-                            "<reasoning_detail>{}</reasoning_detail>",
-                            serde_json::to_string(reasoning_detail).unwrap()
-                        ));
+                        if let Some(text) = &reasoning_detail.text {
+                            lines.push_str(&format!(
+                                "<reasoning_detail>{}</reasoning_detail>",
+                                text
+                            ));
+                        }
                     }
                 }
-
+                
                 lines.push_str("</message>");
             }
             ContextMessage::Tool(result) => {

--- a/crates/forge_domain/src/context.rs
+++ b/crates/forge_domain/src/context.rs
@@ -67,13 +67,12 @@ impl ContextMessage {
                     for reasoning_detail in reasoning_details {
                         if let Some(text) = &reasoning_detail.text {
                             lines.push_str(&format!(
-                                "<reasoning_detail>{}</reasoning_detail>",
-                                text
+                                "<reasoning_detail>{text}</reasoning_detail>"
                             ));
                         }
                     }
                 }
-                
+
                 lines.push_str("</message>");
             }
             ContextMessage::Tool(result) => {


### PR DESCRIPTION
The signature generated for extended thinking is not required at all for summarization. It only consumes input tokens and doesn't contribute to the final result, so it can be dropped.