### PR TITLE
fix: fixed metrics usages in orch.rs

### DIFF
--- a/crates/forge_app/src/app.rs
+++ b/crates/forge_app/src/app.rs
@@ -47,14 +47,11 @@ impl<S: Services> ForgeApp<S> {
         let services = self.services.clone();
 
         // Get the conversation for the chat request
-        let mut conversation = services
+        let conversation = services
             .find(&chat.conversation_id)
             .await
             .unwrap_or_default()
             .expect("conversation for the request should've been created at this point.");
-
-        // Always reset metrics internal conversation metrics
-        conversation.reset_metric();
 
         // Get tool definitions and models
         let tool_definitions = self.tool_registry.list().await?;

--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -395,10 +395,11 @@ impl<S: AgentService> Orchestrator<S> {
         // Retrieve the number of requests allowed per tick.
         let max_requests_per_turn = self.conversation.max_requests_per_turn;
 
-        let metrics = self.conversation.metrics.clone();
         // Store tool calls at turn level
         let mut turn_has_tool_calls = false;
 
+        let tool_context =
+            ToolCallContext::new(self.conversation.metrics.clone()).sender(self.sender.clone());
         while !is_complete {
             // Set context for the current loop iteration
             self.conversation.context = Some(context.clone());
@@ -500,8 +501,6 @@ impl<S: AgentService> Orchestrator<S> {
                 self.send(ChatResponse::TaskReasoning { content: reasoning.to_string() })
                     .await?;
             }
-
-            let tool_context = ToolCallContext::new(metrics.clone()).sender(self.sender.clone());
 
             // Check if tool calls are within allowed limits if max_tool_failure_per_turn is
             // configured
@@ -643,12 +642,15 @@ impl<S: AgentService> Orchestrator<S> {
             turn_has_tool_calls = turn_has_tool_calls || has_tool_calls;
         }
 
+        // Update metrics in conversation
+        tool_context.with_metrics(|metrics| {
+            self.conversation.metrics = metrics.clone();
+        })?;
+
         if has_attempted_completion {
-            self.send(ChatResponse::TaskComplete { metrics: metrics.clone() })
+            self.send(ChatResponse::TaskComplete { metrics: self.conversation.metrics.clone() })
                 .await?;
         }
-
-        self.conversation.metrics = metrics;
 
         Ok(())
     }


### PR DESCRIPTION
# Fixes file change metrics,
## Current behaviour:
 Fails to track file changes since tool_context metrics clones from conversation metrics (which is initialized empty) every time for tool-call context, 
## New behaviour:
 Keeps metrics specific to conversation always updated with tool call context metric