### PR TITLE
Add Dockerfile and .dockerignore for MCP toolkit submission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Rust build artifacts
+target/
+Cargo.lock
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Test files
+tests/
+**/tests/
+**/snapshots/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.circleci/
+
+# Temporary files
+*.tmp
+*.temp
+
+# Node modules (if any)
+node_modules/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Cache directories
+.cache/
+.rustc_info.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use the official Rust image as the base image
+FROM rust:1.75-slim as builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the entire project
+COPY . .
+
+# Build the application in release mode
+RUN cargo build --release --bin forge
+
+# Use a minimal runtime image
+FROM debian:bookworm-slim
+
+# Install necessary runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN useradd -m -u 1000 forge
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/target/release/forge /usr/local/bin/forge
+
+# Create necessary directories and set permissions
+RUN mkdir -p /app/config /app/workspace && \
+    chown -R forge:forge /app
+
+# Switch to the non-root user
+USER forge
+
+# Set environment variables
+ENV FORGE_CONFIG_DIR=/app/config
+ENV FORGE_WORKSPACE_DIR=/app/workspace
+
+# Expose any necessary ports (if needed for future features)
+# EXPOSE 8080
+
+# Set the entrypoint to the forge binary
+ENTRYPOINT ["forge"]
+
+# Default command (can be overridden)
+CMD ["--help"]


### PR DESCRIPTION
This PR adds Docker support to enable Forge to be submitted as an MCP toolkit client.

Changes
- Added `Dockerfile` with multi-stage build for optimized container image
- Added `.dockerignore` to exclude unnecessary files from build context
- Uses Rust 1.75-slim for building and Debian Bookworm for runtime
- Creates non-root user for security
- Sets up proper directory structure and environment variables

Purpose
This enables Forge to be containerized and submitted to the MCP toolkits

Testing
- Dockerfile builds successfully
- Container runs with proper permissions
- Binary is accessible and functional