### PR TITLE
fix: hide "new task" prompt if running in non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,20 @@ FORGE_DUMP_AUTO_OPEN=false     # Automatically open dump files in browser (defau
 </details>
 
 <details>
+<summary><strong>ZSH Plugin Configuration</strong></summary>
+
+Configure the ZSH plugin behavior:
+
+```bash
+# .env
+FORGE_CMD=forge                    # Command to use for forge operations (default: "forge")
+```
+
+The `FORGE_CMD` environment variable allows you to customize the command used by the ZSH plugin when transforming `#` prefixed commands. If not set, it defaults to `"forge"`.
+
+</details>
+
+<details>
 <summary><strong>System Configuration</strong></summary>
 
 System-level environment variables (usually set automatically):

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -963,19 +963,22 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
 
         self.spinner.stop(None)?;
 
-        let prompt_text = "Start a new conversation?";
-        let should_start_new_chat = ForgeSelect::confirm(prompt_text)
-            // Pressing ENTER should start new
-            .with_default(true)
-            .with_help_message("ESC = No, continue current conversation")
-            .prompt()
-            // Cancel or failure should continue with the session
-            .unwrap_or(Some(false))
-            .unwrap_or(false);
+        // Only prompt for new conversation if in interactive mode
+        if self.cli.is_interactive() {
+            let prompt_text = "Start a new conversation?";
+            let should_start_new_chat = ForgeSelect::confirm(prompt_text)
+                // Pressing ENTER should start new
+                .with_default(true)
+                .with_help_message("ESC = No, continue current conversation")
+                .prompt()
+                // Cancel or failure should continue with the session
+                .unwrap_or(Some(false))
+                .unwrap_or(false);
 
-        // if conversation is over
-        if should_start_new_chat {
-            self.on_new().await?;
+            // if conversation is over
+            if should_start_new_chat {
+                self.on_new().await?;
+            }
         }
 
         Ok(())

--- a/zsh-plugin/forge.plugin.zsh
+++ b/zsh-plugin/forge.plugin.zsh
@@ -4,7 +4,7 @@
 # Converts '# abc' to '$FORGE_CMD <<< abc' using ZLE widgets
 
 # Configuration: Change these variables to customize the forge command and special characters
-FORGE_CMD="forge"
+FORGE_CMD="${FORGE_CMD:-forge}"
 FORGE_RESUME_CONV="#\?\?"
 FORGE_NEW_CONV="#\?"
 


### PR DESCRIPTION
- **feat: add ZSH plugin configuration section to README.md**
- **fix: prompt for new conversation only in interactive mode**
