### PR TITLE
fix: minor ZSH plugin improvements

### DIFF
--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -115,11 +115,16 @@ impl From<&UIState> for Info {
 
 impl From<&Metrics> for Info {
     fn from(metrics: &Metrics) -> Self {
-        let duration = match metrics.duration() {
-            Some(d) => humantime::format_duration(Duration::from_secs(d.as_secs())).to_string(),
-            None => "0s".to_string(),
-        };
-        let mut info = Info::new().add_title(format!("TASK COMPLETED [in {duration}]"));
+        let mut info = Info::new();
+        if let Some(duration) = metrics.duration()
+            && duration.as_secs() > 0
+        {
+            let duration =
+                humantime::format_duration(Duration::from_secs(duration.as_secs())).to_string();
+            info = info.add_title(format!("TASK COMPLETED [in {duration}]"));
+        } else {
+            info = info.add_title(format!("TASK COMPLETED"))
+        }
 
         // Add file changes section inspired by the example format
         if metrics.files_changed.is_empty() {
@@ -410,7 +415,8 @@ impl From<&Conversation> for Info {
             info = info.add_key_value("Title", title);
         }
 
-        info
+        // Insert metrics information
+        info.extend(Info::from(&conversation.metrics))
     }
 }
 

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -123,7 +123,7 @@ impl From<&Metrics> for Info {
                 humantime::format_duration(Duration::from_secs(duration.as_secs())).to_string();
             info = info.add_title(format!("TASK COMPLETED [in {duration}]"));
         } else {
-            info = info.add_title(format!("TASK COMPLETED"))
+            info = info.add_title("TASK COMPLETED".to_string())
         }
 
         // Add file changes section inspired by the example format

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -696,7 +696,7 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
         match self.state.conversation_id {
             Some(ref id) => Ok(*id),
             None => {
-                let mut conversation_created = false;
+                let mut new_conversation = false;
                 self.spinner.start(Some("Initializing"))?;
 
                 // Select a model if workflow doesn't have one
@@ -718,11 +718,11 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
                         conversation
                     } else {
                         // Conversation doesn't exist, create a new one with this ID
-
+                        new_conversation = true;
                         Conversation::new(conversation_id)
                     }
                 } else {
-                    conversation_created = true;
+                    new_conversation = true;
                     Conversation::generate()
                 };
 
@@ -733,7 +733,7 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
                     .and_then(|ctx| ctx.usage)
                     .unwrap_or(self.state.usage.clone());
 
-                if conversation_created {
+                if new_conversation {
                     self.writeln_title(
                         TitleFormat::info("Initialized conversation")
                             .sub_title(conversation.id.into_string()),

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -124,9 +124,9 @@ function forge-accept-line() {
         echo  # Add a newline before execution for better UX
         eval "$BUFFER"
         
-        # Clear the buffer and reset prompt
-        BUFFER=""
-        CURSOR=0
+        # Set buffer to conversation pattern for continued interaction
+        BUFFER="?? "
+        CURSOR=${#BUFFER}
         zle reset-prompt
         return
     fi

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -1,13 +1,22 @@
 #!/usr/bin/env zsh
 
 # Forge ZSH Plugin - ZLE Widget Version
-# Converts '#? abc' to always resume conversations using ZLE widgets
+# Converts '?? abc' to always resume conversations using ZLE widgets
 # Features: Auto-resume existing conversations or start new ones, @ tab completion support
 
 # Configuration: Change these variables to customize the forge command and special characters
 # Using typeset to keep variables local to plugin scope and prevent public exposure
 typeset -h _FORGE_BIN="${FORGE_BIN:-forge}"
-typeset -h _FORGE_CONVERSATION_PATTERN="#\?"
+typeset -h _FORGE_CONVERSATION_PATTERN="\?\?"
+
+ZSH_HIGHLIGHT_HIGHLIGHTERS+=(pattern)
+ZSH_HIGHLIGHT_PATTERNS+=('(#s)\?\?' 'fg=green,bold,dim')
+
+# Make sure the pattern highlighter is enabled
+ZSH_HIGHLIGHT_HIGHLIGHTERS+=(pattern)
+# Match "?? " followed by anything, style it bold+dim (no color override)
+ZSH_HIGHLIGHT_PATTERNS+=('(#s)\?\? *' 'fg=white,bold')
+
 
 # Store conversation ID in a temporary variable (local to plugin)
 typeset -h _FORGE_CONVERSATION_ID=""
@@ -17,7 +26,7 @@ function _forge_transform_buffer() {
     local forge_cmd=""
     local input_text=""
     
-    # Check if the line starts with the conversation pattern (default: '# ')
+    # Check if the line starts with the conversation pattern (default: '??')
     if [[ "$BUFFER" =~ "^${_FORGE_CONVERSATION_PATTERN}(.*)$" ]]; then
         input_text="${match[1]}"
         
@@ -88,7 +97,7 @@ function forge-at-completion() {
 function forge-insert-pattern() {
     # Toggle the conversation pattern at the beginning of the line
     # while maintaining cursor position relative to the original text
-    local pattern="#? "
+    local pattern="?? "
     local original_cursor_pos=$CURSOR
     
     # Check if buffer already starts with the pattern
@@ -126,7 +135,7 @@ function forge-accept-line() {
         return
     fi
     
-    # For non-# commands, use normal accept-line
+    # For non-?? commands, use normal accept-line
     zle accept-line
 }
 
@@ -135,7 +144,7 @@ zle -N forge-insert-pattern
 zle -N forge-accept-line
 zle -N forge-at-completion
 
-# Bind Enter to our custom accept-line that transforms # commands
+# Bind Enter to our custom accept-line that transforms ?? commands
 bindkey '^M' forge-accept-line
 bindkey '^J' forge-accept-line
 

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # Forge ZSH Plugin - ZLE Widget Version
-# Converts '?? abc' to always resume conversations using ZLE widgets
+# Converts '#? abc' to always resume conversations using ZLE widgets
 # Features: Auto-resume existing conversations or start new ones, @ tab completion support
 
 # Configuration: Change these variables to customize the forge command and special characters
@@ -49,7 +49,44 @@ function _forge_transform_buffer() {
     return 0  # Successfully transformed
 }
 
-
+# ZLE widget for @ tab completion - opens fd | fzf
+function forge-at-completion() {
+    local current_word="${LBUFFER##* }"
+    
+    # Check if the current word starts with @
+    if [[ "$current_word" =~ ^@.*$ ]]; then
+        # Extract the part after @ for filtering
+        local filter_text="${current_word#@}"
+        
+        # Use fd to find files and fzf for interactive selection
+        local selected
+        if [[ -n "$filter_text" ]]; then
+            # If there's text after @, use it as initial filter
+            selected=$(fd --type f --hidden --exclude .git | fzf --query "$filter_text" --height 40% --reverse)
+        else
+            # If just @ was typed, show all files
+            selected=$(fd --type f --hidden --exclude .git | fzf --height 40% --reverse)
+        fi
+        
+        # If a file was selected, replace the @ text with the selected file path
+        if [[ -n "$selected" ]]; then
+            selected="@[${selected}]"
+            # Remove the @ and any text after it from LBUFFER
+            LBUFFER="${LBUFFER%$current_word}"
+            # Add the selected file path
+            BUFFER="${LBUFFER}${selected}${RBUFFER}"
+            # Move cursor to end of inserted text
+            CURSOR=$((${#LBUFFER} + ${#selected}))
+        fi
+        
+        # Reset the prompt
+        zle reset-prompt
+        return 0
+    fi
+    
+    # If not @ completion, fall back to default completion
+    zle expand-or-complete
+}
 
 # ZLE widget for Enter key that transforms #? commands to always resume conversations
 # ZLE widget for inserting conversation pattern
@@ -79,33 +116,6 @@ function forge-insert-pattern() {
     
     zle redisplay
 }
-# Function to clear the current conversation ID
-function forge-clear-conversation() {
-    _FORGE_CONVERSATION_ID=""    
-}
-
-# ZLE widget that triggers file picker immediately when @ is typed
-function forge-at-input() {
-    # Insert the @ character first
-    LBUFFER="${LBUFFER}@"
-    
-    # Immediately trigger file selection
-    local selected
-    selected=$(fd --type f --hidden --exclude .git | fzf --height 40% --reverse --prompt "Select file: ")
-    
-    # If a file was selected, replace the @ with the selected file path
-    if [[ -n "$selected" ]]; then
-        # Remove the @ we just added
-        LBUFFER="${LBUFFER%@}"
-        # Add the selected file path in the proper format
-        selected="@[${selected}]"
-        LBUFFER="${LBUFFER}${selected}"
-        CURSOR=${#LBUFFER}
-    fi
-    
-    # Reset the prompt
-    zle reset-prompt
-}
 
 function forge-accept-line() {
     # Attempt transformation using helper
@@ -128,8 +138,7 @@ function forge-accept-line() {
 # Register ZLE widgets
 zle -N forge-insert-pattern
 zle -N forge-accept-line
-zle -N forge-clear-conversation
-zle -N forge-at-input
+zle -N forge-at-completion
 
 # Bind Enter to our custom accept-line that transforms ?? commands
 bindkey '^M' forge-accept-line
@@ -138,7 +147,5 @@ bindkey '^J' forge-accept-line
 # Bind CTRL+G to insert/toggle conversation pattern  
 bindkey '^G' forge-insert-pattern
 
-# Bind CTRL+K to clear conversation
-bindkey '^K' forge-clear-conversation
-# Bind @ character to trigger immediate file picker
-bindkey '@' forge-at-input
+# Bind Tab to our custom @ completion widget  
+bindkey '^I' forge-at-completion  # Tab for @ completion

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -10,11 +10,7 @@ typeset -h _FORGE_BIN="${FORGE_BIN:-forge}"
 typeset -h _FORGE_CONVERSATION_PATTERN="\?\?"
 
 ZSH_HIGHLIGHT_HIGHLIGHTERS+=(pattern)
-ZSH_HIGHLIGHT_PATTERNS+=('(#s)\?\?' 'fg=green,bold,dim')
-
-# Make sure the pattern highlighter is enabled
-ZSH_HIGHLIGHT_HIGHLIGHTERS+=(pattern)
-# Match "?? " followed by anything, style it bold+dim (no color override)
+# Style the conversation pattern with appropriate highlighting
 ZSH_HIGHLIGHT_PATTERNS+=('(#s)\?\? *' 'fg=white,bold')
 
 

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -120,6 +120,10 @@ function forge-insert-pattern() {
     
     zle redisplay
 }
+# Function to clear the current conversation ID
+function forge-clear-conversation() {
+    _FORGE_CONVERSATION_ID=""    
+}
 
 function forge-accept-line() {
     # Attempt transformation using helper
@@ -143,6 +147,7 @@ function forge-accept-line() {
 zle -N forge-insert-pattern
 zle -N forge-accept-line
 zle -N forge-at-completion
+zle -N forge-clear-conversation
 
 # Bind Enter to our custom accept-line that transforms ?? commands
 bindkey '^M' forge-accept-line
@@ -153,3 +158,5 @@ bindkey '^G' forge-insert-pattern
 
 # Bind Tab to our custom @ completion widget  
 bindkey '^I' forge-at-completion  # Tab for @ completion
+# Bind CTRL+K to clear conversation
+bindkey '^K' forge-clear-conversation


### PR DESCRIPTION
- Showing conversation information before and after the conversation
- Typing `@` in ZSH will auto-trigger the file selector
- Changed the pattern from `#?` to `??`
- Improved colors for text after the `??` sentinel
- CTRL + K will clear the conversation (TEMP FIX)