### PR TITLE
plugin feedback improvement

### DIFF
--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -414,7 +414,11 @@ impl From<&Conversation> for Info {
         }
 
         // Insert metrics information
-        info.extend(Info::from(&conversation.metrics))
+        if !conversation.metrics.files_changed.is_empty() {
+            info.extend(&conversation.metrics)
+        } else {
+            info
+        }
     }
 }
 

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -47,8 +47,8 @@ impl Info {
         self
     }
 
-    pub fn extend(mut self, other: Info) -> Self {
-        self.sections.extend(other.sections);
+    pub fn extend(mut self, other: impl Into<Info>) -> Self {
+        self.sections.extend(other.into().sections);
         self
     }
 }
@@ -94,10 +94,12 @@ impl From<&Environment> for Info {
 
 impl From<&UIState> for Info {
     fn from(value: &UIState) -> Self {
-        let mut info = Info::new().add_title("MODEL");
+        let mut info = Info::new().add_title("AGENT");
+
+        info = info.add_key_value("Name", value.operating_agent.as_str());
 
         if let Some(model) = &value.model {
-            info = info.add_key_value("Current", model);
+            info = info.add_key_value("Model", model);
         }
 
         if let Some(provider) = &value.provider {
@@ -107,7 +109,7 @@ impl From<&UIState> for Info {
             }
         }
 
-        info = info.extend(get_usage(value));
+        info = info.extend(&value.usage);
 
         info
     }
@@ -167,40 +169,36 @@ impl From<&Metrics> for Info {
     }
 }
 
-pub fn get_usage(state: &UIState) -> Info {
-    let cache_percentage = calculate_cache_percentage(&state.usage);
-    let cached_display = if cache_percentage > 0 {
-        format!(
-            "{} [{}%]",
-            state.usage.cached_tokens.to_formatted_string(&Locale::en),
-            cache_percentage
-        )
-    } else {
-        state.usage.cached_tokens.to_formatted_string(&Locale::en)
-    };
+impl From<&Usage> for Info {
+    fn from(value: &Usage) -> Self {
+        let cache_percentage = calculate_cache_percentage(value);
+        let cached_display = if cache_percentage > 0 {
+            format!(
+                "{} [{}%]",
+                value.cached_tokens.to_formatted_string(&Locale::en),
+                cache_percentage
+            )
+        } else {
+            value.cached_tokens.to_formatted_string(&Locale::en)
+        };
 
-    let mut usage = Info::new()
-        .add_title("TOKEN USAGE")
-        .add_key_value(
-            "Input Tokens",
-            state.usage.prompt_tokens.to_formatted_string(&Locale::en),
-        )
-        .add_key_value("Cached Tokens", cached_display)
-        .add_key_value(
-            "Output Tokens",
-            state
-                .usage
-                .completion_tokens
-                .to_formatted_string(&Locale::en),
-        );
+        let mut usage_info = Info::new()
+            .add_title("TOKEN USAGE")
+            .add_key_value(
+                "Input Tokens",
+                value.prompt_tokens.to_formatted_string(&Locale::en),
+            )
+            .add_key_value("Cached Tokens", cached_display)
+            .add_key_value(
+                "Output Tokens",
+                value.completion_tokens.to_formatted_string(&Locale::en),
+            );
 
-    let is_forge_provider = state.provider.as_ref().is_some_and(|p| p.is_forge());
-    if let Some(cost) = state.usage.cost.as_ref()
-        && !is_forge_provider
-    {
-        usage = usage.add_key_value("Cost", format!("${cost:.4}"));
+        if let Some(cost) = value.cost.as_ref() {
+            usage_info = usage_info.add_key_value("Cost", format!("${cost:.4}"));
+        }
+        usage_info
     }
-    usage
 }
 
 fn calculate_cache_percentage(usage: &Usage) -> u8 {

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -96,7 +96,7 @@ impl From<&UIState> for Info {
     fn from(value: &UIState) -> Self {
         let mut info = Info::new().add_title("AGENT");
 
-        info = info.add_key_value("Name", value.operating_agent.as_str());
+        info = info.add_key_value("Name", value.operating_agent.as_str().to_uppercase());
 
         if let Some(model) = &value.model {
             info = info.add_key_value("Model", model);

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1032,9 +1032,8 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
                 }
             }
             ChatResponse::TaskComplete => {
-                if let Some(conversation_id) = self.state.conversation_id.as_ref() {
-                    let conversation = self.api.conversation(conversation_id).await?;
-                    self.on_completion(conversation.unwrap()).await?;
+                if let Some(conversation_id) = self.state.conversation_id {
+                    self.on_completion(conversation_id).await?;
                 }
             }
         }
@@ -1054,8 +1053,13 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
         Ok(())
     }
 
-    async fn on_completion(&mut self, conversation: Conversation) -> anyhow::Result<()> {
+    async fn on_completion(&mut self, conversation_id: ConversationId) -> anyhow::Result<()> {
         self.spinner.start(Some("Loading Summary"))?;
+        let conversation = self
+            .api
+            .conversation(&conversation_id)
+            .await?
+            .ok_or(anyhow::anyhow!("Conversation not found: {conversation_id}"))?;
 
         let info = Info::default().extend(&conversation).extend(&self.state);
 

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -105,7 +105,6 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
         self.display_banner()?;
         self.trace_user();
         self.hydrate_caches();
-        self.init_conversation().await?;
         Ok(())
     }
 

--- a/shell-plugin/README.md
+++ b/shell-plugin/README.md
@@ -88,6 +88,8 @@ Clear the current conversation context:
 
 ```bash
 :reset
+# or use the alias
+:r
 ```
 
 This will:
@@ -95,6 +97,22 @@ This will:
 - Clear the current conversation ID
 - Reset the session state
 - Display a confirmation message with timestamp
+
+#### System Information
+
+View system and project information:
+
+```bash
+:info
+# or use the alias
+:i
+```
+
+This displays:
+
+- System information
+- Project details
+- Current configuration
 
 #### Session Status
 
@@ -169,6 +187,7 @@ All transformed commands are properly saved to ZSH history, allowing you to:
 : I'm working on a Rust web API
 : What are the best practices for error handling?
 : Show me an example with @[src/errors.rs]
+:info
 :reset
 : New conversation starts here
 ```

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -26,6 +26,12 @@ function _forge_fzf() {
     fzf --cycle --select-1 --height 40% --reverse "$@"
 }
 
+# Helper function to print operating agent messages with consistent formatting
+function _forge_print_agent_message() {
+    local agent_name="${1:-${FORGE_ACTIVE_AGENT}}"
+    echo "\033[33m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] \033[1;37m${agent_name:u}\033[0m \033[90mis now active\033[0m"
+}
+
 
 
 # Store conversation ID in a temporary variable (local to plugin)
@@ -125,12 +131,23 @@ function forge-accept-line() {
             echo "\033[36m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] Reset ${FORGE_CONVERSATION_ID}\033[0m"
         fi
         
-        echo "\033[36m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] Reset operating agent to FORGE"
+        _forge_print_agent_message "FORGE"
         
         FORGE_CONVERSATION_ID=""
         FORGE_ACTIVE_AGENT="forge"
         BUFFER=""
         CURSOR=${#BUFFER}
+        zle reset-prompt
+        return 0
+    fi
+
+    # Check if input_text is empty - just set the active agent
+    if [[ -z "$input_text" ]]; then
+        echo
+        FORGE_ACTIVE_AGENT="${user_action:-${FORGE_ACTIVE_AGENT}}"
+        _forge_print_agent_message
+        BUFFER=""
+        CURSOR=0
         zle reset-prompt
         return 0
     fi

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -29,10 +29,8 @@ function _forge_fzf() {
 # Helper function to print operating agent messages with consistent formatting
 function _forge_print_agent_message() {
     local agent_name="${1:-${FORGE_ACTIVE_AGENT}}"
-    echo "\033[33m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] \033[1;37m${agent_name:u}\033[0m \033[90mis now active\033[0m"
+    echo "\033[33m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] \033[1;37m${agent_name:u}\033[0m \033[90mis now the active agent\033[0m"
 }
-
-
 
 # Store conversation ID in a temporary variable (local to plugin)
 export FORGE_CONVERSATION_ID=""
@@ -140,7 +138,20 @@ function forge-accept-line() {
         zle reset-prompt
         return 0
     fi
-
+    
+    # Handle info command specially
+    if [[ "$user_action" == "info" || "$user_action" == "i" ]]; then
+        echo
+        
+        # Run forge info
+        $_FORGE_BIN info
+        
+        BUFFER=""
+        CURSOR=${#BUFFER}
+        zle reset-prompt
+        return 0
+    fi
+    
     # Check if input_text is empty - just set the active agent
     if [[ -z "$input_text" ]]; then
         echo

--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -125,6 +125,8 @@ function forge-accept-line() {
             echo "\033[36m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] Reset ${FORGE_CONVERSATION_ID}\033[0m"
         fi
         
+        echo "\033[36m⏺\033[0m \033[90m[$(date '+%H:%M:%S')] Reset operating agent to FORGE"
+        
         FORGE_CONVERSATION_ID=""
         FORGE_ACTIVE_AGENT="forge"
         BUFFER=""


### PR DESCRIPTION
- **fix: add log message for resetting operating agent in forge-accept-line function**
- **fix: handle empty user-input**
- **refactor: streamline Info struct extensions and remove unused usage retrieval**
- **fix: update agent message formatting and handle 'info' command in forge-accept-line**
- **fix: simplify conversation completion handling in UI**
- **feat: add system information command and alias to README**
- **fix: avoid extending Info with empty metrics in Conversation**
- **fix: convert operating agent name to uppercase in UIState info**
