### PR TITLE
fix: correct command references from "/conversations" to "/conversation"

### DIFF
--- a/crates/forge_main/src/banner.rs
+++ b/crates/forge_main/src/banner.rs
@@ -31,7 +31,7 @@ pub fn display(cli_mode: bool) -> io::Result<()> {
         // Interactive mode: show all commands
         vec![
             ("New conversation:", "/new"),
-            ("Get started:", "/info, /usage, /help, /conversations"),
+            ("Get started:", "/info, /usage, /help, /conversation"),
             ("Switch model:", "/model"),
             ("Switch agent:", "/forge or /muse or /agent"),
             ("Update:", "/update"),

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -360,7 +360,7 @@ impl ForgeCommandManager {
             "/login" => Ok(Command::Login),
             "/logout" => Ok(Command::Logout),
             "/retry" => Ok(Command::Retry),
-            "/conversations" | "/list" => Ok(Command::Conversations),
+            "/conversation" | "/list" => Ok(Command::Conversations),
             text => {
                 let parts = text.split_ascii_whitespace().collect::<Vec<&str>>();
 
@@ -518,7 +518,7 @@ impl Command {
             Command::Login => "login",
             Command::Logout => "logout",
             Command::Retry => "retry",
-            Command::Conversations => "conversations",
+            Command::Conversations => "conversation",
             Command::AgentSwitch(agent_id) => agent_id,
         }
     }
@@ -739,7 +739,7 @@ mod tests {
         let cmd_manager = ForgeCommandManager::default();
 
         // Execute
-        let result = cmd_manager.parse("/conversations").unwrap();
+        let result = cmd_manager.parse("/conversation").unwrap();
 
         // Verify
         match result {
@@ -757,7 +757,7 @@ mod tests {
         let commands = manager.list();
 
         // The list command should be included
-        let contains_list = commands.iter().any(|cmd| cmd.name == "conversations");
+        let contains_list = commands.iter().any(|cmd| cmd.name == "conversation");
         assert!(
             contains_list,
             "Conversations command should be in default commands"

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -360,7 +360,7 @@ impl ForgeCommandManager {
             "/login" => Ok(Command::Login),
             "/logout" => Ok(Command::Logout),
             "/retry" => Ok(Command::Retry),
-            "/conversation" | "/list" => Ok(Command::Conversations),
+            "/conversation" | "/conversations" => Ok(Command::Conversations),
             text => {
                 let parts = text.split_ascii_whitespace().collect::<Vec<&str>>();
 


### PR DESCRIPTION
fixes https://github.com/antinomyhq/forge/issues/1649