### PR TITLE
fix: improve OpenAI and Anthropic compatible provider types

### DIFF
--- a/crates/forge_app/src/dto/provider.rs
+++ b/crates/forge_app/src/dto/provider.rs
@@ -36,6 +36,9 @@ pub enum ProviderId {
     VertexAi,
     BigModel,
     Azure,
+    #[serde(rename = "openai_compatible")]
+    OpenAICompatible,
+    AnthropicCompatible,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/forge_services/src/provider/provider.json
+++ b/crates/forge_services/src/provider/provider.json
@@ -34,6 +34,14 @@
   {
     "id": "openai",
     "api_key_vars": "OPENAI_API_KEY",
+    "url_param_vars": [],
+    "response_type": "OpenAI",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "model_url": "https://api.openai.com/v1/models"
+  },
+  {
+    "id": "openai_compatible",
+    "api_key_vars": "OPENAI_API_KEY",
     "url_param_vars": ["OPENAI_URL"],
     "response_type": "OpenAI",
     "url": "{{#if OPENAI_URL}}{{OPENAI_URL}}{{else}}https://api.openai.com/v1{{/if}}/chat/completions",
@@ -41,6 +49,14 @@
   },
   {
     "id": "anthropic",
+    "api_key_vars": "ANTHROPIC_API_KEY",
+    "url_param_vars": [],
+    "response_type": "Anthropic",
+    "url": "https://api.anthropic.com/v1/messages",
+    "model_url": "https://api.anthropic.com/v1/models"
+  },
+  {
+    "id": "anthropic_compatible",
     "api_key_vars": "ANTHROPIC_API_KEY",
     "url_param_vars": ["ANTHROPIC_URL"],
     "response_type": "Anthropic",


### PR DESCRIPTION

Openai compatible providers dont work as expected, the requests for models are passed to default URL instead of the custom URL

# Reproducing
```
set OPENAI_URL=..
sets OPENAI_API_KEY=..
```
starting forge shows failed to fetch models

# Changes

Made Compatible providers as a separate provider type, simplifying the resolution logic and added tests

# Todo
[] test with custom anthropic provider