### PR TITLE
fix: tool calls to agent

### DIFF
--- a/crates/forge_app/src/agent_executor.rs
+++ b/crates/forge_app/src/agent_executor.rs
@@ -61,7 +61,7 @@ impl<S: Services> AgentExecutor<S> {
         let app = crate::ForgeApp::new(self.services.clone());
         let mut response_stream = app
             .chat(ChatRequest::new(
-                Event::new(format!("{agent_id}"), Some(task.clone())),
+                Event::new(agent_id.to_string(), Some(task.clone())),
                 conversation.id,
             ))
             .await?;


### PR DESCRIPTION
- From PR #1630, agent subscribes to itself directly on id. so when calling agent as tool we've send event with id only.