### PR TITLE
fix: Display correct message for write tool based on file existence

### DIFF
--- a/crates/forge_app/src/fmt/fmt_input.rs
+++ b/crates/forge_app/src/fmt/fmt_input.rs
@@ -36,11 +36,8 @@ impl FormatContent for Tools {
             }
             Tools::Write(input) => {
                 let display_path = display_path_for(&input.path);
-                let title = if input.overwrite {
-                    "Overwrite"
-                } else {
-                    "Create"
-                };
+                let file_exists = Path::new(&input.path).exists();
+                let title = if file_exists { "Overwrite" } else { "Create" };
                 Some(TitleFormat::debug(title).sub_title(display_path).into())
             }
             Tools::Search(input) => {
@@ -83,6 +80,119 @@ impl FormatContent for Tools {
                     .into(),
             ),
             Tools::Plan(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use forge_domain::FSWrite;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn setup_env() -> (Environment, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let env = Environment {
+            os: "test".to_string(),
+            pid: 1,
+            cwd: temp_dir.path().to_path_buf(),
+            home: None,
+            shell: "bash".to_string(),
+            base_path: temp_dir.path().to_path_buf(),
+            forge_api_url: "http://localhost".parse().unwrap(),
+            retry_config: Default::default(),
+            max_search_lines: 100,
+            max_search_result_bytes: 1000,
+            fetch_truncation_limit: 1000,
+            stdout_max_prefix_length: 100,
+            stdout_max_suffix_length: 100,
+            stdout_max_line_length: 100,
+            max_read_size: 1000,
+            http: Default::default(),
+            max_file_size: 1000,
+            max_image_size: 1000,
+            tool_timeout: 300,
+            auto_open_dump: false,
+            custom_history_path: None,
+            max_conversations: 100,
+        };
+        (env, temp_dir)
+    }
+
+    #[test]
+    fn test_write_shows_create_for_new_file() {
+        let (env, temp_dir) = setup_env();
+        let new_file_path = temp_dir.path().join("new_file.txt");
+
+        let input = FSWrite {
+            path: new_file_path.to_string_lossy().to_string(),
+            content: "test content".to_string(),
+            overwrite: false,
+        };
+
+        let tool = Tools::Write(input);
+        let actual = tool.to_content(&env);
+
+        assert!(actual.is_some());
+        let content = actual.unwrap();
+        if let ChatResponseContent::Title(title) = content {
+            assert_eq!(title.title, "Create");
+        } else {
+            panic!("Expected Title content");
+        }
+    }
+
+    #[test]
+    fn test_write_shows_overwrite_for_existing_file() {
+        let (env, temp_dir) = setup_env();
+        let existing_file_path = temp_dir.path().join("existing_file.txt");
+
+        // Create the file first
+        fs::write(&existing_file_path, "existing content").unwrap();
+
+        let input = FSWrite {
+            path: existing_file_path.to_string_lossy().to_string(),
+            content: "new content".to_string(),
+            overwrite: true,
+        };
+
+        let tool = Tools::Write(input);
+        let actual = tool.to_content(&env);
+
+        assert!(actual.is_some());
+        let content = actual.unwrap();
+        if let ChatResponseContent::Title(title) = content {
+            assert_eq!(title.title, "Overwrite");
+        } else {
+            panic!("Expected Title content");
+        }
+    }
+
+    #[test]
+    fn test_write_shows_create_for_new_file_with_overwrite_flag() {
+        let (env, temp_dir) = setup_env();
+        let new_file_path = temp_dir.path().join("new_file.txt");
+
+        // File doesn't exist, but overwrite flag is set to true
+        let input = FSWrite {
+            path: new_file_path.to_string_lossy().to_string(),
+            content: "test content".to_string(),
+            overwrite: true,
+        };
+
+        let tool = Tools::Write(input);
+        let actual = tool.to_content(&env);
+
+        assert!(actual.is_some());
+        let content = actual.unwrap();
+        if let ChatResponseContent::Title(title) = content {
+            // Should show "Create" because file doesn't exist, regardless of overwrite flag
+            assert_eq!(title.title, "Create");
+        } else {
+            panic!("Expected Title content");
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes issue #1755 where the write tool incorrectly displays 'Overwrite' message instead of 'Create' when creating a new file.

## Changes
- Modified `crates/forge_app/src/fmt/fmt_input.rs` to check if the file actually exists on the filesystem
- Now displays 'Create' when the file doesn't exist, regardless of the `overwrite` flag setting
- Only displays 'Overwrite' when the file actually exists
- Added comprehensive test suite with 3 test cases to verify the behavior

## Test Cases
1. `test_write_shows_create_for_new_file` - Verifies 'Create' is shown for new files
2. `test_write_shows_overwrite_for_existing_file` - Verifies 'Overwrite' is shown when file exists
3. `test_write_shows_create_for_new_file_with_overwrite_flag` - Verifies 'Create' is shown even when overwrite flag is true but file doesn't exist

Closes #1755

Co-Authored-By: ForgeCode <noreply@forgecode.dev>