### PR TITLE
fix(ui): display full error details in stderr output

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -263,7 +263,7 @@ impl<A: API + 'static, F: Fn() -> A> UI<A, F> {
                                     tracker::error(&error);
                                     tracing::error!(error = ?error);
                                     self.spinner.stop(None)?;
-                                    self.writeln_to_stderr(TitleFormat::error(error.to_string()).display().to_string())?;
+                                    self.writeln_to_stderr(TitleFormat::error(format!("{:?}", error)).display().to_string())?;
                                 },
                             }
                         }


### PR DESCRIPTION
<img width="1056" height="133" alt="Screenshot 2025-11-18 at 8 16 58 PM" src="https://github.com/user-attachments/assets/3a6a717f-5742-4f80-8629-920efc7dc924" />
