### PR TITLE
fix(zsh): ensure arrow keys function correctly in dialoguer

### DIFF
--- a/shell-plugin/forge.plugin.zsh
+++ b/shell-plugin/forge.plugin.zsh
@@ -63,7 +63,14 @@ function _forge_exec() {
     # Ensure FORGE_ACTIVE_AGENT always has a value, default to "forge"
     local agent_id="${_FORGE_ACTIVE_AGENT:-forge}"
     
+    # Disable application cursor keys mode - ensures arrow keys work in dialoguer
+    # Without this, arrow keys send wrong sequences and print A/B characters
+    printf '\e[?1l'
+    
     eval "$_FORGE_BIN --agent $(printf '%q' "$agent_id") $(printf '%q ' "$@")"
+    
+    # Re-enable application cursor keys mode
+    printf '\e[?1h'
 }
 
 # Helper function to clear buffer and reset prompt


### PR DESCRIPTION
Fixes terminal mode handling issues in the Zsh plugin to prevent escape sequences and character issues in interactive prompts:

**Changes:**
- Disable application cursor keys mode to fix arrow key sequences (prevents A/B characters)
- Re-enable mode after command completion

**Fixes:**
- Arrow keys now work correctly in interactive prompts

Co-Authored-By: ForgeCode <noreply@forgecode.dev>