### PR TITLE
feat(zsh): add conversation rename command

### DIFF
--- a/crates/forge_main/src/built_in_commands.json
+++ b/crates/forge_main/src/built_in_commands.json
@@ -74,5 +74,9 @@
   {
     "command": "clone",
     "description": "Clone and manage conversation context"
+  },
+  {
+    "command": "rename",
+    "description": "Rename conversation"
   }
 ]

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -179,6 +179,9 @@ function forge-accept-line() {
         clone)
             _forge_action_clone "$input_text"
         ;;
+        rename)
+            _forge_action_rename "$input_text"
+        ;;
         sync)
             _forge_action_sync
         ;;


### PR DESCRIPTION
Add conversation rename functionality to ZSH shell plugin.

Changes:
- Add rename command to built_in_commands.json
- Add _forge_action_rename function to conversation.zsh
- Add rename case to dispatcher.zsh
- Support both direct rename and interactive mode
- Handle current conversation rename when no ID provided
- Use fzf for conversation selection in interactive mode
- Show success/error feedback with appropriate logging

Usage:
- Direct: rename abc123 New Title
- Current: rename New Title  
- Interactive: rename

Depends on PR #2076