### PR TITLE
fix(zsh): add buffer redisplay before prompt reset in bracketed paste handler

### DIFF
--- a/shell-plugin/lib/bindings.zsh
+++ b/shell-plugin/lib/bindings.zsh
@@ -7,8 +7,17 @@ zle -N forge-accept-line
 zle -N forge-completion
 
 # Custom bracketed-paste handler to fix syntax highlighting after paste
+# Addresses timing issues by ensuring buffer state stabilizes before prompt reset
 function forge-bracketed-paste() {
+    # Call the built-in bracketed-paste widget first
     zle .$WIDGET "$@"
+    
+    # Explicitly redisplay the buffer to ensure paste content is visible
+    # This is critical for large or multiline pastes
+    zle redisplay
+    
+    # Reset the prompt to trigger syntax highlighting refresh
+    # The redisplay before reset-prompt ensures the buffer is fully rendered
     zle reset-prompt
 }
 


### PR DESCRIPTION
## Summary

Resolves timing issues in the ZSH bracketed paste handler that caused pasted content to become invisible or improperly rendered. The fix adds an explicit buffer redisplay step between paste execution and prompt reset, ensuring paste content stabilizes before syntax highlighting refresh.

## Changes

- Added `zle redisplay` call after bracketed-paste widget execution
- Ensures buffer state stabilizes before `reset-prompt` is triggered
- Enhanced inline documentation explaining the timing-sensitive operation sequence

## Impact

- Fixes large/multiline paste content disappearing or not rendering properly
- Ensures syntax highlighting correctly applies to pasted content
- Improves overall paste reliability in ZSH shell integration

---
Co-Authored-By: ForgeCode <noreply@forgecode.dev>