### PR TITLE
fix(select): adjust cursor position in prompt suffix

### DIFF
--- a/crates/forge_select/src/select.rs
+++ b/crates/forge_select/src/select.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use console::{strip_ansi_codes, style};
+use crossterm::cursor;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, FuzzySelect, Input, MultiSelect};
 
@@ -38,7 +39,7 @@ impl ForgeSelect {
     /// suffix arrow
     fn default_theme() -> ColorfulTheme {
         ColorfulTheme {
-            prompt_suffix: style("".to_string()),
+            prompt_suffix: style(format!("{}", cursor::MoveLeft(1))),
             ..ColorfulTheme::default()
         }
     }


### PR DESCRIPTION
Before:
<img width="1307" height="136" alt="image" src="https://github.com/user-attachments/assets/0bdcabd2-cf37-4311-9d95-516442c58111" />

After:
<img width="1304" height="135" alt="image" src="https://github.com/user-attachments/assets/f982bf84-5d5d-4cfd-8954-2292fc831b05" />
