### PR TITLE
test(operation): fix flaky test_fs_remove_success by setting deterministic cwd

### DIFF
--- a/crates/forge_app/src/operation.rs
+++ b/crates/forge_app/src/operation.rs
@@ -584,6 +584,7 @@ mod tests {
         let max_bytes: f64 = 250.0 * 1024.0; // 250 KB
         let fixture: Environment = Faker.fake();
         fixture
+            .cwd(PathBuf::from("/projects/test")) // Set deterministic cwd to avoid flaky path formatting
             .max_search_lines(25)
             .max_search_result_bytes(max_bytes.ceil() as usize)
             .fetch_truncation_limit(55)


### PR DESCRIPTION
## Summary

Fixes flaky snapshot test by ensuring deterministic path formatting across test runs. The test was randomly failing due to non-deterministic faker-generated  values causing inconsistent path prefix stripping.

## Problem

The  test was flaky with intermittent snapshot failures:
- **Expected**: `path="/home/user/file_to_delete.txt"`
- **Got**: `path="home/user/file_to_delete.txt"` (missing leading slash)

### Root Cause

1. The test used faker to generate a random `Environment` fixture
2. The `cwd` field was randomly generated by faker (e.g., `/home/user`, `/tmp`, `/projects/xyz`)
3. The `format_display_path` function strips the `cwd` prefix from paths when they match
4. When faker generated `cwd="/home/user"`, it would strip that from `/home/user/file_to_delete.txt` → `file_to_delete.txt`
5. When faker generated a different `cwd`, the full path was preserved → `/home/user/file_to_delete.txt`

## Solution

Set a deterministic `cwd` value in `fixture_environment()` that doesn't match the test paths:

```rust
fixture.cwd(PathBuf::from("/projects/test"))
```

This ensures consistent path formatting across all test runs since `/projects/test` never matches the test path `/home/user/file_to_delete.txt`.

## Verification

- ✅ Test runs successfully 10 times in a row
- ✅ All 343 tests in forge_app pass
- ✅ Snapshot output is now consistent

Co-Authored-By: ForgeCode <noreply@forgecode.dev>