### PR TITLE
fix(zsh): prevent environment variable pollution by removing export from plugin and theme markers

### DIFF
--- a/crates/forge_main/src/zsh/plugin.rs
+++ b/crates/forge_main/src/zsh/plugin.rs
@@ -50,7 +50,7 @@ pub fn generate_zsh_plugin() -> Result<String> {
     output.push_str(&completions_str);
 
     // Set environment variable to indicate plugin is loaded (with timestamp)
-    output.push_str("\nexport _FORGE_PLUGIN_LOADED=$(date +%s)\n");
+    output.push_str("\n_FORGE_PLUGIN_LOADED=$(date +%s)\n");
 
     Ok(output)
 }
@@ -60,7 +60,7 @@ pub fn generate_zsh_theme() -> Result<String> {
     let mut content = include_str!("../../../../shell-plugin/forge.theme.zsh").to_string();
 
     // Set environment variable to indicate theme is loaded (with timestamp)
-    content.push_str("\nexport _FORGE_THEME_LOADED=$(date +%s)\n");
+    content.push_str("\n_FORGE_THEME_LOADED=$(date +%s)\n");
 
     Ok(content)
 }


### PR DESCRIPTION
## Summary

Removes `export` keyword from `_FORGE_PLUGIN_LOADED` and `_FORGE_THEME_LOADED` variables to prevent unnecessary environment variable pollution. These internal marker variables are used exclusively by the `forge zsh doctor` command to verify plugin and theme loading status and do not need to be propagated to child processes.

## Changes

- **crates/forge_main/src/zsh/plugin.rs:53**: Remove `export` from `_FORGE_PLUGIN_LOADED` variable assignment
- **crates/forge_main/src/zsh/plugin.rs:63**: Remove `export` from `_FORGE_THEME_LOADED` variable assignment

## Rationale

The `_FORGE_PLUGIN_LOADED` and `_FORGE_THEME_LOADED` variables serve as internal markers checked by the diagnostic script (shell-plugin/doctor.zsh:150, 193) to determine if Forge's ZSH plugin and theme are properly loaded. These variables:

- Are implementation details not intended for user interaction
- Don't need to be available to child processes
- Should remain local to the current shell session
- Using `export` unnecessarily pollutes the environment namespace

By removing `export`, these variables remain accessible within the current shell session for diagnostic purposes while maintaining cleaner environment variable hygiene.

## Testing

The variables continue to function correctly for their intended purpose:
- The `forge zsh doctor` command still detects plugin/theme loading status
- Variables remain accessible within the current shell session
- No child processes depend on these variables

Co-Authored-By: ForgeCode <noreply@forgecode.dev>