### PR TITLE
feat(html): add error styling for failed tool calls

### DIFF
--- a/crates/forge_domain/src/conversation_style.css
+++ b/crates/forge_domain/src/conversation_style.css
@@ -210,3 +210,27 @@ img {
   color: #28a745;
   font-weight: 600;
 }
+
+/* Tool Call Error Styles */
+.tool-call-error {
+  background-color: #fff5f5;
+  border-left: 4px solid #ef4444;
+  padding: 16px;
+  margin: 12px 0;
+  border-radius: 4px;
+}
+
+.tool-call-error .error-cause {
+  color: #dc2626;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.tool-call-error .error-reflection {
+  background-color: #fee2e2;
+  padding: 12px;
+  border-radius: 4px;
+  margin-top: 8px;
+  font-size: 0.9em;
+  color: #7f1d1d;
+}

--- a/crates/forge_domain/src/snapshots/forge_domain__conversation_html__tests__conversation.snap
+++ b/crates/forge_domain/src/snapshots/forge_domain__conversation_html__tests__conversation.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/forge_domain/src/conversation_html.rs
+assertion_line: 413
 expression: html_bytes
 extension: html
 snapshot_kind: binary

--- a/crates/forge_domain/src/snapshots/forge_domain__conversation_html__tests__conversation.snap.html
+++ b/crates/forge_domain/src/snapshots/forge_domain__conversation_html__tests__conversation.snap.html
@@ -225,7 +225,30 @@ img {
   color: #28a745;
   font-weight: 600;
 }
-</style>
+
+/* Tool Call Error Styles */
+.tool-call-error {
+  background-color: #fff5f5;
+  border-left: 4px solid #ef4444;
+  padding: 16px;
+  margin: 12px 0;
+  border-radius: 4px;
+}
+
+.tool-call-error .error-cause {
+  color: #dc2626;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.tool-call-error .error-reflection {
+  background-color: #fee2e2;
+  padding: 12px;
+  border-radius: 4px;
+  margin-top: 8px;
+  font-size: 0.9em;
+  color: #7f1d1d;
+}</style>
 </head>
 <body>
 <div


### PR DESCRIPTION
<img width="1397" height="286" alt="image" src="https://github.com/user-attachments/assets/5f34082a-c3d4-4585-90d6-5dd41f8c6a62" />
Co-Authored-By: Amit Singh <amitksingh1490@gmail.com>
Co-Authored-By: ForgeCode <noreply@forgecode.dev>
