### PR TITLE
fix(zsh): remove unnecessary command ready log message

### DIFF
--- a/shell-plugin/lib/actions/editor.zsh
+++ b/shell-plugin/lib/actions/editor.zsh
@@ -62,7 +62,6 @@ function _forge_action_editor() {
     BUFFER=": $content"
     CURSOR=${#BUFFER}
     
-    _forge_log info "Command ready - press Enter to execute"
     zle reset-prompt
 }
 


### PR DESCRIPTION
## Summary

Removes redundant informational log message from the Zsh shell plugin editor action. This streamlines the command editing workflow by reducing visual noise while maintaining the core functionality of buffer manipulation and prompt reset.

## Changes

- Removed `_forge_log info "Command ready - press Enter to execute"` from `_forge_action_editor` function
- The command buffer is still properly populated and the prompt is reset as expected
- Users can still see the command in their buffer without the additional log message

## Impact

- Cleaner, less cluttered terminal output during command editing
- Improved user experience with reduced visual noise
- No functional changes to the editor workflow

Co-Authored-By: ForgeCode <noreply@forgecode.dev>