### PR TITLE
chore: add HTTP 522 to retry status codes

### DIFF
--- a/crates/forge_domain/src/retry_config.rs
+++ b/crates/forge_domain/src/retry_config.rs
@@ -42,7 +42,7 @@ impl Default for RetryConfig {
             min_delay_ms: 1000,
             backoff_factor: 2,
             max_retry_attempts: 8,
-            retry_status_codes: vec![429, 500, 502, 503, 504, 408],
+            retry_status_codes: vec![429, 500, 502, 503, 504, 408, 522],
             max_delay: None,
             suppress_retry_errors: false,
         }
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(config.max_retry_attempts, 8);
         assert_eq!(
             config.retry_status_codes,
-            vec![429, 500, 502, 503, 504, 408]
+            vec![429, 500, 502, 503, 504, 408, 522]
         );
         assert_eq!(config.suppress_retry_errors, false);
     }

--- a/crates/forge_repo/src/provider/openai_responses/repository.rs
+++ b/crates/forge_repo/src/provider/openai_responses/repository.rs
@@ -688,7 +688,7 @@ mod tests {
 
         assert_eq!(
             repo.retry_config.retry_status_codes,
-            vec![429, 500, 502, 503, 504, 408]
+            vec![429, 500, 502, 503, 504, 408, 522]
         );
     }
 


### PR DESCRIPTION
## Summary

This PR adds HTTP status code 522 (Connection Timed Out) to the default retry configuration.

## Changes

- Added status code 522 to `RetryConfig::default()` retry_status_codes list
- Updated corresponding tests in:
  - `forge_domain/src/retry_config.rs`
  - `forge_repo/src/provider/openai_responses/repository.rs`

## Context

HTTP 522 is a Cloudflare-specific error that indicates the origin server connection timed out. This is a transient network error that should be retried, similar to other 5xx errors already in our retry list (500, 502, 503, 504).

This change was extracted from the `fix/sub-workspace` PR where it was unrelated to the main workspace refactoring changes.

## Testing

- ✅ All retry_config tests pass
- ✅ OpenAI repository tests pass

Co-Authored-By: ForgeCode <noreply@forgecode.dev>