### PR TITLE
fix(anthropic): make model display_name optional in DTO

### DIFF
--- a/crates/forge_app/src/dto/anthropic/response.rs
+++ b/crates/forge_app/src/dto/anthropic/response.rs
@@ -15,7 +15,7 @@ pub struct ListModelResponse {
 #[derive(Deserialize)]
 pub struct Model {
     pub id: String,
-    pub display_name: String,
+    pub display_name: Option<String>,
 }
 
 impl From<Model> for forge_domain::Model {
@@ -23,7 +23,7 @@ impl From<Model> for forge_domain::Model {
         let context_length = get_context_length(&value.id);
         Self {
             id: ModelId::new(value.id),
-            name: Some(value.display_name),
+            name: value.display_name,
             description: None,
             context_length,
             tools_supported: Some(true),
@@ -658,7 +658,7 @@ mod tests {
     fn test_model_conversion_includes_context_length() {
         let fixture = Model {
             id: "claude-sonnet-4-5-20250929".to_string(),
-            display_name: "Claude 3.5 Sonnet (New)".to_string(),
+            display_name: Some("Claude 3.5 Sonnet (New)".to_string()),
         };
 
         let actual: forge_domain::Model = fixture.into();
@@ -672,7 +672,7 @@ mod tests {
     fn test_model_conversion_unknown_model_no_context() {
         let fixture = Model {
             id: "unknown-claude-model".to_string(),
-            display_name: "Unknown Model".to_string(),
+            display_name: Some("Unknown Model".to_string()),
         };
 
         let actual: forge_domain::Model = fixture.into();


### PR DESCRIPTION
## Summary

Updates the Anthropic API response DTO to treat `display_name` as an optional field, preventing deserialization failures for models lacking this attribute. This ensures robust model listing functionality even when the upstream API omits display names.

## Changes

- Changed `display_name` type from `String` to `Option<String>` in `Model` struct.
- Updated `From<Model>` implementation to handle the optional `display_name`.
- Updated tests to reflect the schema change.