### PR TITLE
chore(toolchain): migrate rust channel from pinned version to stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "stable"
 profile = "default"


### PR DESCRIPTION
## Summary

This PR updates the Rust toolchain configuration to use the stable channel instead of a pinned version (1.92). This ensures the project automatically benefits from the latest stable Rust releases while maintaining stability guarantees.

## Changes

- Updated `rust-toolchain.toml` to use `channel = "stable"` instead of `channel = "1.92"`

## Benefits

- **Automatic updates**: The project will automatically use the latest stable Rust version without manual version bumps
- **Latest features**: Access to newest stable language features and performance improvements
- **Security patches**: Automatic inclusion of security fixes in stable releases
- **Simplified maintenance**: Eliminates the need to manually update the pinned version

## Impact

- CI/CD pipelines will use the latest stable Rust compiler
- Developers will use the latest stable version on their local machines
- No breaking changes expected as stable releases maintain backward compatibility

---

Co-Authored-By: ForgeCode <noreply@forgecode.dev>