### PR TITLE
refactor(markdown): match heading prefix color for hash prefix

### DIFF
--- a/crates/forge_markdown_stream/src/heading.rs
+++ b/crates/forge_markdown_stream/src/heading.rs
@@ -56,16 +56,36 @@ pub fn render_heading<S: InlineStyler + HeadingStyler>(
                 )
             }
             3 => {
-                format!("{}{} {}", margin, styler.dimmed(&styler.h3(&prefix)), styler.h3(&line))
+                format!(
+                    "{}{} {}",
+                    margin,
+                    styler.dimmed(&styler.h3(&prefix)),
+                    styler.h3(&line)
+                )
             }
             4 => {
-                format!("{}{} {}", margin, styler.dimmed(&styler.h4(&prefix)), styler.h4(&line))
+                format!(
+                    "{}{} {}",
+                    margin,
+                    styler.dimmed(&styler.h4(&prefix)),
+                    styler.h4(&line)
+                )
             }
             5 => {
-                format!("{}{} {}", margin, styler.dimmed(&styler.h5(&prefix)), styler.h5(&line))
+                format!(
+                    "{}{} {}",
+                    margin,
+                    styler.dimmed(&styler.h5(&prefix)),
+                    styler.h5(&line)
+                )
             }
             _ => {
-                format!("{}{} {}", margin, styler.dimmed(&styler.h6(&prefix)), styler.h6(&line))
+                format!(
+                    "{}{} {}",
+                    margin,
+                    styler.dimmed(&styler.h6(&prefix)),
+                    styler.h6(&line)
+                )
             }
         };
         result.push(formatted);


### PR DESCRIPTION
<img width="1009" height="344" alt="Screenshot 2026-01-21 at 11 04 21 AM" src="https://github.com/user-attachments/assets/0b7f8664-005e-4b5f-9cef-9bfc3f0c4328" />
