### PR TITLE
fix: enable structured outputs for Anthropic API key authentication

### DIFF
--- a/crates/forge_repo/src/provider/anthropic.rs
+++ b/crates/forge_repo/src/provider/anthropic.rs
@@ -407,14 +407,25 @@ mod tests {
         let actual = fixture.get_headers();
 
         // Should contain anthropic-version header
-        assert!(actual.iter().any(|(k, v)| k == "anthropic-version" && v == "2023-06-01"));
+        assert!(
+            actual
+                .iter()
+                .any(|(k, v)| k == "anthropic-version" && v == "2023-06-01")
+        );
 
         // Should contain x-api-key header (not authorization)
-        assert!(actual.iter().any(|(k, v)| k == "x-api-key" && v == "sk-test-key"));
+        assert!(
+            actual
+                .iter()
+                .any(|(k, v)| k == "x-api-key" && v == "sk-test-key")
+        );
 
         // Should contain anthropic-beta header with structured outputs support
         let beta_header = actual.iter().find(|(k, _)| k == "anthropic-beta");
-        assert!(beta_header.is_some(), "anthropic-beta header should be present for API key auth");
+        assert!(
+            beta_header.is_some(),
+            "anthropic-beta header should be present for API key auth"
+        );
 
         let (_, beta_value) = beta_header.unwrap();
         assert!(
@@ -443,14 +454,25 @@ mod tests {
         let actual = fixture.get_headers();
 
         // Should contain anthropic-version header
-        assert!(actual.iter().any(|(k, v)| k == "anthropic-version" && v == "2023-06-01"));
+        assert!(
+            actual
+                .iter()
+                .any(|(k, v)| k == "anthropic-version" && v == "2023-06-01")
+        );
 
         // Should contain authorization header (not x-api-key)
-        assert!(actual.iter().any(|(k, v)| k == "authorization" && v == "Bearer oauth-token"));
+        assert!(
+            actual
+                .iter()
+                .any(|(k, v)| k == "authorization" && v == "Bearer oauth-token")
+        );
 
         // Should contain anthropic-beta header with structured outputs support
         let beta_header = actual.iter().find(|(k, _)| k == "anthropic-beta");
-        assert!(beta_header.is_some(), "anthropic-beta header should be present for OAuth");
+        assert!(
+            beta_header.is_some(),
+            "anthropic-beta header should be present for OAuth"
+        );
 
         let (_, beta_value) = beta_header.unwrap();
         assert!(


### PR DESCRIPTION
## Problem

Commands using structured JSON output (, ) were failing with Anthropic API key authentication:

```
ERROR: POST https://api.anthropic.com/v1/messages
  Caused by: 400 Bad Request 
  Reason: {"type":"error","error":{"type":"invalid_request_error","message":"output_format: Extra inputs are not permitted"}}
```

## Root Cause

The `output_format` field in Anthropic API requests requires the `structured-outputs-2025-11-13` beta header. This header was only being sent for OAuth authentication, not for API key authentication (which most users use).

## Solution

- Added `anthropic-beta` header for API key authentication with required flags:
  - `interleaved-thinking-2025-05-14` (for thinking/reasoning)
  - `structured-outputs-2025-11-13` (for JSON schema outputs)
- Kept OAuth-specific flags (`oauth-2025-04-20`, `claude-code-20250219`) only for OAuth flows

## Testing

- ✅ All existing tests pass (216 tests)
- ✅ Added 2 new tests to verify headers for both API key and OAuth authentication
- ✅ Full project compiles successfully

## Impact

- Fixes `:commit-preview` command for API key users
- Fixes `forge suggest` command for API key users with Anthropic models
- No breaking changes - only extends functionality

Co-Authored-By: ForgeCode <noreply@forgecode.dev>