### PR TITLE
fix(zsh): clear buffer before running precmd hooks

### DIFF
--- a/shell-plugin/lib/helpers.zsh
+++ b/shell-plugin/lib/helpers.zsh
@@ -27,6 +27,9 @@ function _forge_exec() {
 
 # Helper function to clear buffer and reset prompt
 function _forge_reset() {
+    BUFFER=""
+    CURSOR=0
+    
     # Invoke precmd hooks to ensure prompt customizations (starship, oh-my-zsh themes, etc.) refresh properly
     for precmd in $precmd_functions; do
         if typeset -f "$precmd" >/dev/null 2>&1; then
@@ -34,8 +37,6 @@ function _forge_reset() {
         fi
     done
 
-   BUFFER=""
-   CURSOR=0
 
    zle reset-prompt 
     


### PR DESCRIPTION
## Summary

This fix ensures the Zsh command buffer and cursor are cleared before invoking precmd hooks, preventing stale input from appearing in the prompt after forge operations complete. By resetting the buffer state before prompt customizations (starship, oh-my-zsh themes) refresh, the shell maintains a clean state and avoids visual artifacts.

## Changes

- Move `BUFFER=""` and `CURSOR=0` to the beginning of `_forge_reset()` function
- Ensures buffer is cleared before precmd hooks run, not after
- Fixes potential display issues where old command text could briefly appear in the prompt

## Impact

- **Files changed**: 1 (`shell-plugin/lib/helpers.zsh`)
- **Lines modified**: +3/-2
- **Type**: Bug fix

Co-Authored-By: ForgeCode <noreply@forgecode.dev>