### PR TITLE
docs(zsh-plugin): add fzf version requirements and local development setup

### DIFF
--- a/shell-plugin/README.md
+++ b/shell-plugin/README.md
@@ -15,21 +15,50 @@ A powerful ZSH plugin that provides intelligent command transformation, file tag
 
 Before using this plugin, ensure you have the following tools installed:
 
-- **fzf** - Command-line fuzzy finder
+- **fzf** (>= 0.36.0) - Command-line fuzzy finder
 - **fd** - Fast file finder (alternative to find)
 - **forge** - The Forge CLI tool
 
 ### Installation of Prerequisites
 
+#### fzf (minimum version 0.36.0 required)
+
+The plugin requires fzf version 0.36.0 or later for the `--no-scrollbar` option. Check your version:
+
+```bash
+fzf --version
+```
+
+If you have an older version, install the latest fzf:
+
 ```bash
 # macOS (using Homebrew)
-brew install fzf fd
+brew install fzf
 
-# Ubuntu/Debian
-sudo apt install fzf fd-find
+# Ubuntu/Debian - Install from GitHub releases (apt version may be outdated)
+curl -Lo /tmp/fzf.tar.gz https://github.com/junegunn/fzf/releases/latest/download/fzf-$(curl -s https://api.github.com/repos/junegunn/fzf/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')-linux_amd64.tar.gz
+sudo tar -xzf /tmp/fzf.tar.gz -C /usr/local/bin/
+rm /tmp/fzf.tar.gz
+
+# Or use the official install script
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+~/.fzf/install
 
 # Arch Linux
-sudo pacman -S fzf fd
+sudo pacman -S fzf
+```
+
+#### fd (file finder)
+
+```bash
+# macOS (using Homebrew)
+brew install fd
+
+# Ubuntu/Debian
+sudo apt install fd-find
+
+# Arch Linux
+sudo pacman -S fd
 ```
 
 ## Usage
@@ -196,6 +225,38 @@ The plugin provides visual feedback through syntax highlighting:
 - **Command Text**: Remaining text in **white bold**
 
 ## Configuration
+
+### Using Local Development Plugin
+
+If you're developing or testing changes to the plugin, you can configure your `.zshrc` to use the local plugin files instead of the installed version:
+
+```bash
+# In ~/.zshrc, replace:
+eval "$(forge zsh plugin)"
+eval "$(forge zsh theme)"
+
+# With:
+# Load Forge ZSH plugin - prefer local development version if available
+if [[ -f "$HOME/forge/shell-plugin/forge.plugin.zsh" ]]; then
+    source "$HOME/forge/shell-plugin/forge.plugin.zsh"
+elif command -v forge &> /dev/null; then
+    eval "$(forge zsh plugin)"
+fi
+
+# Load Forge theme - prefer local development version if available
+if [[ -f "$HOME/forge/shell-plugin/forge.theme.zsh" ]]; then
+    source "$HOME/forge/shell-plugin/forge.theme.zsh"
+elif command -v forge &> /dev/null; then
+    eval "$(forge zsh theme)"
+fi
+```
+
+This configuration:
+1. **First** tries to load the local plugin from `~/forge/shell-plugin/` (for development)
+2. **Falls back** to `eval "$(forge zsh plugin)"` if the local files don't exist (for production)
+3. Allows you to test plugin changes immediately without reinstalling forge
+
+### Custom Configuration
 
 Customize the plugin behavior by setting these variables before loading the plugin:
 


### PR DESCRIPTION
## Summary

This PR updates the ZSH plugin README to address fzf compatibility issues and document local development setup.

## Changes

### 1. fzf Version Requirements
- Added minimum version requirement (>= 0.36.0) for the `--no-scrollbar` option
- Included version check instructions
- Provided platform-specific installation commands:
  - macOS (Homebrew)
  - Ubuntu/Debian (GitHub releases, noting apt may be outdated)
  - Official install script
  - Arch Linux

### 2. Local Development Plugin Setup
- Documented how to configure `.zshrc` to use local plugin files
- Added fallback pattern: local files first, then `eval` command
- Benefits:
  - Test plugin changes immediately without rebuilding forge
  - Seamless fallback to production version
  - Ideal for contributors and developers

## Motivation

Users on Linux were encountering `unknown option: --no-scrollbar` errors during tab completion because:
- The plugin uses `--no-scrollbar` in `shell-plugin/lib/helpers.zsh:16`
- This option was added in fzf 0.36.0
- Many Linux distributions ship with older fzf versions (e.g., 0.29)

## Testing

- ✅ Updated fzf from 0.29 to 0.67.0
- ✅ Verified tab completion works without errors
- ✅ Confirmed local plugin loading with fallback pattern
- ✅ Tested on Ubuntu Linux

Co-Authored-By: ForgeCode <noreply@forgecode.dev>