### PR TITLE
fix(git): escape single quotes in commit messages

### DIFF
--- a/crates/forge_app/src/git_app.rs
+++ b/crates/forge_app/src/git_app.rs
@@ -154,8 +154,10 @@ where
 
         // Set ForgeCode as the committer while keeping the user as the author
         // by prefixing the command with environment variables
+        // Escape single quotes in the message by replacing ' with '\''
+        let escaped_message = message.replace('\'', r"'\''");
         let commit_command = format!(
-            "GIT_COMMITTER_NAME='ForgeCode' GIT_COMMITTER_EMAIL='noreply@forgecode.dev' git commit {flags} -m '{message}'"
+            "GIT_COMMITTER_NAME='ForgeCode' GIT_COMMITTER_EMAIL='noreply@forgecode.dev' git commit {flags} -m '{escaped_message}'"
         );
 
         let commit_result = self


### PR DESCRIPTION
## Summary

This PR fixes shell escaping for git commit messages containing single quotes. Commit messages with apostrophes (e.g., "don't", "can't") previously caused shell syntax errors and command failures. The fix properly escapes single quotes using the shell-safe pattern '\'''.

## Changes

- **Fixed**: Shell escaping for single quotes in commit messages in git_app.rs
- **Added**: Comment documenting the escaping technique
- **Improved**: Robustness of git commit operations when messages contain special characters

## Technical Details

The commit command is constructed as a shell string with the message embedded in single quotes:
```bash
git commit -m 'message here'
```

When the message contains a single quote (e.g., "don't panic"), the unescaped version would produce:
```bash
git commit -m 'don't panic'  # Syntax error!
```

The fix replaces each `'` with `'\''` (close quote, escaped quote, open quote), which is the standard POSIX shell technique for embedding single quotes within single-quoted strings:
```bash
git commit -m 'don'\''t panic'  # Works correctly!
```

## Testing

This fix prevents errors when commit messages include:
- Contractions (don't, can't, won't)
- Possessives (user's changes)
- Quoted text (fixing 'bug' in parser)

Co-Authored-By: ForgeCode <noreply@forgecode.dev>
