### PR TITLE
fix(file_tracking): use raw content hash for consistent change detection

### DIFF
--- a/crates/forge_app/src/file_tracking.rs
+++ b/crates/forge_app/src/file_tracking.rs
@@ -383,14 +383,12 @@ mod tests {
         // Step 1: Read the file (insert via Metrics::insert like production)
         let metrics = Metrics::default().insert(
             "/test/file.txt".to_string(),
-            FileOperation::new(ToolKind::Read)
-                .content_hash(Some(compute_hash(original))),
+            FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash(original))),
         );
         // Step 2: Write the file (overwrites the Read entry)
         let metrics = metrics.insert(
             "/test/file.txt".to_string(),
-            FileOperation::new(ToolKind::Write)
-                .content_hash(Some(written_hash)),
+            FileOperation::new(ToolKind::Write).content_hash(Some(written_hash)),
         );
 
         // File on disk matches what was written -- no change
@@ -417,13 +415,11 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(compute_hash("original"))),
+                FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash("original"))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Write)
-                    .content_hash(Some(written_hash)),
+                FileOperation::new(ToolKind::Write).content_hash(Some(written_hash)),
             );
 
         // External modification detected
@@ -451,13 +447,11 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Write)
-                    .content_hash(Some(content_hash.clone())),
+                FileOperation::new(ToolKind::Write).content_hash(Some(content_hash.clone())),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(content_hash)),
+                FileOperation::new(ToolKind::Read).content_hash(Some(content_hash)),
             );
 
         // Last entry is Read with matching hash -- no false positive
@@ -492,8 +486,7 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/a.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(compute_hash(a_content))),
+                FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash(a_content))),
             )
             .insert(
                 "/test/b.txt".to_string(),
@@ -502,18 +495,15 @@ mod tests {
             )
             .insert(
                 "/test/b.txt".to_string(),
-                FileOperation::new(ToolKind::Write)
-                    .content_hash(Some(compute_hash(b_written))),
+                FileOperation::new(ToolKind::Write).content_hash(Some(compute_hash(b_written))),
             )
             .insert(
                 "/test/c.txt".to_string(),
-                FileOperation::new(ToolKind::Patch)
-                    .content_hash(Some(compute_hash(c_content))),
+                FileOperation::new(ToolKind::Patch).content_hash(Some(compute_hash(c_content))),
             )
             .insert(
                 "/test/d.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(compute_hash(d_content))),
+                FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash(d_content))),
             );
 
         let actual = detector.detect(&metrics).await;
@@ -541,8 +531,7 @@ mod tests {
 
         let metrics = Metrics::default().insert(
             "/test/file.txt".to_string(),
-            FileOperation::new(ToolKind::Read)
-                .content_hash(Some(compute_hash(original))),
+            FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash(original))),
         );
 
         let actual = detector.detect(&metrics).await;
@@ -567,23 +556,19 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(compute_hash("v0"))),
+                FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash("v0"))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Patch)
-                    .content_hash(Some(compute_hash("v1"))),
+                FileOperation::new(ToolKind::Patch).content_hash(Some(compute_hash("v1"))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Patch)
-                    .content_hash(Some(compute_hash("v2"))),
+                FileOperation::new(ToolKind::Patch).content_hash(Some(compute_hash("v2"))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Patch)
-                    .content_hash(Some(final_hash)),
+                FileOperation::new(ToolKind::Patch).content_hash(Some(final_hash)),
             );
 
         let actual = detector.detect(&metrics).await;
@@ -605,18 +590,15 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(original_hash.clone())),
+                FileOperation::new(ToolKind::Read).content_hash(Some(original_hash.clone())),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Write)
-                    .content_hash(Some(compute_hash("modified"))),
+                FileOperation::new(ToolKind::Write).content_hash(Some(compute_hash("modified"))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Undo)
-                    .content_hash(Some(original_hash)),
+                FileOperation::new(ToolKind::Undo).content_hash(Some(original_hash)),
             );
 
         let actual = detector.detect(&metrics).await;
@@ -641,13 +623,11 @@ mod tests {
         let metrics = Metrics::default()
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Read)
-                    .content_hash(Some(compute_hash(&raw_content))),
+                FileOperation::new(ToolKind::Read).content_hash(Some(compute_hash(&raw_content))),
             )
             .insert(
                 "/test/file.txt".to_string(),
-                FileOperation::new(ToolKind::Write)
-                    .content_hash(Some(written_hash)),
+                FileOperation::new(ToolKind::Write).content_hash(Some(written_hash)),
             );
 
         let actual = detector.detect(&metrics).await;


### PR DESCRIPTION
## Summary

Fix false positives in file change detection by using the raw content hash (`ReadOutput.content_hash`) directly instead of re-hashing truncated/formatted content. This ensures both the stored hash and the comparison hash are always derived from the same unprocessed file content, eliminating spurious "externally modified" notifications for files with long lines, 2000+ lines, or trailing newlines.

## Problem

Files that were not modified were being reported as "externally changed." This affected both read-only and written files whenever the displayed content diverged from the raw file content.

## Root Cause

The hash comparison in `FileChangeDetector::detect()` was inconsistent:

| When | What was hashed |
|---|---|
| File first accessed (stored hash) | Raw full file content (`fs_read.rs:164` — `compute_hash(&full_content)`) |
| Change detection re-check | Processed content after line truncation, range limiting to 2000 lines, and `.lines().join("\n")` reconstruction |

These two representations diverge whenever a file has:
- Any line longer than `max_line_length` (truncated by `truncate_line`)
- More than 2000 lines (range-limited by `resolve_range`)
- A trailing newline (stripped by `.lines().join("\n")`)

## Fix

Changed `FileChangeDetector` to use `ReadOutput.content_hash` directly — the hash already computed from the full raw file by the read service — instead of re-hashing the processed `output.content`.

**Before** (`file_tracking.rs`):
```rust
let current_hash = match self.read_file_content(&file_path).await {
    Ok(content) => Some(compute_hash(&content)),  // hash of truncated content
    Err(_) => None,
};
```

**After**:
```rust
let current_hash = match self.read_file_hash(&file_path).await {
    Ok(hash) => Some(hash),  // ReadOutput.content_hash — hash of raw full file
    Err(_) => None,
};
```

## Tests

| Test | Verifies |
|---|---|
| `test_read_file_with_matching_hash_not_detected` | Read-only file with consistent raw hash produces no false positive |
| `test_truncated_content_does_not_cause_false_positive` | File with long lines (truncated display) matches by raw hash |
| `test_truncated_written_file_not_false_positive` | Written file with >2000 lines (range-limited display) matches by raw hash |
| 4 existing tests | Unchanged — real modifications, unreadable files, and duplicate prevention still work |

## Changed Files

- `crates/forge_app/src/file_tracking.rs` — Use `ReadOutput.content_hash` directly; update mock to simulate raw vs truncated content divergence (+134 −17)