### PR TITLE
chore(ui): remove verbose agent response log

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2811,7 +2811,6 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                     self.writeln(text)?;
                 }
                 ChatResponseContent::Markdown { text, partial: _ } => {
-                    tracing::info!(message = %text, "Agent Response");
                     writer.write(&text)?;
                 }
             },


### PR DESCRIPTION
## Summary

Removes a verbose `tracing::info!` log statement that was emitting the full text of every agent markdown response during UI rendering. This reduces log noise and improves signal-to-noise ratio in production and debug logs.

## Changes

- Removed `tracing::info!(message = %text, "Agent Response")` from the `ChatResponseContent::Markdown` handler in `crates/forge_main/src/ui.rs`

## Motivation

The agent response text is already rendered to the user via the markdown writer (`writer.write(&text)`). Logging the full response content at `info` level was redundant and created excessive log volume, especially for long or streaming responses. Removing it keeps the logs focused on actionable events.