### PR TITLE
fix(porcelain): use char count instead of byte len for truncation

### DIFF
--- a/crates/forge_main/src/porcelain.rs
+++ b/crates/forge_main/src/porcelain.rs
@@ -660,7 +660,7 @@ mod tests {
         // Each emoji is 4 bytes but 1 char — byte-based truncation would misbehave here
         let fixture = Porcelain(vec![vec![
             Some("🦀🦀🦀🦀🦀🦀".into()), // 6 chars, 24 bytes
-            Some("hi".into()),              // 2 chars, under limit
+            Some("hi".into()),           // 2 chars, under limit
         ]]);
         let actual = fixture.truncate(0, 5).into_rows();
         let expected = vec![vec![


### PR DESCRIPTION
Fixes the following issue:

<img width="1353" height="77" alt="Screenshot 2026-02-23 at 2 31 52 PM" src="https://github.com/user-attachments/assets/f9ab2da2-86e2-45cc-915d-62c987980c02" />
