### PR TITLE
feat(shell-plugin): rename login to provider-login (keep login alias)

### DIFF
--- a/crates/forge_main/src/built_in_commands.json
+++ b/crates/forge_main/src/built_in_commands.json
@@ -60,8 +60,8 @@
     "description": "Generate shell commands without executing them [alias: s]"
   },
   {
-    "command": "login",
-    "description": "Login to a provider"
+    "command": "provider-login",
+    "description": "Login to a provider [alias: login]"
   },
   {
     "command": "logout",

--- a/shell-plugin/README.md
+++ b/shell-plugin/README.md
@@ -80,6 +80,16 @@ Commands within the same session maintain context:
 
 The plugin automatically manages conversation IDs to maintain context across related commands.
 
+### Command Naming
+
+Shell commands should follow the **Object-Action** format.
+
+Examples:
+- `:provider-login`
+- `:sync-status`
+
+For backward compatibility, `:login` remains available as an alias for `:provider-login`.
+
 ### Session Management
 
 #### Starting New Sessions

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -132,6 +132,8 @@ function forge-accept-line() {
     #     crates/forge_main/src/built_in_commands.json
     #     Add a new entry: {"command": "name", "description": "Description [alias: x]"}
     #
+    # Naming convention: shell commands should follow Object-Action (e.g., provider-login).
+    #
     # Dispatch to appropriate action handler using pattern matching
     case "$user_action" in
         new|n)
@@ -203,7 +205,7 @@ function forge-accept-line() {
         sync-info)
             _forge_action_sync_info
         ;;
-        login)
+        provider-login|login)
             _forge_action_login "$input_text"
         ;;
         logout)


### PR DESCRIPTION
## Summary
Rename the shell command `:login` to `:provider-login` while preserving `:login` as a backward-compatible alias, aligning command naming with the Object-Action convention.

## Context
Shell commands are moving toward a consistent Object-Action naming format. The existing `:login` command did not follow this convention, which made command naming less uniform across the plugin.

## Changes
- Renamed the built-in command from `login` to `provider-login` in command metadata
- Kept backward compatibility by exposing `login` as an alias
- Updated the dispatcher command pattern to accept both `provider-login` and `login`
- Added command naming guidance and alias behavior to shell-plugin documentation

### Key Implementation Details
- Built-in command metadata now declares:
  - `command: "provider-login"`
  - `description: "Login to a provider [alias: login]"`
- Dispatcher routing now matches `provider-login|login` and maps both to `_forge_action_login`
- README now documents the Object-Action naming convention and the backward-compatible alias behavior

## Use Cases
- Users can adopt the clearer `:provider-login` command name
- Existing users relying on `:login` continue to work without disruption
- Future command additions have clearer naming guidance and consistency

## Testing
1. Run the shell plugin and execute `:provider-login` to verify it triggers provider login flow.
2. Execute `:login` to verify alias behavior still triggers the same login flow.
3. Run `:tools` (or command listing) and confirm `provider-login` is shown with alias metadata.

## Links
- Related issues: N/A
