### PR TITLE
fix(ui): use action format instead of warning for zsh doctor success

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1714,10 +1714,10 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
         let doctor_result = self.on_zsh_doctor().await;
 
         if doctor_result.is_ok() {
-            self.writeln_title(TitleFormat::warning(
+            self.writeln_title(TitleFormat::action(
                 "run `exec zsh` now (or open a new terminal window) to load the updated shell config",
             ))?;
-            self.writeln_title(TitleFormat::warning(
+            self.writeln_title(TitleFormat::action(
                 "run `: Hi` after restarting your shell to confirm everything works",
             ))?;
         }


### PR DESCRIPTION
## Summary
Update the zsh doctor success follow-up messages to use action styling so the next steps read as guidance instead of warnings.

## Context
After a successful shell setup, Forge runs the zsh doctor and then tells the user to reload their shell and run `: Hi`. These messages are part of the happy path, but they were rendered with warning formatting, which made a successful result look more alarming than intended.

## Changes
- Swapped the two post-success zsh doctor messages from `TitleFormat::warning(...)` to `TitleFormat::action(...)`
- Kept the message copy and success-only behavior unchanged

### Key Implementation Details
The change is limited to the `doctor_result.is_ok()` branch in the setup flow, so only successful zsh doctor runs get the updated presentation. No command behavior or validation logic changed.

## Use Cases
- Users completing shell setup see clear next steps without warning styling
- Successful zsh doctor runs now better match the intended UI semantics for follow-up actions

## Testing
1. Run the shell setup flow in an environment where `forge zsh doctor` succeeds.
2. Confirm the two follow-up lines after the doctor run are rendered as actions, not warnings:
   - `run \`exec zsh\` now (or open a new terminal window) to load the updated shell config`
   - `run \`: Hi\` after restarting your shell to confirm everything works`
3. Verify the messages still appear only when the doctor run succeeds.
