### PR TITLE
fix: resolve oai Summary struct breaking change in OpenAI responses request

### DIFF
--- a/crates/forge_main/src/completer/command.rs
+++ b/crates/forge_main/src/completer/command.rs
@@ -38,6 +38,7 @@ impl Completer for CommandCompleter {
                         span: Span::new(0, line.len()),
                         append_whitespace: false,
                         match_indices: None,
+                        display_override: None,
                     })
                 } else {
                     None

--- a/crates/forge_main/src/completer/input_completer.rs
+++ b/crates/forge_main/src/completer/input_completer.rs
@@ -63,6 +63,7 @@ impl Completer for InputCompleter {
                                 span: query.span,
                                 append_whitespace: true,
                                 match_indices: None,
+                                display_override: None,
                             },
                         ))
                     } else {

--- a/crates/forge_repo/src/provider/openai_responses/request.rs
+++ b/crates/forge_repo/src/provider/openai_responses/request.rs
@@ -68,7 +68,7 @@ fn map_reasoning_details_to_input_items(
 
             let summary: Vec<oai::SummaryPart> = summary_texts
                 .into_iter()
-                .map(|text| oai::SummaryPart::SummaryText(oai::Summary { text }))
+                .map(|text| oai::SummaryPart::SummaryText(oai::SummaryTextContent { text }))
                 .collect();
 
             Some(oai::InputItem::Item(oai::Item::Reasoning(
@@ -908,7 +908,7 @@ mod tests {
 
         let expected = oai::ReasoningItem {
             id: "rs_123".to_string(),
-            summary: vec![oai::SummaryPart::SummaryText(oai::Summary {
+            summary: vec![oai::SummaryPart::SummaryText(oai::SummaryTextContent {
                 text: "Summary of reasoning".to_string(),
             })],
             content: None,


### PR DESCRIPTION
## Problem
After the dependency upgrade in #2474 , the CI was failing 
because the `Summary` struct was removed/renamed in the new version of the 
`oai` crate.

## Changes
- Updated `oai::Summary` usage in `crates/forge_repo/src/provider/openai_responses/request.rs` 
  to use the new API shape (lines 71 and 911)

## Testing
- Reproduced the issue locally and verified the fix compiles successfully
- CI should pass with these changes