### PR TITLE
fix(zsh): use _forge_exec_interactive for provider/model config set to fix API key input under ZLE

### DIFF
--- a/shell-plugin/lib/actions/config.zsh
+++ b/shell-plugin/lib/actions/config.zsh
@@ -85,8 +85,11 @@ function _forge_action_provider() {
         # Extract the second field (provider ID) from the selected line
         # Format: "DisplayName  provider_id  host  type  status"
         local provider_id=$(echo "$selected" | awk '{print $2}')
-        # Always use config set - it will handle authentication if needed
-        _forge_exec config set provider "$provider_id"
+        # Use _forge_exec_interactive because config-set may trigger
+        # interactive authentication prompts (rustyline) when the provider
+        # is not yet configured. Without /dev/tty redirection, ZLE's pipes
+        # cause rustyline to see EOF and fail with "API key input cancelled".
+        _forge_exec_interactive config set provider "$provider_id"
     fi
 }
 
@@ -158,7 +161,7 @@ function _forge_action_model() {
             local current_provider
             current_provider=$(_forge_exec config get provider --porcelain 2>/dev/null)
             if [[ -n "$provider_display" && "$provider_display" != "$current_provider" ]]; then
-                _forge_exec config set provider "$provider_id"
+                _forge_exec_interactive config set provider "$provider_id"
             fi
 
             _forge_exec config set model "$model_id"


### PR DESCRIPTION
## Summary

Fix `:provider` and `:model` shell actions failing with "API key input cancelled" when selecting an unconfigured provider (e.g., Cerebras) by using `_forge_exec_interactive` instead of `_forge_exec` for commands that may trigger interactive authentication.

## Context

When a user types `:provider` in the shell and selects a provider that hasn't been configured yet (no API key set), the Rust binary prompts for the API key using `rustyline`. However, the `:provider` action runs as a **ZLE widget**, meaning ZLE owns the terminal and replaces the process's stdin/stdout with its own pipes. `rustyline` then reads from those pipes instead of the real terminal, immediately receives EOF, and the code converts this into an `"API key input cancelled"` error.

The shell plugin already has `_forge_exec_interactive()` which redirects stdin/stdout to `/dev/tty` for exactly this scenario -- the `:login` action already uses it correctly. The `:provider` and `:model` actions were missing this treatment.

**Call chain that fails:**
1. ZLE widget -> `_forge_action_provider()` -> `_forge_exec config set provider cerebras`
2. Rust: `handle_config_set` -> `activate_provider` -> `configure_provider` -> `handle_api_key_input`
3. `rustyline::readline_with_initial()` -> reads piped stdin -> EOF -> `Ok(None)`
4. `.context("API key input cancelled")?` -> **ERROR**

## Changes

- `_forge_action_provider()`: Changed `_forge_exec` to `_forge_exec_interactive` for the `config set provider` call so interactive auth prompts work under ZLE
- `_forge_action_model()`: Same fix for the provider switch path that runs when selecting a model from a different provider

## Testing

1. Open a terminal with the forge zsh plugin loaded
2. Type `:provider` and select an **unconfigured** provider (e.g., Cerebras)
3. Verify the API key prompt appears and accepts input instead of erroring with "API key input cancelled"
4. Type `:model`, select a model from a different unconfigured provider, and verify the same
