### PR TITLE
fix(forge_select): skip interactive prompts when stdin is not a terminal

### DIFF
--- a/crates/forge_select/src/input.rs
+++ b/crates/forge_select/src/input.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use colored::Colorize;
 use rustyline::DefaultEditor;
@@ -55,6 +57,12 @@ impl InputBuilder {
     ///
     /// Returns an error if rustyline fails to initialise or read input.
     pub fn prompt(self) -> Result<Option<String>> {
+        // Bail immediately when stdin is not a terminal to prevent the process
+        // from blocking indefinitely on a detached or non-interactive session.
+        if !std::io::stdin().is_terminal() {
+            return Ok(None);
+        }
+
         let mut rl = DefaultEditor::new()?;
 
         // On Windows, rustyline miscounts ANSI escape bytes as visible characters,

--- a/crates/forge_select/src/multi.rs
+++ b/crates/forge_select/src/multi.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use console::strip_ansi_codes;
 use fzf_wrapped::{Fzf, Layout};
@@ -25,6 +27,12 @@ impl<T> MultiSelectBuilder<T> {
     where
         T: std::fmt::Display + Clone,
     {
+        // Bail immediately when stdin is not a terminal to prevent the process
+        // from blocking indefinitely on a detached or non-interactive session.
+        if !std::io::stdin().is_terminal() {
+            return Ok(None);
+        }
+
         if self.options.is_empty() {
             return Ok(None);
         }

--- a/crates/forge_select/src/select.rs
+++ b/crates/forge_select/src/select.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use console::strip_ansi_codes;
 use fzf_wrapped::{Fzf, Layout, run_with_output};
@@ -151,6 +153,12 @@ impl<T: 'static> SelectBuilder<T> {
     where
         T: std::fmt::Display + Clone,
     {
+        // Bail immediately when stdin is not a terminal to prevent the process
+        // from blocking indefinitely on a detached or non-interactive session.
+        if !std::io::stdin().is_terminal() {
+            return Ok(None);
+        }
+
         if std::any::TypeId::of::<T>() == std::any::TypeId::of::<bool>() {
             return prompt_confirm(&self.message, self.default);
         }


### PR DESCRIPTION
## Summary
Skip interactive prompts in `forge_select` when stdin is not a terminal, preventing the process from blocking indefinitely in non-interactive sessions.

## Context
When Forge runs in a non-interactive environment (e.g., piped input, CI pipelines, detached sessions), the interactive selection prompts (`Select`, `MultiSelect`, `Input`) attempt to read from stdin and block indefinitely since there is no terminal to interact with. This makes Forge unusable in scripted or automated workflows where stdin is not a TTY.

## Changes
- Added an `is_terminal()` check at the start of the `prompt()` method in all three interactive selection components:
  - **`InputBuilder::prompt`** - text input prompts
  - **`MultiSelectBuilder::prompt`** - multi-select (fzf-based) prompts
  - **`SelectBuilder::prompt`** - single-select (fzf-based) and confirm prompts
- Each check returns `Ok(None)` immediately when stdin is not a terminal, allowing callers to handle the absence of user input gracefully

### Key Implementation Details
Uses `std::io::IsTerminal` (stabilized in Rust 1.70) to detect whether stdin is connected to a terminal. The guard is placed as the very first check in each `prompt()` method, before any other logic (editor initialization, option validation, etc.), ensuring no resources are allocated unnecessarily.

## Testing
```bash
# Verify interactive prompts still work normally in a terminal
cargo run

# Verify non-interactive behavior (should not hang)
echo "" | cargo test -p forge_select

# Run the crate tests
cargo test -p forge_select
```
