### PR TITLE
fix(sync): workspace indexing on Windows

### DIFF
--- a/crates/forge_repo/src/context_engine.rs
+++ b/crates/forge_repo/src/context_engine.rs
@@ -136,7 +136,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
     ) -> Result<WorkspaceId> {
         let request = tonic::Request::new(CreateWorkspaceRequest {
             workspace: Some(WorkspaceDefinition {
-                working_dir: working_dir.to_string_lossy().to_string(),
+                working_dir: working_dir.to_string_lossy().replace("\\", "/"),
                 ..Default::default()
             }),
         });


### PR DESCRIPTION
This fixes workspace indexing on Windows. This was caused by the server expecting forward slashes for the workspace and failing with an error otherwise.

```
    code: 'Internal error', message: "Working directory must be an absolute path: \\\\?\\O:\\GitHub\\forge"
```

To test, run `/index`  on Windows

After
<img width="1209" height="396" alt="image" src="https://github.com/user-attachments/assets/36272014-4a45-464c-9789-6f69261a581e" />


Before
<img width="1747" height="340" alt="image" src="https://github.com/user-attachments/assets/fa8f779c-6e8c-4e91-b3f1-e07cd064beaf" />
