### PR TITLE
fix: [Performance]: massive memory usage  from `forge workspace info` (#2630)

### DIFF
--- a/crates/forge_app/src/orch_spec/orch_setup.rs
+++ b/crates/forge_app/src/orch_spec/orch_setup.rs
@@ -96,6 +96,7 @@ impl Default for TestContext {
                 max_extensions: 15,
                 parallel_file_reads: 64,
                 model_cache_ttl: 604_800,
+                max_workspace_files: 50_000,
             },
             title: Some("test-conversation".into()),
             agent: Agent::new(

--- a/crates/forge_domain/src/env.rs
+++ b/crates/forge_domain/src/env.rs
@@ -103,6 +103,12 @@ pub struct Environment {
     /// TTL in seconds for the model API list cache.
     /// Controlled by FORGE_MODEL_CACHE_TTL environment variable.
     pub model_cache_ttl: u64,
+    /// Maximum number of files to discover and process during workspace
+    /// operations (sync, status, etc.). Protects against excessive memory
+    /// usage when a workspace inadvertently covers a very large directory
+    /// tree (e.g. a user's home directory).
+    /// Controlled by FORGE_MAX_WORKSPACE_FILES environment variable.
+    pub max_workspace_files: usize,
 }
 
 /// The output format used when auto-dumping a conversation on task completion.
@@ -343,6 +349,7 @@ fn test_command_path() {
         auto_dump: None,
         parallel_file_reads: 64,
         model_cache_ttl: 604_800,
+        max_workspace_files: 50_000,
     };
 
     let actual = fixture.command_path();
@@ -386,6 +393,7 @@ fn test_command_cwd_path() {
         auto_dump: None,
         parallel_file_reads: 64,
         model_cache_ttl: 604_800,
+        max_workspace_files: 50_000,
     };
 
     let actual = fixture.command_cwd_path();
@@ -429,6 +437,7 @@ fn test_command_cwd_path_independent_from_command_path() {
         auto_dump: None,
         parallel_file_reads: 64,
         model_cache_ttl: 604_800,
+        max_workspace_files: 50_000,
     };
 
     let command_path = fixture.command_path();

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -102,6 +102,8 @@ impl ForgeEnvironmentInfra {
                 },
             ),
             model_cache_ttl: parse_env::<u64>("FORGE_MODEL_CACHE_TTL").unwrap_or(604_800), /* 1 week */
+            max_workspace_files: parse_env::<usize>("FORGE_MAX_WORKSPACE_FILES")
+                .unwrap_or(50_000),
         }
     }
 

--- a/crates/forge_services/src/fd.rs
+++ b/crates/forge_services/src/fd.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
-use forge_app::{CommandInfra, WalkerInfra};
+use forge_app::{CommandInfra, EnvironmentInfra, WalkerInfra};
 use forge_domain::WorkspaceId;
 use tracing::{info, warn};
 
@@ -105,7 +105,7 @@ impl<F> FdDefault<F> {
 }
 
 #[async_trait]
-impl<F: CommandInfra + WalkerInfra + 'static> FileDiscovery for FdDefault<F> {
+impl<F: CommandInfra + WalkerInfra + EnvironmentInfra + 'static> FileDiscovery for FdDefault<F> {
     async fn discover(&self, dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
         match self.git.discover(dir_path).await {
             Ok(files) => Ok(files),

--- a/crates/forge_services/src/fd_git.rs
+++ b/crates/forge_services/src/fd_git.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use forge_app::CommandInfra;
-use tracing::info;
+use forge_app::{CommandInfra, EnvironmentInfra};
+use tracing::{info, warn};
 
 use crate::fd::{FileDiscovery, filter_and_resolve};
 
@@ -23,14 +23,18 @@ impl<F> FsGit<F> {
     }
 }
 
-impl<F: CommandInfra> FsGit<F> {
+impl<F: CommandInfra + EnvironmentInfra> FsGit<F> {
     /// Runs `git ls-files` in `dir_path` and returns the resulting file paths.
     ///
     /// # Errors
     ///
     /// Returns an error when the command cannot be executed or exits with a
     /// non-zero status (e.g. the directory is not a git repository).
-    async fn git_ls_files(&self, dir_path: &Path) -> anyhow::Result<Vec<String>> {
+    async fn git_ls_files(
+        &self,
+        dir_path: &Path,
+        max_files: usize,
+    ) -> anyhow::Result<Vec<String>> {
         let output = self
             .infra
             .execute_command(
@@ -49,10 +53,11 @@ impl<F: CommandInfra> FsGit<F> {
             });
         }
 
-        let paths = output
+        let paths: Vec<String> = output
             .stdout
             .lines()
             .filter(|line| !line.is_empty())
+            .take(max_files)
             .map(|line| line.trim().to_string())
             .collect();
 
@@ -61,11 +66,20 @@ impl<F: CommandInfra> FsGit<F> {
 }
 
 #[async_trait]
-impl<F: CommandInfra + 'static> FileDiscovery for FsGit<F> {
+impl<F: CommandInfra + EnvironmentInfra + 'static> FileDiscovery for FsGit<F> {
     async fn discover(&self, dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
-        let paths = self.git_ls_files(dir_path).await?;
+        let max_files = self.infra.get_environment().max_workspace_files;
+        let paths = self.git_ls_files(dir_path, max_files).await?;
         if paths.is_empty() {
             return Err(anyhow::anyhow!("git ls-files returned no files"));
+        }
+        if paths.len() >= max_files {
+            warn!(
+                max_files = max_files,
+                path = %dir_path.display(),
+                "git ls-files reached the maximum file limit; results are truncated. \
+                 Set FORGE_MAX_WORKSPACE_FILES to increase the limit."
+            );
         }
         info!(
             file_count = paths.len(),

--- a/crates/forge_services/src/fd_walker.rs
+++ b/crates/forge_services/src/fd_walker.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use forge_app::{Walker, WalkerInfra};
-use tracing::info;
+use forge_app::{EnvironmentInfra, Walker, WalkerInfra};
+use tracing::{info, warn};
 
 use crate::fd::{FileDiscovery, filter_and_resolve};
 
@@ -25,11 +25,17 @@ impl<F> FdWalker<F> {
 }
 
 #[async_trait]
-impl<F: WalkerInfra + 'static> FileDiscovery for FdWalker<F> {
+impl<F: WalkerInfra + EnvironmentInfra + 'static> FileDiscovery for FdWalker<F> {
     async fn discover(&self, dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
+        let max_files = self.infra.get_environment().max_workspace_files;
+
+        // Use the workspace file limit instead of unlimited to prevent
+        // excessive memory usage when the workspace covers a very large
+        // directory tree (e.g. a user's home directory).
         let walker_config = Walker::unlimited()
             .cwd(dir_path.to_path_buf())
-            .skip_binary(true);
+            .skip_binary(true)
+            .max_files(max_files);
 
         let files = self
             .infra
@@ -42,6 +48,15 @@ impl<F: WalkerInfra + 'static> FileDiscovery for FdWalker<F> {
             .filter(|f| !f.is_dir())
             .map(|f| f.path)
             .collect();
+
+        if paths.len() >= max_files {
+            warn!(
+                max_files = max_files,
+                path = %dir_path.display(),
+                "File discovery reached the maximum file limit; results are truncated. \
+                 Set FORGE_MAX_WORKSPACE_FILES to increase the limit."
+            );
+        }
 
         info!(file_count = paths.len(), "Discovered files via walker");
         filter_and_resolve(dir_path, paths)


### PR DESCRIPTION
## Summary

This PR resolves issue #2630.

The fix is complete. All tests pass and the implementation is minimal and focused. The key insight is that adding a configurable file count limit (default 50,000, configurable via `FORGE_MAX_WORKSPACE_FILES`) at the file discovery layer prevents both the walker and git-based discovery from enumerating millions of files, which was the root cause of the 69GB memory usage when a home directory became a workspace.

---

/claim #2630