### PR TITLE
docs: Warn users about running Forge in large directories (#2630)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On first run, Forge will guide you through setting up your AI provider credentia
 # Configure your provider credentials interactively
 forge provider login
 
-# Then start Forge
+# Then start Forge (Avoid running in large directories like ~ or /)
 forge
 ```
 That's it! Forge is now ready to assist you with your development tasks.


### PR DESCRIPTION
This PR adds a warning to the README to prevent users from accidentally indexing large directories like the home folder or root, which was a contributing factor to the memory issues in #2630.