### PR TITLE
fix: add safety ceilings to Walker::max_all() to prevent OOM on broad workspaces (#2630)

### DIFF
--- a/crates/forge_infra/src/walker.rs
+++ b/crates/forge_infra/src/walker.rs
@@ -16,7 +16,12 @@ impl ForgeWalkerService {
             && config.max_files.is_none()
             && config.max_total_size.is_none()
         {
-            forge_walker::Walker::max_all()
+            // Domain-level `Walker::unlimited()` has no bounds set.  Map to
+            // `forge_walker::Walker::unlimited()` (not `max_all()`) so that
+            // the safety ceilings introduced in `max_all()` are not silently
+            // stripped away.  Callers that want safe defaults should use
+            // `Walker::conservative()` at the domain layer.
+            forge_walker::Walker::unlimited()
         } else {
             forge_walker::Walker::min_all()
         };

--- a/crates/forge_main/src/completer/input_completer.rs
+++ b/crates/forge_main/src/completer/input_completer.rs
@@ -18,6 +18,9 @@ pub struct InputCompleter {
 
 impl InputCompleter {
     pub fn new(cwd: PathBuf, command_manager: Arc<ForgeCommandManager>) -> Self {
+        // Use safe limits for tab-completion: scanning unbounded directories
+        // (e.g. $HOME) with Walker::unlimited() causes 69GB+ memory usage.
+        // max_all() applies generous-but-safe ceilings (100k files, 50 depth).
         let walker = Walker::max_all().cwd(cwd).skip_binary(true);
         Self {
             walker,

--- a/crates/forge_walker/src/walker.rs
+++ b/crates/forge_walker/src/walker.rs
@@ -49,6 +49,15 @@ const DEFAULT_MAX_TOTAL_SIZE: u64 = 10 * 1024 * 1024; // 10MB
 const DEFAULT_MAX_DEPTH: usize = 5;
 const DEFAULT_MAX_BREADTH: usize = 10;
 
+/// Safety ceilings for `Walker::max_all()`. These prevent OOM when the
+/// workspace root is a broad directory like `$HOME` or `/`.
+/// Callers that genuinely need no limits should use `Walker::unlimited()`.
+const SAFE_MAX_FILE_SIZE: u64 = 100 * 1024 * 1024; // 100MB per file
+const SAFE_MAX_FILES: usize = 100_000; // 100k files total
+const SAFE_MAX_TOTAL_SIZE: u64 = 2 * 1024 * 1024 * 1024; // 2GB aggregate
+const SAFE_MAX_DEPTH: usize = 50; // 50 directory levels
+const SAFE_MAX_BREADTH: usize = 50_000; // 50k entries per directory
+
 impl Walker {
     /// Creates a new Walker instance with all settings set to conservative
     /// values.
@@ -64,10 +73,33 @@ impl Walker {
         }
     }
 
-    /// Creates a new Walker instance with all settings set to maximum values.
-    /// NOTE: This could produce a large number of files and should be used with
-    /// carefully.
+    /// Creates a new Walker instance with generous-but-safe limits.
+    ///
+    /// Unlike `unlimited()`, this applies safety ceilings (100k files, 50
+    /// depth levels, 2 GB aggregate) to prevent runaway memory usage when the
+    /// workspace root is a broad directory such as `$HOME` or `/`.
+    ///
+    /// Prefer `unlimited()` only when you genuinely need unbounded traversal
+    /// (e.g. tool-search inside a known, bounded scope).
     pub fn max_all() -> Self {
+        Self {
+            cwd: PathBuf::new(),
+            max_depth: SAFE_MAX_DEPTH,
+            max_breadth: SAFE_MAX_BREADTH,
+            max_file_size: SAFE_MAX_FILE_SIZE,
+            max_files: SAFE_MAX_FILES,
+            max_total_size: SAFE_MAX_TOTAL_SIZE,
+            skip_binary: false,
+        }
+    }
+
+    /// Creates a new Walker instance with **no** limits.
+    ///
+    /// ⚠️ Use with caution: scanning large directory trees (e.g. `$HOME`) with
+    /// no limits can exhaust memory and cause OOM crashes.  For most callers
+    /// `max_all()` (which applies generous-but-safe ceilings) is a better
+    /// choice.
+    pub fn unlimited() -> Self {
         Self {
             cwd: PathBuf::new(),
             max_depth: usize::MAX,
@@ -537,5 +569,42 @@ mod tests {
                 file
             );
         }
+    }
+
+    /// Validate that `max_all()` has safe, finite limits rather than
+    /// `usize::MAX` / `u64::MAX`.  This guards against regressions that
+    /// would re-introduce the 69GB OOM bug on broad workspaces (#2630).
+    #[test]
+    fn test_max_all_has_safe_finite_limits() {
+        let walker = Walker::max_all();
+
+        assert!(
+            walker.max_depth < usize::MAX,
+            "max_all() max_depth must not be usize::MAX to prevent runaway traversal"
+        );
+        assert!(
+            walker.max_breadth < usize::MAX,
+            "max_all() max_breadth must not be usize::MAX"
+        );
+        assert!(
+            walker.max_files < usize::MAX,
+            "max_all() max_files must not be usize::MAX"
+        );
+        assert!(
+            walker.max_total_size < u64::MAX,
+            "max_all() max_total_size must not be u64::MAX"
+        );
+    }
+
+    /// Validate that `unlimited()` truly has no bounds (for callers that need
+    /// genuine unrestricted traversal).
+    #[test]
+    fn test_unlimited_has_no_bounds() {
+        let walker = Walker::unlimited();
+
+        assert_eq!(walker.max_depth, usize::MAX);
+        assert_eq!(walker.max_breadth, usize::MAX);
+        assert_eq!(walker.max_files, usize::MAX);
+        assert_eq!(walker.max_total_size, u64::MAX);
     }
 }


### PR DESCRIPTION
## Problem

Running `forge workspace info` with a workspace rooted at `$HOME` (or any other large directory) causes memory usage to spike to **69 GB+**, as reported in #2630.

**Root cause:** `Walker::max_all()` set every limit to `usize::MAX` / `u64::MAX`. When the workspace root is a broad directory, the walker enumerates every file with no guard, allocating an unbounded `HashMap` and `Vec` on the heap.

## Fix

### 1. `Walker::max_all()` now applies generous-but-safe ceilings

| Field | Before | After |
|---|---|---|
| `max_depth` | `usize::MAX` | `50` |
| `max_breadth` | `usize::MAX` | `50 000` |
| `max_file_size` | `u64::MAX` | `100 MB` |
| `max_files` | `usize::MAX` | `100 000` |
| `max_total_size` | `u64::MAX` | `2 GB` |

These limits are generous enough to handle any normal software project, but prevent runaway allocation on `$HOME` or `/`.

### 2. New `Walker::unlimited()` method

Preserves the original `usize::MAX` / `u64::MAX` behaviour for callers that genuinely need unrestricted traversal (tool search inside a known bounded scope, etc.).

### 3. `forge_infra::ForgeWalkerService` fix

When the domain-level config has **no bounds set** (i.e. `Walker::unlimited()` in domain land), the infra layer was mapping it to `forge_walker::Walker::max_all()`. This would silently strip any future safety additions to `max_all()`. Now it correctly maps to `forge_walker::Walker::unlimited()`.

### 4. Regression-guard tests

Two new unit tests are added in `forge_walker`:

- `test_max_all_has_safe_finite_limits` — asserts no field is `MAX`.
- `test_unlimited_has_no_bounds` — asserts every field IS `MAX`.

These will catch any future accidental reset to unbounded values.

## Testing

All existing tests continue to pass (they use small `tempdir` fixtures well within the new limits). The two new regression tests explicitly validate the invariants.

## Related

Closes #2630

/claim #2630