### PR TITLE
fix: add walker limits to prevent memory explosion on large directories

### DIFF
--- a/crates/forge_services/src/fd_walker.rs
+++ b/crates/forge_services/src/fd_walker.rs
@@ -27,9 +27,14 @@ impl<F> FdWalker<F> {
 #[async_trait]
 impl<F: WalkerInfra + 'static> FileDiscovery for FdWalker<F> {
     async fn discover(&self, dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
+        // Use reasonable limits to prevent memory explosion on large directories
+        // (e.g. home directory with hundreds of thousands of files).
         let walker_config = Walker::unlimited()
             .cwd(dir_path.to_path_buf())
-            .skip_binary(true);
+            .skip_binary(true)
+            .max_depth(7)
+            .max_files(50_000)
+            .max_total_size(500 * 1024 * 1024); // 500MB total
 
         let files = self
             .infra


### PR DESCRIPTION
## Problem

`forge workspace info` uses `Walker::unlimited()` in `FdWalker::discover()`, which causes unbounded directory traversal. When the workspace path is a large directory (e.g. home directory with hundreds of thousands of files), this loads all file paths into memory, causing ~69GB memory usage and effectively freezing the system.

## Root Cause

In `crates/forge_services/src/fd_walker.rs`, the walker config was:

```rust
let walker_config = Walker::unlimited()
    .cwd(dir_path.to_path_buf())
    .skip_binary(true);
```

`Walker::unlimited()` sets `max_depth: None`, `max_files: None`, `max_total_size: None`, which maps to `usize::MAX` / `u64::MAX` in the underlying walker — effectively no limits.

## Fix

Added reasonable limits to the walker configuration:

- **`max_depth: 7`** — sufficient for any real project structure
- **`max_files: 50,000`** — generous cap for any workspace
- **`max_total_size: 500MB`** — prevents unbounded memory growth

These limits prevent memory explosion while still covering all realistic workspace sizes. The walker still respects `.gitignore` and `.ignore` files via `standard_filters(true)`.

## Testing

- Existing tests in `forge_walker` cover the walker limits functionality
- `test_walker_service_unlimited_config` verifies unlimited mode works on small directories
- The new limits are conservative enough for all real-world projects

Fixes #2630