### PR TITLE
fix(zsh): downgrade oh-my-zsh missing and NERD_FONT=0 from fail to warn (#2612)

### DIFF
--- a/shell-plugin/doctor.zsh
+++ b/shell-plugin/doctor.zsh
@@ -120,7 +120,7 @@ if [[ -n "$ZSH" ]] && [[ -d "$ZSH" ]]; then
     fi
     print_result info "${ZSH}"
 else
-    print_result fail "Oh My Zsh not found" "Install: sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\""
+    print_result warn "Oh My Zsh not found" "Optional: sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\""
 fi
 
 # 2. Check if forge is installed and in PATH
@@ -529,17 +529,13 @@ if [[ -n "$NERD_FONT" ]]; then
     if [[ "$NERD_FONT" == "1" || "$NERD_FONT" == "true" ]]; then
         print_result pass "NERD_FONT: enabled"
     else
-        print_result fail "NERD_FONT: disabled (${NERD_FONT})"
-        print_result instruction "Enable Nerd Font by setting:"
-        print_result code "export NERD_FONT=1"
+        print_result warn "NERD_FONT: disabled (${NERD_FONT})" "Icons may not display correctly; re-enable with: export NERD_FONT=1"
     fi
 elif [[ -n "$USE_NERD_FONT" ]]; then
     if [[ "$USE_NERD_FONT" == "1" || "$USE_NERD_FONT" == "true" ]]; then
         print_result pass "USE_NERD_FONT: enabled"
     else
-        print_result fail "USE_NERD_FONT: disabled (${USE_NERD_FONT})"
-        print_result instruction "Enable Nerd Font by setting:"
-        print_result code "export NERD_FONT=1"
+        print_result warn "USE_NERD_FONT: disabled (${USE_NERD_FONT})" "Icons may not display correctly; re-enable with: export NERD_FONT=1"
     fi
 else
     print_result pass "Nerd Font: enabled (default)"


### PR DESCRIPTION
## Summary

Fixes #2612

The `forge zsh setup` command was failing with a ZSH doctor error exit code even for valid setups, because two checks were treating optional/intentional states as errors.

### Bug 1: Oh My Zsh reported as [ERROR] when missing

Oh My Zsh is **optional** — forge works without it. Users without OMZ were seeing a scary `[ERROR]` message suggesting their setup was broken. This should be a `[WARN]` since it's not required.

### Bug 2: NERD_FONT=0 reported as [ERROR]

When a user answers 'n' to the nerd fonts question during `forge zsh setup`, forge itself writes `export NERD_FONT=0` to their .zshrc. Then when the doctor runs immediately after, it reports that same value as `[ERROR] NERD_FONT: disabled (0)`.

This is doubly confusing: forge set that value, and now it's reporting it as an error. It should be a `[WARN]` with an instruction to re-enable if they change their mind.

## Changes

- `shell-plugin/doctor.zsh`: Oh My Zsh not found: `fail` → `warn`  
- `shell-plugin/doctor.zsh`: NERD_FONT disabled: `fail` → `warn` with actionable hint
- `shell-plugin/doctor.zsh`: USE_NERD_FONT disabled: `fail` → `warn` with actionable hint

## Testing

Run `forge zsh setup` and answer 'n' to the Nerd Fonts question. Doctor should now exit cleanly (exit 0) with warnings instead of errors.