### PR TITLE
fix: pass last shell command as context to forge via --context flag (#2639)

### DIFF
--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -79,6 +79,15 @@ pub struct Cli {
     #[arg(long)]
     pub provider: Option<ProviderId>,
 
+    /// Additional context to include with the prompt.
+    ///
+    /// This allows passing contextual information (e.g., the last shell command
+    /// executed) to help the agent understand the user's intent. This is
+    /// particularly useful when using the ZSH plugin's `:` command after
+    /// running shell commands.
+    #[arg(long)]
+    pub context: Option<String>,
+
     /// Top-level subcommands.
     #[command(subcommand)]
     pub subcommands: Option<TopLevelCommand>,

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2955,6 +2955,12 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
             event = event.additional_context(piped);
         }
 
+        // Add CLI --context as additional context if provided
+        // This allows the ZSH plugin to pass the last shell command as context
+        if let Some(ctx) = &self.cli.context {
+            event = event.additional_context(ctx.clone());
+        }
+
         // Create the chat request with the event
         let chat = ChatRequest::new(event, conversation_id);
 

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -78,8 +78,16 @@ function _forge_action_default() {
         _FORGE_ACTIVE_AGENT="$user_action"
     fi
     
-    # Execute the forge command directly with proper escaping
-    _forge_exec_interactive -p "$input_text" --cid "$_FORGE_CONVERSATION_ID"
+    # Capture last command from history for context
+    # This allows forge to understand what the user was doing before asking for help
+    local last_cmd=$(fc -ln -1 2>/dev/null || echo "")
+    
+    # Execute the forge command with last command context
+    if [[ -n "$last_cmd" ]]; then
+        _forge_exec_interactive -p "$input_text" --cid "$_FORGE_CONVERSATION_ID" --context "Last command: $last_cmd"
+    else
+        _forge_exec_interactive -p "$input_text" --cid "$_FORGE_CONVERSATION_ID"
+    fi
     
     # Start background sync job if enabled and not already running
     _forge_start_background_sync


### PR DESCRIPTION
## Summary

This PR resolves #2639 by enabling the ZSH plugin to pass the last executed shell command as context to the Forge agent. This allows the agent to understand what 'fix it' refers to after a failed command (e.g., a failed 'rm' or 'cargo build').

## Problem

When users run shell commands outside of forge, then say `:` to ask forge for help, the agent has no context about what the user was doing. For example:

```bash
$ rm test
rm: cannot remove 'test': Is a directory
$ : fix it
```

The agent would respond with "I'm trying to figure out what 'fix it' means without any context."

## Solution

This PR implements a complete solution with three changes:

1. **Added `--context` CLI flag** (`crates/forge_main/src/cli.rs`)
   - Accepts an optional string for additional context
   - Documented for users and developers

2. **Modified UI to use context** (`crates/forge_main/src/ui.rs`)
   - Passes the `--context` value as `additional_context` in the Event
   - Works alongside existing piped input context handling

3. **Updated ZSH dispatcher** (`shell-plugin/lib/dispatcher.zsh`)
   - Captures the last command from shell history using `fc -ln -1`
   - Passes it via the new `--context` flag when invoking forge

## How It Works

When a user runs:
```bash
$ rm test
rm: cannot remove 'test': Is a directory
$ : fix it
```

The ZSH plugin will:
1. Capture `rm test` from history
2. Execute forge with: `forge -p "fix it" --cid <conversation> --context "Last command: rm test"`
3. The agent receives both the prompt ("fix it") and the context ("Last command: rm test")
4. The agent can now understand what needs to be fixed

## Testing

The changes are minimal and follow the existing pattern for `additional_context`. The ZSH plugin change uses the standard `fc -ln -1` command which is available in all ZSH installations.

## Alternative Approaches Considered

PR #2666 attempted to use `--context` but didn't add the CLI flag, so it wouldn't work. This PR provides the complete implementation.

Fixes #2639