### PR TITLE
feat: per-agent model and provider configuration

### DIFF
--- a/crates/forge_api/src/api.rs
+++ b/crates/forge_api/src/api.rs
@@ -173,6 +173,9 @@ pub trait API: Sync + Send {
     /// suggestion generation).
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()>;
 
+    async fn get_agent_model_config(&self, agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>>;
+    async fn set_agent_model_config(&self, agent_id: String, config: forge_domain::AgentModelConfig) -> anyhow::Result<()>;
+
     /// Refresh MCP caches by fetching fresh data
     async fn reload_mcp(&self) -> Result<()>;
 

--- a/crates/forge_api/src/forge_api.rs
+++ b/crates/forge_api/src/forge_api.rs
@@ -309,6 +309,16 @@ impl<
         self.services.set_suggest_config(config).await
     }
 
+    async fn get_agent_model_config(&self, agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>> {
+        self.services.get_agent_model_config(agent_id).await
+    }
+
+    async fn set_agent_model_config(&self, agent_id: String, config: forge_domain::AgentModelConfig) -> anyhow::Result<()> {
+        let result = self.services.set_agent_model_config(agent_id, config).await;
+        let _ = self.services.reload_agents().await;
+        result
+    }
+
     async fn get_login_info(&self) -> Result<Option<LoginInfo>> {
         self.services.auth_service().get_auth_token().await
     }

--- a/crates/forge_app/src/command_generator.rs
+++ b/crates/forge_app/src/command_generator.rs
@@ -268,6 +268,14 @@ mod tests {
         async fn set_suggest_config(&self, _config: forge_domain::SuggestConfig) -> Result<()> {
             Ok(())
         }
+
+        async fn get_agent_model_config(&self, _agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>> {
+            Ok(None)
+        }
+
+        async fn set_agent_model_config(&self, _agent_id: String, _config: forge_domain::AgentModelConfig) -> Result<()> {
+            Ok(())
+        }
     }
 
     #[tokio::test]

--- a/crates/forge_app/src/services.rs
+++ b/crates/forge_app/src/services.rs
@@ -227,6 +227,10 @@ pub trait AppConfigService: Send + Sync {
     /// Sets the suggest configuration (provider and model for command
     /// suggestion generation).
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()>;
+
+    async fn get_agent_model_config(&self, agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>>;
+
+    async fn set_agent_model_config(&self, agent_id: String, config: forge_domain::AgentModelConfig) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -1059,6 +1063,14 @@ impl<I: Services> AppConfigService for I {
 
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()> {
         self.config_service().set_suggest_config(config).await
+    }
+
+    async fn get_agent_model_config(&self, agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>> {
+        self.config_service().get_agent_model_config(agent_id).await
+    }
+
+    async fn set_agent_model_config(&self, agent_id: String, config: forge_domain::AgentModelConfig) -> anyhow::Result<()> {
+        self.config_service().set_agent_model_config(agent_id, config).await
     }
 }
 

--- a/crates/forge_domain/src/agent_model_config.rs
+++ b/crates/forge_domain/src/agent_model_config.rs
@@ -1,0 +1,15 @@
+use derive_setters::Setters;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{ModelId, ProviderId};
+
+/// Per-agent model and provider configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Setters, JsonSchema, PartialEq)]
+#[setters(into)]
+pub struct AgentModelConfig {
+    /// Provider ID to use for this agent.
+    pub provider: ProviderId,
+    /// Model ID to use for this agent.
+    pub model: ModelId,
+}

--- a/crates/forge_domain/src/app_config.rs
+++ b/crates/forge_domain/src/app_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
-use crate::{CommitConfig, ModelId, ProviderId, SuggestConfig};
+use crate::{AgentModelConfig, CommitConfig, ModelId, ProviderId, SuggestConfig};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,6 +25,8 @@ pub struct AppConfig {
     pub commit: Option<CommitConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suggest: Option<SuggestConfig>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub agent_models: HashMap<String, AgentModelConfig>,
 }
 
 #[derive(Clone, Serialize, Deserialize, From, Debug, PartialEq)]

--- a/crates/forge_domain/src/lib.rs
+++ b/crates/forge_domain/src/lib.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod agent_definition;
+mod agent_model_config;
 mod app_config;
 mod attachment;
 mod auth;
@@ -60,6 +61,7 @@ mod xml;
 
 pub use agent::*;
 pub use agent_definition::*;
+pub use agent_model_config::*;
 pub use attachment::*;
 pub use chat_request::*;
 pub use chat_response::*;

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -567,6 +567,15 @@ pub enum ConfigSetField {
         /// Model ID to use for command suggestion generation.
         model: ModelId,
     },
+    /// Set a per-agent model and provider override.
+    AgentModel {
+        /// Agent ID to configure.
+        agent: AgentId,
+        /// Provider ID for this agent.
+        provider: ProviderId,
+        /// Model ID for this agent.
+        model: ModelId,
+    },
 }
 
 /// Type-safe subcommands for `forge config get`.
@@ -580,6 +589,11 @@ pub enum ConfigGetField {
     Commit,
     /// Get the command suggestion generation config.
     Suggest,
+    /// Get the per-agent model configuration.
+    AgentModel {
+        /// Agent ID to query.
+        agent: AgentId,
+    },
 }
 
 /// Command group for conversation management.

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -3428,6 +3428,17 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                     format!("is now the suggest model for provider '{provider}'"),
                 ))?;
             }
+            ConfigSetField::AgentModel { agent, provider, model } => {
+                let validated_model = self.validate_model(model.as_str(), Some(&provider)).await?;
+                let agent_config = forge_domain::AgentModelConfig {
+                    provider: provider.clone(),
+                    model: validated_model.clone(),
+                };
+                self.api.set_agent_model_config(agent.as_str().to_string(), agent_config).await?;
+                self.writeln_title(TitleFormat::action(validated_model.as_str()).sub_title(
+                    format!("is now the model for agent '{}' (provider '{}')", agent, provider),
+                ))?;
+            }
         }
 
         Ok(())
@@ -3487,6 +3498,16 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                         self.writeln(config.model.as_str().to_string())?;
                     }
                     None => self.writeln("Suggest: Not set")?,
+                }
+            }
+            ConfigGetField::AgentModel { agent } => {
+                let agent_config = self.api.get_agent_model_config(agent.as_str()).await?;
+                match agent_config {
+                    Some(config) => {
+                        self.writeln(config.provider.as_ref())?;
+                        self.writeln(config.model.as_str().to_string())?;
+                    }
+                    None => self.writeln(format!("Agent model for '{}': Not set (using default)", agent))?,
                 }
             }
         }

--- a/crates/forge_services/src/agent_registry.rs
+++ b/crates/forge_services/src/agent_registry.rs
@@ -90,8 +90,13 @@ impl<R: AgentRepository + AppConfigRepository + ProviderRepository> ForgeAgentRe
 
         // Convert definitions to runtime agents and populate map
         for def in agent_defs {
-            let agent =
-                Agent::from_agent_def(def, default_provider.id.clone(), default_model.clone());
+            let agent_id_str = def.id.as_str().to_string();
+            let (agent_provider, agent_model) = if let Some(agent_config) = app_config.agent_models.get(&agent_id_str) {
+                (agent_config.provider.clone(), agent_config.model.clone())
+            } else {
+                (default_provider.id.clone(), default_model.clone())
+            };
+            let agent = Agent::from_agent_def(def, agent_provider, agent_model);
             agents_map.insert(agent.id.as_str().to_string(), agent);
         }
 

--- a/crates/forge_services/src/app_config.rs
+++ b/crates/forge_services/src/app_config.rs
@@ -110,6 +110,15 @@ impl<F: ProviderRepository + AppConfigRepository + Send + Sync> AppConfigService
         })
         .await
     }
+
+    async fn get_agent_model_config(&self, agent_id: &str) -> anyhow::Result<Option<forge_domain::AgentModelConfig>> {
+        let config = self.infra.get_app_config().await?;
+        Ok(config.agent_models.get(agent_id).cloned())
+    }
+
+    async fn set_agent_model_config(&self, agent_id: String, agent_config: forge_domain::AgentModelConfig) -> anyhow::Result<()> {
+        self.update(|config| { config.agent_models.insert(agent_id, agent_config); }).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #2637

## Summary

Adds per-agent model+provider configuration so each agent (forge, sage, muse) can use a different model.

## Changes

- **`AgentModelConfig`** new struct with `provider` and `model` fields
- **`AppConfig`**: new `agent_models: HashMap<String, AgentModelConfig>` field persisted in `.config.json`
- **`AppConfigService`**: `get_agent_model_config` / `set_agent_model_config` methods
- **`AgentRegistry`**: applies per-agent overrides when loading agents, before falling back to global default
- **CLI**: `forge config set agent-model <agent> <provider> <model>` and `forge config get agent-model <agent>`
- **UI handler**: processes new config commands and triggers `reload_agents()` after set

## Usage

```
forge config set agent-model sage anthropic claude-3-5-sonnet-20241022
forge config get agent-model sage
```

When switching to an agent with a custom model, the prompt automatically shows that agent's model.

## Tests

Compilation verified with `cargo check` on all affected crates.