### PR TITLE
feat: expose env variables via config commands

### DIFF
--- a/crates/forge_api/src/api.rs
+++ b/crates/forge_api/src/api.rs
@@ -173,6 +173,20 @@ pub trait API: Sync + Send {
     /// suggestion generation).
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()>;
 
+    /// Gets all persistent environment variable overrides.
+    async fn get_env_overrides(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<String, String>>;
+
+    /// Sets a persistent environment variable override.
+    async fn set_env_override(&self, key: String, value: String) -> anyhow::Result<()>;
+
+    /// Removes a persistent environment variable override.
+    async fn remove_env_override(&self, key: &str) -> anyhow::Result<()>;
+
+    /// Gets all FORGE_* environment variables with current effective values.
+    fn list_forge_env_vars(&self) -> std::collections::BTreeMap<String, String>;
+
     /// Refresh MCP caches by fetching fresh data
     async fn reload_mcp(&self) -> Result<()>;
 

--- a/crates/forge_api/src/forge_api.rs
+++ b/crates/forge_api/src/forge_api.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -307,6 +308,26 @@ impl<
 
     async fn set_suggest_config(&self, config: SuggestConfig) -> anyhow::Result<()> {
         self.services.set_suggest_config(config).await
+    }
+
+    async fn get_env_overrides(&self) -> anyhow::Result<HashMap<String, String>> {
+        self.services.get_env_overrides().await
+    }
+
+    async fn set_env_override(&self, key: String, value: String) -> anyhow::Result<()> {
+        self.services.set_env_override(key, value).await
+    }
+
+    async fn remove_env_override(&self, key: &str) -> anyhow::Result<()> {
+        self.services.remove_env_override(key).await
+    }
+
+    fn list_forge_env_vars(&self) -> BTreeMap<String, String> {
+        self.infra
+            .get_env_vars()
+            .into_iter()
+            .filter(|(key, _)| key.starts_with("FORGE_"))
+            .collect()
     }
 
     async fn get_login_info(&self) -> Result<Option<LoginInfo>> {

--- a/crates/forge_app/src/services.rs
+++ b/crates/forge_app/src/services.rs
@@ -227,6 +227,17 @@ pub trait AppConfigService: Send + Sync {
     /// Sets the suggest configuration (provider and model for command
     /// suggestion generation).
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()>;
+
+    /// Gets all persistent environment variable overrides.
+    async fn get_env_overrides(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<String, String>>;
+
+    /// Sets a persistent environment variable override.
+    async fn set_env_override(&self, key: String, value: String) -> anyhow::Result<()>;
+
+    /// Removes a persistent environment variable override.
+    async fn remove_env_override(&self, key: &str) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -1059,6 +1070,20 @@ impl<I: Services> AppConfigService for I {
 
     async fn set_suggest_config(&self, config: forge_domain::SuggestConfig) -> anyhow::Result<()> {
         self.config_service().set_suggest_config(config).await
+    }
+
+    async fn get_env_overrides(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<String, String>> {
+        self.config_service().get_env_overrides().await
+    }
+
+    async fn set_env_override(&self, key: String, value: String) -> anyhow::Result<()> {
+        self.config_service().set_env_override(key, value).await
+    }
+
+    async fn remove_env_override(&self, key: &str) -> anyhow::Result<()> {
+        self.config_service().remove_env_override(key).await
     }
 }
 

--- a/crates/forge_domain/src/app_config.rs
+++ b/crates/forge_domain/src/app_config.rs
@@ -25,6 +25,9 @@ pub struct AppConfig {
     pub commit: Option<CommitConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suggest: Option<SuggestConfig>,
+    /// Persistent overrides for FORGE_* environment variables.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env_overrides: HashMap<String, String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, From, Debug, PartialEq)]

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -21,6 +21,7 @@ impl ForgeEnvironmentInfra {
     /// * `cwd` - Required working directory path
     pub fn new(restricted: bool, cwd: PathBuf) -> Self {
         Self::dot_env(&cwd);
+        Self::load_persisted_env_overrides();
         Self { restricted, cwd }
     }
 
@@ -102,6 +103,26 @@ impl ForgeEnvironmentInfra {
                 },
             ),
             model_cache_ttl: parse_env::<u64>("FORGE_MODEL_CACHE_TTL").unwrap_or(604_800), /* 1 week */
+        }
+    }
+
+    /// Load persisted environment variable overrides from the config file.
+    fn load_persisted_env_overrides() {
+        let config_path = dirs::home_dir()
+            .map(|a| a.join("forge"))
+            .unwrap_or(PathBuf::from(".").join("forge"))
+            .join(".config.json");
+
+        if let Ok(content) = std::fs::read_to_string(&config_path) {
+            if let Ok(config) = serde_json::from_str::<forge_domain::AppConfig>(&content) {
+                for (key, value) in &config.env_overrides {
+                    if key.starts_with("FORGE_") {
+                        unsafe {
+                            std::env::set_var(key, value);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -519,6 +519,15 @@ pub enum ConfigCommand {
 
     /// List configuration values.
     List,
+
+    /// List all FORGE_* environment variables with current values and overrides.
+    ListEnv,
+
+    /// Remove a persistent environment variable override.
+    UnsetEnv {
+        /// Environment variable name to remove from persistent overrides.
+        key: String,
+    },
 }
 
 /// Arguments for `forge config set`.
@@ -567,6 +576,13 @@ pub enum ConfigSetField {
         /// Model ID to use for command suggestion generation.
         model: ModelId,
     },
+    /// Set a persistent FORGE_* environment variable override.
+    Env {
+        /// Environment variable name (e.g. FORGE_TOOL_TIMEOUT).
+        key: String,
+        /// Value to set.
+        value: String,
+    },
 }
 
 /// Type-safe subcommands for `forge config get`.
@@ -580,6 +596,11 @@ pub enum ConfigGetField {
     Commit,
     /// Get the command suggestion generation config.
     Suggest,
+    /// Get a persistent environment variable override.
+    Env {
+        /// Environment variable name (e.g. FORGE_TOOL_TIMEOUT).
+        key: String,
+    },
 }
 
 /// Command group for conversation management.

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -3384,6 +3384,13 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
             crate::cli::ConfigCommand::List => {
                 self.on_show_config(porcelain).await?;
             }
+            crate::cli::ConfigCommand::ListEnv => {
+                self.handle_list_env().await?;
+            }
+            crate::cli::ConfigCommand::UnsetEnv { key } => {
+                self.api.remove_env_override(&key).await?;
+                self.writeln(format!("Removed persistent override for {key}"))?;
+            }
         }
         Ok(())
     }
@@ -3427,6 +3434,17 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                 self.writeln_title(TitleFormat::action(validated_model.as_str()).sub_title(
                     format!("is now the suggest model for provider '{provider}'"),
                 ))?;
+            }
+            ConfigSetField::Env { key, value } => {
+                if !key.starts_with("FORGE_") {
+                    anyhow::bail!(
+                        "Only FORGE_* environment variables can be set. Got: {key}"
+                    );
+                }
+                self.api
+                    .set_env_override(key.clone(), value.clone())
+                    .await?;
+                self.writeln(format!("Set {key}={value} (persisted to config)"))?;
             }
         }
 
@@ -3489,12 +3507,79 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                     None => self.writeln("Suggest: Not set")?,
                 }
             }
+            ConfigGetField::Env { key } => {
+                let overrides = self.api.get_env_overrides().await?;
+                match overrides.get(&key) {
+                    Some(value) => self.writeln(format!("{key}={value}"))?,
+                    None => match std::env::var(&key) {
+                        Ok(value) => {
+                            self.writeln(format!("{key}={value} (from environment)"))?
+                        }
+                        Err(_) => self.writeln(format!("{key}: Not set"))?,
+                    },
+                }
+            }
         }
 
         Ok(())
     }
 
-    /// Handle prompt command - returns model and conversation stats for shell
+    /// Handle list-env: shows all FORGE_* vars with values and overrides
+    async fn handle_list_env(&mut self) -> Result<()> {
+        let overrides = self.api.get_env_overrides().await?;
+        let env_vars = self.api.list_forge_env_vars();
+
+        let known_vars = [
+            "FORGE_API_URL", "FORGE_AUTO_DUMP", "FORGE_DEBUG_REQUESTS",
+            "FORGE_DUMP_AUTO_OPEN", "FORGE_HISTORY_FILE",
+            "FORGE_HTTP_ACCEPT_INVALID_CERTS", "FORGE_HTTP_ADAPTIVE_WINDOW",
+            "FORGE_HTTP_CONNECT_TIMEOUT", "FORGE_HTTP_KEEP_ALIVE_INTERVAL",
+            "FORGE_HTTP_KEEP_ALIVE_TIMEOUT", "FORGE_HTTP_KEEP_ALIVE_WHILE_IDLE",
+            "FORGE_HTTP_MAX_REDIRECTS", "FORGE_HTTP_MIN_TLS_VERSION",
+            "FORGE_HTTP_MAX_TLS_VERSION", "FORGE_HTTP_POOL_IDLE_TIMEOUT",
+            "FORGE_HTTP_POOL_MAX_IDLE_PER_HOST", "FORGE_HTTP_READ_TIMEOUT",
+            "FORGE_HTTP_ROOT_CERT_PATHS", "FORGE_HTTP_TLS_BACKEND",
+            "FORGE_HTTP_USE_HICKORY", "FORGE_MAX_CONVERSATIONS",
+            "FORGE_MAX_EXTENSIONS", "FORGE_MAX_FILE_READ_BATCH_SIZE",
+            "FORGE_MAX_IMAGE_SIZE", "FORGE_MAX_LINE_LENGTH",
+            "FORGE_MAX_SEARCH_RESULT_BYTES", "FORGE_MODEL_CACHE_TTL",
+            "FORGE_PARALLEL_FILE_READS", "FORGE_RETRY_BACKOFF_FACTOR",
+            "FORGE_RETRY_INITIAL_BACKOFF_MS", "FORGE_RETRY_MAX_ATTEMPTS",
+            "FORGE_RETRY_STATUS_CODES", "FORGE_SEM_SEARCH_LIMIT",
+            "FORGE_SEM_SEARCH_TOP_K", "FORGE_STDOUT_MAX_LINE_LENGTH",
+            "FORGE_SUPPRESS_RETRY_ERRORS", "FORGE_TOOL_TIMEOUT",
+            "FORGE_WORKSPACE_SERVER_URL",
+        ];
+
+        let mut all_vars: std::collections::BTreeSet<String> =
+            known_vars.iter().map(|s| s.to_string()).collect();
+        for key in env_vars.keys() {
+            all_vars.insert(key.clone());
+        }
+        for key in overrides.keys() {
+            all_vars.insert(key.clone());
+        }
+
+        for key in &all_vars {
+            let env_value = env_vars.get(key);
+            let override_value = overrides.get(key);
+            match (override_value, env_value) {
+                (Some(ov), _) => {
+                    self.writeln(format!("{key}={ov}  [persisted]"))?;
+                }
+                (None, Some(ev)) => {
+                    self.writeln(format!("{key}={ev}"))?;
+                }
+                (None, None) => {
+                    self.writeln(format!("{key}=  [not set]"))?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+        /// Handle prompt command - returns model and conversation stats for shell
     /// integration
     async fn handle_zsh_rprompt_command(&mut self) -> Option<String> {
         let cid = std::env::var("_FORGE_CONVERSATION_ID")

--- a/crates/forge_services/src/app_config.rs
+++ b/crates/forge_services/src/app_config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use forge_app::AppConfigService;
@@ -107,6 +108,26 @@ impl<F: ProviderRepository + AppConfigRepository + Send + Sync> AppConfigService
     ) -> anyhow::Result<()> {
         self.update(|config| {
             config.suggest = Some(suggest_config);
+        })
+        .await
+    }
+
+    async fn get_env_overrides(&self) -> anyhow::Result<HashMap<String, String>> {
+        let config = self.infra.get_app_config().await?;
+        Ok(config.env_overrides)
+    }
+
+    async fn set_env_override(&self, key: String, value: String) -> anyhow::Result<()> {
+        self.update(|config| {
+            config.env_overrides.insert(key, value);
+        })
+        .await
+    }
+
+    async fn remove_env_override(&self, key: &str) -> anyhow::Result<()> {
+        let key = key.to_string();
+        self.update(|config| {
+            config.env_overrides.remove(&key);
         })
         .await
     }

--- a/shell-plugin/lib/actions/config.zsh
+++ b/shell-plugin/lib/actions/config.zsh
@@ -382,6 +382,41 @@ function _forge_action_config() {
     $_FORGE_BIN config list
 }
 
+# Action handler: Set or list FORGE_* environment variable overrides
+# Usage: :config-env               - list all FORGE_* vars with values
+#        :config-env KEY VALUE     - persist a FORGE_* env var override
+#        :config-env --unset KEY   - remove a persisted override
+function _forge_action_config_env() {
+    local input_text="$1"
+    echo
+
+    if [[ -z "$input_text" ]]; then
+        # No arguments: list all env vars
+        _forge_exec config list-env
+        return
+    fi
+
+    # Check for --unset flag
+    if [[ "$input_text" == --unset\ * ]]; then
+        local key="${input_text#--unset }"
+        key="${key## }"  # trim leading spaces
+        _forge_exec config unset-env "$key"
+        return
+    fi
+
+    # Parse KEY VALUE from input
+    local key="${input_text%% *}"
+    local value="${input_text#* }"
+
+    if [[ "$key" == "$value" ]]; then
+        # Only one argument provided - show current value
+        _forge_exec config get env "$key"
+        return
+    fi
+
+    _forge_exec config set env "$key" "$value"
+}
+
 # Action handler: Show tools
 function _forge_action_tools() {
     echo

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -190,6 +190,9 @@ function forge-accept-line() {
         config)
             _forge_action_config
         ;;
+        config-env|ce)
+            _forge_action_config_env "$input_text"
+        ;;
         skill)
             _forge_action_skill
         ;;


### PR DESCRIPTION
Fixes #2638

## Summary

Exposes all `FORGE_*` environment variables as interactive config commands for discoverability and persistent configuration.

## Changes

**Domain** (`app_config.rs`): `env_overrides: HashMap<String, String>` in `AppConfig` for persistent storage

**Services** (`app_config.rs`, `services.rs`): `get_env_overrides`, `set_env_override`, `remove_env_override` methods

**Infrastructure** (`env.rs`): `load_persisted_env_overrides()` at startup applies overrides as env vars (highest priority)

**CLI** (`cli.rs`):
- `forge config set env KEY VALUE` - persist an override
- `forge config get env KEY` - show current value
- `forge config list-env` - show all 38 FORGE_* vars with current values and `[persisted]`/`[not set]` annotations
- `forge config unset-env KEY` - remove a persisted override

**ZSH Plugin** (`config.zsh`, `dispatcher.zsh`):
- `:config-env` / `:ce` - list all vars
- `:config-env KEY VALUE` - set persistent override
- `:config-env --unset KEY` - remove override

## Design Decisions

- Single generic `config set env KEY VALUE` pattern instead of 30+ individual commands
- Only `FORGE_*` prefixed keys accepted (validated at CLI and infra levels)
- Overrides applied via `std::env::set_var` at startup so existing `parse_env()` calls work automatically
- `[persisted]` / `[not set]` annotations in `list-env` for clarity

## Tests

Compilation verified with `cargo check` on all affected crates.