### PR TITLE
fix(doctor): downgrade non-critical checks from error to warning

### DIFF
--- a/shell-plugin/doctor.zsh
+++ b/shell-plugin/doctor.zsh
@@ -120,7 +120,7 @@ if [[ -n "$ZSH" ]] && [[ -d "$ZSH" ]]; then
     fi
     print_result info "${ZSH}"
 else
-    print_result fail "Oh My Zsh not found" "Install: sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\""
+    print_result warn "Oh My Zsh: not installed (optional)" "Install: sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\""
 fi
 
 # 2. Check if forge is installed and in PATH
@@ -151,7 +151,7 @@ if [[ -n "$_FORGE_PLUGIN_LOADED" ]]; then
     print_result pass "Forge plugin loaded"
 else
     print_result fail "Forge plugin not loaded"
-    print_result instruction "Add to your ~/.zshrc:"
+    print_result instruction "Run 'forge zsh setup' for guided setup, or add manually to ~/.zshrc:"
     print_result code "eval \"\$(forge zsh plugin)\""
 fi
 
@@ -186,8 +186,8 @@ if [[ -f "$zshrc_file" ]] && [[ -n "$_FORGE_PLUGIN_LOADED" ]]; then
     fi
 fi
 
-# 4. Check ZSH theme RPROMPT
-print_section "ZSH Theme RPROMPT"
+# 4. Check FORGE RIGHT PROMPT
+print_section "FORGE RIGHT PROMPT"
 
 # Check if forge theme is loaded by checking environment variable
 if [[ -n "$_FORGE_THEME_LOADED" ]]; then
@@ -195,11 +195,11 @@ if [[ -n "$_FORGE_THEME_LOADED" ]]; then
 elif (( $+functions[p10k] )); then
     print_result info "Powerlevel10k detected (not using Forge theme)"
 elif [[ -n "$ZSH_THEME" ]]; then
-    print_result fail "Using theme: ${ZSH_THEME}"
+    print_result warn "Using theme: ${ZSH_THEME}"
     print_result instruction "To use Forge theme, add to ~/.zshrc:"
     print_result code "eval \"\$(forge zsh theme)\""
 else
-    print_result fail "No theme loaded"
+    print_result warn "No theme loaded"
     print_result instruction "To use Forge theme, add to ~/.zshrc:"
     print_result code "eval \"\$(forge zsh theme)\""
 fi
@@ -529,16 +529,16 @@ if [[ -n "$NERD_FONT" ]]; then
     if [[ "$NERD_FONT" == "1" || "$NERD_FONT" == "true" ]]; then
         print_result pass "NERD_FONT: enabled"
     else
-        print_result fail "NERD_FONT: disabled (${NERD_FONT})"
-        print_result instruction "Enable Nerd Font by setting:"
+        print_result warn "NERD_FONT: disabled (${NERD_FONT})"
+        print_result instruction "To enable Nerd Font icons, set:"
         print_result code "export NERD_FONT=1"
     fi
 elif [[ -n "$USE_NERD_FONT" ]]; then
     if [[ "$USE_NERD_FONT" == "1" || "$USE_NERD_FONT" == "true" ]]; then
         print_result pass "USE_NERD_FONT: enabled"
     else
-        print_result fail "USE_NERD_FONT: disabled (${USE_NERD_FONT})"
-        print_result instruction "Enable Nerd Font by setting:"
+        print_result warn "USE_NERD_FONT: disabled (${USE_NERD_FONT})"
+        print_result instruction "To enable Nerd Font icons, set:"
         print_result code "export NERD_FONT=1"
     fi
 else


### PR DESCRIPTION
Fixes #2612

## Problem

`forge zsh doctor` exits with code 1 (failure) in two scenarios that are not actually failures:

1. **NERD_FONT=0** — the user explicitly opted out during `forge zsh setup`. Forge itself writes `export NERD_FONT=0` to `.zshrc`, then doctor reports it as `[ERROR]`. That's contradictory.
2. **Oh My Zsh missing** — it is optional, not required, but doctor marks it `[ERROR]` with an install instruction.

Additionally, the theme section header and plugin instructions needed small improvements per the spec.

## Changes

- **Oh My Zsh not found**: `fail` → `warn` (it is optional)
- **NERD_FONT / USE_NERD_FONT disabled**: `fail` → `warn` (user chose to disable it)
- **Forge theme not loaded**: `fail` → `warn` (theme is optional, not required for forge to work)
- **Section header**: `"ZSH Theme RPROMPT"` → `"FORGE RIGHT PROMPT"`
- **Forge plugin missing instructions**: also mention `forge zsh setup` alongside the manual `eval` snippet

## Exit code behaviour

The existing summary logic already exits 0 when `$failed -eq 0`. These changes ensure that "opted-out Nerd Font" and "no Oh My Zsh" never increment `$failed`, so the command exits cleanly for typical setups where only warnings are present.

The only remaining hard `[ERROR]` (exit 1) paths are ZSH itself being absent and genuinely required tools like `fzf`.