### PR TITLE
chore(templates): remove tool-use non-negotiable rule

### DIFF
--- a/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt.snap
+++ b/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt.snap
@@ -55,7 +55,6 @@ If any required arguments are missing, do not attempt to use the tool.
 
 
 <non_negotiable_rules>
-- ALWAYS use tools to investigate the codebase before answering questions about how it works. Your answers MUST be grounded in actual inspection using tools. NEVER answer based solely on general programming knowledge or assumptions. **Important**: When asked for documentation, configuration guides, or setup instructions, use tools to find the relevant documentation files (README, guides, markdown) - these ARE the source of truth for those questions. When asked for implementation details, debugging, or code modification, use tools to find the actual code files - these ARE the source of truth for those questions.
 - ALWAYS present the result of your work in a neatly structured format (using markdown syntax in your response) to the user at the end of every task.
 - Do what has been asked; nothing more, nothing less.
 - NEVER create files unless they're absolutely necessary for achieving your goal.

--- a/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_tool_supported.snap
+++ b/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_tool_supported.snap
@@ -27,7 +27,6 @@ Do it nicely
 </project_guidelines>
 
 <non_negotiable_rules>
-- ALWAYS use tools to investigate the codebase before answering questions about how it works. Your answers MUST be grounded in actual inspection using tools. NEVER answer based solely on general programming knowledge or assumptions. **Important**: When asked for documentation, configuration guides, or setup instructions, use tools to find the relevant documentation files (README, guides, markdown) - these ARE the source of truth for those questions. When asked for implementation details, debugging, or code modification, use tools to find the actual code files - these ARE the source of truth for those questions.
 - ALWAYS present the result of your work in a neatly structured format (using markdown syntax in your response) to the user at the end of every task.
 - Do what has been asked; nothing more, nothing less.
 - NEVER create files unless they're absolutely necessary for achieving your goal.

--- a/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_with_extensions.snap
+++ b/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_with_extensions.snap
@@ -26,7 +26,6 @@ You are Forge
 
 
 <non_negotiable_rules>
-- ALWAYS use tools to investigate the codebase before answering questions about how it works. Your answers MUST be grounded in actual inspection using tools. NEVER answer based solely on general programming knowledge or assumptions. **Important**: When asked for documentation, configuration guides, or setup instructions, use tools to find the relevant documentation files (README, guides, markdown) - these ARE the source of truth for those questions. When asked for implementation details, debugging, or code modification, use tools to find the actual code files - these ARE the source of truth for those questions.
 - ALWAYS present the result of your work in a neatly structured format (using markdown syntax in your response) to the user at the end of every task.
 - Do what has been asked; nothing more, nothing less.
 - NEVER create files unless they're absolutely necessary for achieving your goal.

--- a/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_with_extensions_truncated.snap
+++ b/crates/forge_app/src/orch_spec/snapshots/forge_app__orch_spec__orch_system_spec__system_prompt_with_extensions_truncated.snap
@@ -38,7 +38,6 @@ You are Forge
 
 
 <non_negotiable_rules>
-- ALWAYS use tools to investigate the codebase before answering questions about how it works. Your answers MUST be grounded in actual inspection using tools. NEVER answer based solely on general programming knowledge or assumptions. **Important**: When asked for documentation, configuration guides, or setup instructions, use tools to find the relevant documentation files (README, guides, markdown) - these ARE the source of truth for those questions. When asked for implementation details, debugging, or code modification, use tools to find the actual code files - these ARE the source of truth for those questions.
 - ALWAYS present the result of your work in a neatly structured format (using markdown syntax in your response) to the user at the end of every task.
 - Do what has been asked; nothing more, nothing less.
 - NEVER create files unless they're absolutely necessary for achieving your goal.

--- a/templates/forge-custom-agent-template.md
+++ b/templates/forge-custom-agent-template.md
@@ -30,7 +30,6 @@
 {{/if}}
 
 <non_negotiable_rules>
-- ALWAYS use tools to investigate the codebase before answering questions about how it works. Your answers MUST be grounded in actual inspection using tools. NEVER answer based solely on general programming knowledge or assumptions. **Important**: When asked for documentation, configuration guides, or setup instructions, use tools to find the relevant documentation files (README, guides, markdown) - these ARE the source of truth for those questions. When asked for implementation details, debugging, or code modification, use tools to find the actual code files - these ARE the source of truth for those questions.
 - ALWAYS present the result of your work in a neatly structured format (using markdown syntax in your response) to the user at the end of every task.
 - Do what has been asked; nothing more, nothing less.
 - NEVER create files unless they're absolutely necessary for achieving your goal.


### PR DESCRIPTION
## Summary
Remove the tool-use non-negotiable rule from the custom agent template, as it is not applicable in contexts where tools are unavailable or unnecessary.

## Context
The custom agent template included a non-negotiable rule requiring agents to always use tools to investigate the codebase before answering. However, custom agents may operate in environments where tools are not available or where the rule is irrelevant to their purpose. Keeping this rule in the template imposes an unnecessary constraint on all agents generated from it.

## Changes
- Removed the "ALWAYS use tools to investigate the codebase" non-negotiable rule from `templates/forge-custom-agent-template.md`

## Testing
No functional code was changed. Verify the template renders correctly:

```bash
cargo insta test --accept
```
