### PR TITLE
fix(ui): show full MCP error messages without truncation

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
+use console::style;
 use convert_case::{Case, Casing};
 use forge_api::{
     API, AgentId, AnyProvider, ApiKeyRequest, AuthContextRequest, AuthContextResponse, ChatRequest,
@@ -1422,24 +1423,19 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
             }
         }
 
-        // Show failed MCP servers
-        if !all_tools.mcp.get_failures().is_empty() {
-            info = info.add_title("FAILED");
-            for (server_name, error) in all_tools.mcp.get_failures().iter() {
-                // Truncate error message for readability
-                let truncated_error = if error.len() > 80 {
-                    format!("{}...", &error[..77])
-                } else {
-                    error.clone()
-                };
-                info = info.add_value(format!("[✗] {server_name} - {truncated_error}"));
-            }
-        }
-
         if porcelain {
             self.writeln(Porcelain::from(&info).uppercase_headers().truncate(3, 60))?;
         } else {
             self.writeln(info)?;
+        }
+
+        // Show failed MCP servers
+        if !porcelain && !all_tools.mcp.get_failures().is_empty() {
+            self.writeln("MCP FAILURES\n".dimmed().bold())?;
+            for (_, error) in all_tools.mcp.get_failures().iter() {
+                let error = style(error).red();
+                self.writeln(error)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
Fix `mcp list` to display full MCP server error messages without truncation, shown in red after the server list.

## Context
Previously, MCP failure messages were truncated to 80 characters with a trailing `...`, making it impossible to read the full error — especially for multi-line errors like connection stack traces. This made diagnosing why an MCP server failed to initialize unnecessarily difficult.

## Changes
- Removed the 80-character truncation applied to MCP failure error messages
- Moved the failures section to render after the main server list (and after porcelain output), so it doesn't interfere with machine-readable output
- Failures are now displayed in full, in red, under a `MCP FAILURES` heading
- Failures are suppressed in `--porcelain` mode to keep machine-readable output clean

## Testing
```bash
# Run mcp list with a failing server configured (e.g. a bad URL)
cargo run -- mcp list

# Verify:
# - Full error message is shown (not truncated)
# - Error text is rendered in red
# - Porcelain output is unaffected
cargo run -- mcp list --porcelain
```
