### PR TITLE
fix(forge_config): make global config file optional

### DIFF
--- a/crates/forge_config/src/reader.rs
+++ b/crates/forge_config/src/reader.rs
@@ -105,7 +105,9 @@ impl ConfigReader {
     /// absent.
     pub fn read_global(mut self) -> Self {
         let path = Self::config_path();
-        self.builder = self.builder.add_source(config::File::from(path));
+        self.builder = self
+            .builder
+            .add_source(config::File::from(path).required(false));
         self
     }
 


### PR DESCRIPTION
## Summary
Fix a missed case from the config refactor where the global TOML config file was required to be present, causing failures when it doesn't exist.

## Context
PR #2685 introduced the `forge_config` crate as part of a config refactor. During that refactor, the `read_global` method was added to `ConfigReader`, but the config file source was registered as required — meaning Forge would fail to start if the global config file (`forge.toml`) was absent. Since the global config file is optional by design, this was an oversight.

## Changes
- Mark the global config file source as `required(false)` so Forge starts normally even when the file does not exist

## Testing
```bash
# Ensure no global config file is present and start Forge
rm -f ~/.config/forge/forge.toml  # or wherever the global config lives
cargo run -- --help

# Run crate tests
cargo insta test --accept -p forge_config
```

## Links
- Config refactor PR: #2685
