### PR TITLE
fix(forge_main): strip trailing slash from base URL during OpenAICompatible login; fixes #2715

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2207,6 +2207,8 @@ impl<A: API + ConsoleWriter + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
 
                 anyhow::ensure!(!param_value.trim().is_empty(), "{param} cannot be empty");
 
+                let param_value = param_value.trim_end_matches('/').to_string();
+
                 Ok((param.to_string(), param_value))
             })
             .collect::<anyhow::Result<HashMap<_, _>>>()?;


### PR DESCRIPTION

Normalizes the user-provided base URL by stripping any trailing slash before it is stored in credentials. Previously, entering a URL like 'http://localhost:8080/v1/' would produce double-slash endpoints such as 'http://localhost:8080/v1//chat/completions' when the template '\{\{OPENAI_URL\}\}/chat/completions' was rendered. The fix applies trim_end_matches('/') to the collected URL parameter value right after input validation, ensuring clean URL construction downstream.