### PR TITLE
fix(ui): use bullet glyph for better Windows terminal compatibility

### DIFF
--- a/crates/forge_main/src/title_display.rs
+++ b/crates/forge_main/src/title_display.rs
@@ -24,11 +24,11 @@ impl TitleDisplay {
         let mut buf = String::new();
 
         let icon = match self.inner.category {
-            Category::Action => "⏺".yellow(),
-            Category::Info => "⏺".white(),
-            Category::Debug => "⏺".cyan(),
-            Category::Error => "⏺".red(),
-            Category::Completion => "⏺".yellow(),
+            Category::Action => "●".yellow(),
+            Category::Info => "●".white(),
+            Category::Debug => "●".cyan(),
+            Category::Error => "●".red(),
+            Category::Completion => "●".yellow(),
             Category::Warning => "⚠️".bright_yellow(),
         };
 
@@ -61,7 +61,7 @@ impl TitleDisplay {
     fn format_plain(&self) -> String {
         let mut buf = String::new();
 
-        buf.push_str("⏺ ");
+        buf.push_str("● ");
 
         let local_time: chrono::DateTime<Local> = self.inner.timestamp.into();
         let timestamp_str = format!("[{}] ", local_time.format("%H:%M:%S"));


### PR DESCRIPTION
## Summary
Replace the `⏺` glyph with `●` for title icons to improve rendering on Windows terminals.

## Context
The `⏺` (U+23FA, Black Circle for Record) glyph is part of the Miscellaneous Technical Unicode block and renders inconsistently — particularly on Windows terminals where it often appears as a hollow or oversized circle, or falls back to a box character. The `●` (U+25CF, Black Circle) glyph is in the General Punctuation block, has much broader font support, and renders as a clean, solid dot across all platforms including Windows.

## Changes
- Replaced `⏺` with `●` in all colored icon variants (`Action`, `Info`, `Debug`, `Error`, `Completion`) in `TitleDisplay`
- Replaced `⏺` with `●` in the plain-text format path used for non-color output

## Testing
Run the application and observe the title display icons render correctly as solid dots across terminals, including Windows.

```bash
cargo run -- "hello"
```
