### PR TITLE
feat: add Fireworks AI as a built-in provider

### DIFF
--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -71,6 +71,7 @@ impl ProviderId {
     pub const CODEX: ProviderId = ProviderId(Cow::Borrowed("codex"));
     pub const OPENCODE_ZEN: ProviderId = ProviderId(Cow::Borrowed("opencode_zen"));
     pub const NOVITA: ProviderId = ProviderId(Cow::Borrowed("novita"));
+    pub const FIREWORKS: ProviderId = ProviderId(Cow::Borrowed("fireworks"));
 
     /// Returns all built-in provider IDs
     ///
@@ -102,6 +103,7 @@ impl ProviderId {
             ProviderId::CODEX,
             ProviderId::OPENCODE_ZEN,
             ProviderId::NOVITA,
+            ProviderId::FIREWORKS,
         ]
     }
 
@@ -126,6 +128,7 @@ impl ProviderId {
             "minimax" => "MiniMax".to_string(),
             "codex" => "Codex".to_string(),
             "novita" => "Novita".to_string(),
+            "fireworks" => "Fireworks".to_string(),
             _ => {
                 // For other providers, use UpperCamelCase conversion
                 use convert_case::{Case, Casing};
@@ -169,6 +172,7 @@ impl std::str::FromStr for ProviderId {
             "minimax" => ProviderId::MINIMAX,
             "codex" => ProviderId::CODEX,
             "novita" => ProviderId::NOVITA,
+            "fireworks" => ProviderId::FIREWORKS,
             // For custom providers, use Cow::Owned to avoid memory leaks
             custom => ProviderId(Cow::Owned(custom.to_string())),
         };

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -2564,5 +2564,25 @@
       }
     ],
     "auth_methods": ["api_key"]
+  },
+  {
+    "id": "fireworks",
+    "api_key_vars": "FIREWORKS_API_KEY",
+    "url_param_vars": [],
+    "response_type": "OpenAI",
+    "url": "https://api.fireworks.ai/inference/v1/chat/completions",
+    "models": [
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p5-turbo",
+        "name": "Kimi K2.5 Turbo (FirePass)",
+        "description": "Fireworks FirePass router for Kimi K2.5 Turbo — intelligent routing for optimal cost-performance. Free tier via FirePass.",
+        "context_length": 131072,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      }
+    ],
+    "auth_methods": ["api_key"]
   }
 ]


### PR DESCRIPTION
Fixes #2738

Adds Fireworks AI as a built-in provider, same pattern as the Novita AI addition in #2687.

Changes:
- `crates/forge_domain/src/provider.rs`: added FIREWORKS const, registered in `built_in_providers()`, added `from_str` match arm and `display_name()` entry
- `crates/forge_repo/src/provider/provider.json`: added fireworks provider config with the Kimi K2.5 Turbo (FirePass) model, OpenAI-compatible response type

Tested with `cargo check --all-features --workspace` and `cargo test --all-features --workspace`, both pass clean.