### PR TITLE
docs: Remove PR/issue references from release notes template

### DIFF
--- a/.forge/skills/write-release-notes/SKILL.md
+++ b/.forge/skills/write-release-notes/SKILL.md
@@ -55,7 +55,7 @@ Speak to impact, not implementation. Use active voice. Be enthusiastic.]
 ## Highlights
 
 ### [Feature/Fix Category]
-**[PR Title rephrased as user benefit]** ([#NNN](url))
+**[PR Title rephrased as user benefit]**
 [1-2 sentences expanding on the PR description. Focus on what the user gains. 
 If the PR body has useful context, distill it. If empty, infer from the title.]
 
@@ -63,7 +63,7 @@ If the PR body has useful context, distill it. If empty, infer from the title.]
 
 ## Bug Fixes & Reliability
 
-[Bullet list of fixes, each with a brief impact statement and PR link]
+[Bullet list of fixes, each with a brief impact statement]
 
 ## Under the Hood
 
@@ -88,6 +88,7 @@ A huge thank you to everyone who made this release happen: [list @handles — ex
 - **Celebrate contributors**: Name them enthusiastically
 - **Tagline formula**: `[Version] — [Adjective] [Theme]` (e.g. "v1.32.0 — Smarter Config, Smoother Workflows")
 - **No implementation details**: Do not mention internal module names, struct names, function names, crate names, or how something was implemented. Focus purely on what the user experiences or gains.
+- **No PR/issue references**: Do not include PR numbers, issue numbers, or links to GitHub PRs/issues in the release notes. Focus on the changes themselves, not their tracking identifiers.
 
 ### 5. Contributors Filter
 


### PR DESCRIPTION
## Summary
Remove PR/issue references from the release notes skill template to create cleaner, more user-focused release notes.

## Context
Release notes are meant to communicate value to end users, not serve as a changelog for developers. Including PR numbers and GitHub links (`#123`, `[PR link]`) adds noise and shifts focus from the user experience to development tracking.

This update aligns the release notes skill with best practices for user-facing documentation by removing all PR/issue reference patterns from the template and adding explicit guidance against including them.

## Changes
- Removed `([#NNN](url))` pattern from highlights section template
- Updated bug fixes section guidance to remove "PR link" reference
- Added explicit guideline: "No PR/issue references - do not include PR numbers, issue numbers, or links to GitHub PRs/issues in the release notes"

## Use Cases
When using the `write-release-notes` skill, the generated release notes will now:
- Focus purely on user value and impact
- Avoid GitHub-specific tracking identifiers
- Be cleaner and more readable for end users
- Match industry best practices for public-facing release notes

## Testing
```bash
# Verify the skill template has been updated
cat .forge/skills/write-release-notes/SKILL.md | grep -A 5 "No PR/issue"

# Test the skill by generating release notes
forge skill write-release-notes
# Verify generated notes do not contain PR/issue references
```

## Links
- Related skill: `.forge/skills/write-release-notes/SKILL.md`
