### PR TITLE
fix: clear thought_signature in DropReasoningDetails transformer

### DIFF
--- a/crates/forge_domain/src/transformer/drop_reasoning_details.rs
+++ b/crates/forge_domain/src/transformer/drop_reasoning_details.rs
@@ -9,6 +9,7 @@ impl Transformer for DropReasoningDetails {
         context.messages.iter_mut().for_each(|message| {
             if let crate::ContextMessage::Text(text) = &mut **message {
                 text.reasoning_details = None;
+                text.thought_signature = None;
             }
         });
 
@@ -180,5 +181,31 @@ mod tests {
         let snapshot =
             TransformationSnapshot::new("DropReasoningDetails_preserve_non_text", fixture, actual);
         assert_yaml_snapshot!(snapshot);
+    }
+
+    #[test]
+    fn test_drop_reasoning_clears_thought_signature() {
+        let reasoning_details = vec![ReasoningFull {
+            text: Some("thinking".to_string()),
+            signature: Some("sig_minimax".to_string()),
+            ..Default::default()
+        }];
+
+        let fixture = Context::default().add_message(ContextMessage::Text(
+            TextMessage::new(Role::Assistant, "response")
+                .model(crate::ModelId::new("MiniMax-M2.7"))
+                .reasoning_details(reasoning_details)
+                .thought_signature("minimax_thought_sig".to_string()),
+        ));
+
+        let mut transformer = DropReasoningDetails;
+        let actual = transformer.transform(fixture);
+
+        if let crate::ContextMessage::Text(text) = &*actual.messages[0] {
+            assert_eq!(text.reasoning_details, None);
+            assert_eq!(text.thought_signature, None);
+        } else {
+            panic!("expected TextMessage");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `DropReasoningDetails` only cleared `reasoning_details` but left `thought_signature` intact on text messages
- When switching from a provider like MiniMax back to Claude, the leftover signature caused a 400 error because Claude rejects unknown thinking block signatures
- Added `text.thought_signature = None;` alongside the existing `text.reasoning_details = None;` to match the behavior of `ReasoningNormalizer` which already clears both fields

Fixes #2646

## Test plan
- [x] Added `test_drop_reasoning_clears_thought_signature` — creates an assistant message with both `reasoning_details` and `thought_signature` set, runs `DropReasoningDetails`, asserts both are `None`
- [x] All existing tests pass (`cargo test --all-features --workspace`)
- [x] `RUSTFLAGS='-Dwarnings' cargo check --all-features --workspace` passes