### PR TITLE
chore(dependabot): add type: chore labels to update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels: ["type: chore"]
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--
     groups:
       major:
@@ -18,6 +19,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels: ["type: chore"]
     groups:
       actions:
         # Combine all images of last week


### PR DESCRIPTION
## Summary
Apply the `type: chore` label automatically to Dependabot-generated dependency update pull requests.

## Context
Dependabot updates should be classified consistently so triage and automation can identify them as maintenance work. This change adds the standard chore label directly in the Dependabot configuration.

## Changes
- Added `labels: ["type: chore"]` to the Cargo Dependabot update configuration
- Added `labels: ["type: chore"]` to the GitHub Actions Dependabot update configuration

### Key Implementation Details
The label is configured at the update block level in `.github/dependabot.yml`, so every PR opened by those Dependabot update jobs inherits the same label automatically.

## Testing
- Review `.github/dependabot.yml` and confirm both update entries include `labels: ["type: chore"]`
- Allow the next Dependabot Cargo or GitHub Actions PR to open and verify GitHub applies the `type: chore` label automatically

## Links
- Pull request: #2756
