### PR TITLE
fix(git_app): add retry mechanism for commit message generation

### DIFF
--- a/crates/forge_app/src/git_app.rs
+++ b/crates/forge_app/src/git_app.rs
@@ -55,7 +55,7 @@ pub struct CommitMessageResponse {
 }
 
 /// Context for generating a commit message from a diff
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct DiffContext {
     diff_content: String,
     branch_name: String,
@@ -212,13 +212,20 @@ where
         // Truncate diff if it exceeds max size
         let (truncated_diff, _) = self.truncate_diff(diff_content, max_diff_size, original_size);
 
-        self.generate_message_from_diff(DiffContext {
+        let ctx = DiffContext {
             diff_content: truncated_diff,
             branch_name,
             recent_commits,
             has_staged_files,
             additional_context,
-        })
+        };
+
+        let retry_config = self.services.get_config().retry.unwrap_or_default();
+        crate::retry::retry_with_config(
+            &retry_config,
+            || self.generate_message_from_diff(ctx.clone()),
+            None::<fn(&anyhow::Error, std::time::Duration)>,
+        )
         .await
     }
 
@@ -387,6 +394,10 @@ where
                 message.content.trim().to_string()
             }
         };
+
+        if commit_message.is_empty() {
+            return Err(Error::Retryable(anyhow::anyhow!("Empty commit message generated")).into());
+        }
 
         Ok(CommitMessageDetails {
             message: commit_message,


### PR DESCRIPTION
## Summary
Add a retry mechanism to commit message generation so that transient LLM failures or empty responses are automatically retried instead of surfacing as errors to the user.

## Context
Commit message generation relies on an LLM call, which can occasionally fail transiently or return an empty message due to model hiccups, rate limits, or network blips. Previously these failures would propagate immediately as errors, forcing the user to manually re-invoke the command. This change wraps the generation call in the project's existing `retry_with_config` infrastructure, providing automatic resilience.

## Changes
- Derived `Clone` on `DiffContext` so it can be passed into the retry closure on each attempt
- Wrapped `generate_message_from_diff` with `retry_with_config`, pulling retry settings from the project config (`services.get_config().retry`)
- Added an empty-message guard that returns a `Retryable` error when the LLM produces an empty commit message, triggering a retry rather than silently returning a blank string

### Key Implementation Details
The retry configuration is sourced from `get_config().retry`, falling back to `RetryConfig::default()` when not set. The empty-message check is placed after parsing the LLM response so only the generation + parse step is retried — not the diff truncation or context-building logic.

## Testing
```bash
# Run the forge_app crate tests
cargo insta test --accept -p forge_app

# Verify the build
cargo check -p forge_app
```

## Links
- No related issues
