### PR TITLE
Force .zsh to be checked out with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zsh eol=lf


### PR DESCRIPTION
Now that #2433 is merged Windows is looking much better, but since .zsh is LF only - it's worth marking them as such in .gitattributes so that they're not broken by default git for windows config on checkout