### PR TITLE
feat(config): add config-reload to clear all session overrides

### DIFF
--- a/crates/forge_main/src/built_in_commands.json
+++ b/crates/forge_main/src/built_in_commands.json
@@ -20,8 +20,8 @@
     "description": "Switch the model for the current session only, without modifying global config [alias: m]"
   },
   {
-    "command": "model-reset",
-    "description": "Reset session model to use global config [alias: mr]"
+    "command": "config-reload",
+    "description": "Reset all session overrides (model, provider, reasoning effort) to use global config [alias: cr]"
   },
   {
     "command": "reasoning-effort",

--- a/shell-plugin/lib/actions/config.zsh
+++ b/shell-plugin/lib/actions/config.zsh
@@ -358,21 +358,23 @@ function _forge_action_session_model() {
     fi
 }
 
-# Action handler: Reset session model and provider to defaults.
-# Clears both _FORGE_SESSION_MODEL and _FORGE_SESSION_PROVIDER,
-# reverting to global config for subsequent forge invocations.
-function _forge_action_model_reset() {
+# Action handler: Reload config by resetting all session-scoped overrides.
+# Clears _FORGE_SESSION_MODEL, _FORGE_SESSION_PROVIDER, and
+# _FORGE_SESSION_REASONING_EFFORT so that every subsequent forge invocation
+# falls back to the permanent global configuration.
+function _forge_action_config_reload() {
     echo
 
-    if [[ -z "$_FORGE_SESSION_MODEL" && -z "$_FORGE_SESSION_PROVIDER" ]]; then
-        _forge_log info "Session model already cleared (using global config)"
+    if [[ -z "$_FORGE_SESSION_MODEL" && -z "$_FORGE_SESSION_PROVIDER" && -z "$_FORGE_SESSION_REASONING_EFFORT" ]]; then
+        _forge_log info "No session overrides active (already using global config)"
         return 0
     fi
 
     _FORGE_SESSION_MODEL=""
     _FORGE_SESSION_PROVIDER=""
+    _FORGE_SESSION_REASONING_EFFORT=""
 
-    _forge_log success "Session model reset to global config"
+    _forge_log success "Session overrides cleared — using global config"
 }
 
 # Action handler: Select reasoning effort for the current session only.

--- a/shell-plugin/lib/config.zsh
+++ b/shell-plugin/lib/config.zsh
@@ -34,3 +34,7 @@ typeset -h _FORGE_PREVIOUS_CONVERSATION_ID
 # invocation for the lifetime of the current shell session.
 typeset -h _FORGE_SESSION_MODEL
 typeset -h _FORGE_SESSION_PROVIDER
+
+# Session-scoped reasoning effort override (set via :reasoning-effort / :re).
+# When non-empty, exported as FORGE_REASONING__EFFORT for every forge invocation.
+typeset -h _FORGE_SESSION_REASONING_EFFORT

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -175,8 +175,8 @@ function forge-accept-line() {
         model|m)
             _forge_action_session_model "$input_text"
         ;;
-        model-reset|mr)
-            _forge_action_model_reset
+        config-reload|cr|model-reset|mr)
+            _forge_action_config_reload
         ;;
         reasoning-effort|re)
             _forge_action_reasoning_effort "$input_text"


### PR DESCRIPTION
## Summary
Replace the narrow `model-reset` command with a broader `config-reload` command that clears all session-scoped overrides — model, provider, and reasoning effort — restoring the global configuration in one step.

## Context
The existing `model-reset` (`mr`) command only cleared `_FORGE_SESSION_MODEL` and `_FORGE_SESSION_PROVIDER`. Once reasoning effort was added as a third session override, users had no single command to return to a clean, config-driven state. The new `config-reload` (`cr`) command fills that gap, and the old aliases (`model-reset` / `mr`) are kept for backwards compatibility.

## Changes
- Renamed `model-reset` built-in command to `config-reload` with an updated description reflecting its expanded scope
- Renamed `_forge_action_model_reset` → `_forge_action_config_reload` in the shell plugin and extended it to also clear `_FORGE_SESSION_REASONING_EFFORT`
- Declared `_FORGE_SESSION_REASONING_EFFORT` as a typed shell variable in `config.zsh`
- Updated the dispatcher to route `config-reload|cr|model-reset|mr` to the new action (backwards-compatible aliases preserved)
- Improved the informational messages to accurately describe what was cleared

### Key Implementation Details
The dispatcher now matches four aliases (`config-reload`, `cr`, `model-reset`, `mr`) to the same handler, so existing shell history and muscle memory continue to work. The clear-all logic in `_forge_action_config_reload` checks all three session variables before deciding whether anything needs resetting, providing a more accurate "nothing to do" message.

## Testing
```bash
# Start a shell session with the plugin loaded
source shell-plugin/forge.plugin.zsh

# Set session overrides
:model gpt-4o
:reasoning-effort high

# Verify overrides are active
echo $_FORGE_SESSION_MODEL          # gpt-4o
echo $_FORGE_SESSION_REASONING_EFFORT  # high

# Reset everything with the new command
:config-reload
# Expected: "Session overrides cleared — using global config"

# Verify all overrides are cleared
echo $_FORGE_SESSION_MODEL          # (empty)
echo $_FORGE_SESSION_PROVIDER       # (empty)
echo $_FORGE_SESSION_REASONING_EFFORT  # (empty)

# Verify backwards-compatible alias still works
:model gpt-4o
:model-reset
# Expected: same success message
```
