### PR TITLE
feat(config): add `[[providers]]` in `.forge.toml`

### DIFF
--- a/crates/forge_config/src/config.rs
+++ b/crates/forge_config/src/config.rs
@@ -12,6 +12,40 @@ use crate::{
     AutoDumpFormat, Compact, Decimal, HttpConfig, ModelConfig, ReasoningConfig, RetryConfig, Update,
 };
 
+/// Wire protocol a provider uses for chat completions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Dummy)]
+pub enum ProviderResponseType {
+    OpenAI,
+    OpenAIResponses,
+    Anthropic,
+    Bedrock,
+    Google,
+    OpenCode,
+}
+
+/// Category of a provider.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, Dummy)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderTypeEntry {
+    /// LLM provider for chat completions.
+    #[default]
+    Llm,
+    /// Context engine provider for code indexing and search.
+    ContextEngine,
+}
+
+/// Authentication method supported by a provider.
+///
+/// Only the simple (non-OAuth) methods are available here; providers that
+/// require OAuth device or authorization-code flows must be configured via the
+/// file-based `provider.json` override instead.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Dummy)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderAuthMethod {
+    ApiKey,
+    GoogleAdc,
+}
+
 /// A URL parameter variable for a provider, used to substitute template
 /// variables in URL strings.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Dummy)]
@@ -45,10 +79,9 @@ pub struct ProviderEntry {
     /// placeholders.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub models: Option<String>,
-    /// Wire protocol used by this provider. Accepted values: `"OpenAI"`,
-    /// `"Anthropic"`, `"Google"`, `"Bedrock"`, `"OpenAIResponses"`.
+    /// Wire protocol used by this provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub response_type: Option<String>,
+    pub response_type: Option<ProviderResponseType>,
     /// Environment variables whose values are substituted into `{{VAR}}`
     /// placeholders in the `url` and `models` templates.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -56,6 +89,13 @@ pub struct ProviderEntry {
     /// Additional HTTP headers sent with every request to this provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_headers: Option<HashMap<String, String>>,
+    /// Provider category; defaults to `llm` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_type: Option<ProviderTypeEntry>,
+    /// Authentication methods supported by this provider; defaults to
+    /// `["api_key"]` when omitted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auth_methods: Vec<ProviderAuthMethod>,
 }
 
 /// Top-level Forge configuration merged from all sources (defaults, file,

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -115,17 +115,48 @@ impl From<forge_config::ProviderUrlParam> for UrlParamVarConfig {
 
 impl From<forge_config::ProviderEntry> for ProviderConfig {
     fn from(entry: forge_config::ProviderEntry) -> Self {
+        let provider_type = match entry.provider_type {
+            Some(forge_config::ProviderTypeEntry::ContextEngine) => {
+                forge_domain::ProviderType::ContextEngine
+            }
+            Some(forge_config::ProviderTypeEntry::Llm) | None => forge_domain::ProviderType::Llm,
+        };
+
+        let auth_methods = if entry.auth_methods.is_empty() {
+            vec![forge_domain::AuthMethod::ApiKey]
+        } else {
+            entry
+                .auth_methods
+                .into_iter()
+                .map(|m| match m {
+                    forge_config::ProviderAuthMethod::ApiKey => forge_domain::AuthMethod::ApiKey,
+                    forge_config::ProviderAuthMethod::GoogleAdc => {
+                        forge_domain::AuthMethod::GoogleAdc
+                    }
+                })
+                .collect()
+        };
+
+        let response_type = entry.response_type.map(|r| match r {
+            forge_config::ProviderResponseType::OpenAI => ProviderResponse::OpenAI,
+            forge_config::ProviderResponseType::OpenAIResponses => {
+                ProviderResponse::OpenAIResponses
+            }
+            forge_config::ProviderResponseType::Anthropic => ProviderResponse::Anthropic,
+            forge_config::ProviderResponseType::Bedrock => ProviderResponse::Bedrock,
+            forge_config::ProviderResponseType::Google => ProviderResponse::Google,
+            forge_config::ProviderResponseType::OpenCode => ProviderResponse::OpenCode,
+        });
+
         ProviderConfig {
             id: ProviderId::from(entry.id),
-            provider_type: forge_domain::ProviderType::Llm,
+            provider_type,
             api_key_vars: entry.api_key_var,
             url_param_vars: entry.url_param_vars.into_iter().map(Into::into).collect(),
-            response_type: entry
-                .response_type
-                .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok()),
+            response_type,
             url: entry.url,
             models: entry.models.map(Models::Url),
-            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            auth_methods,
             custom_headers: entry.custom_headers,
         }
     }

--- a/forge.schema.json
+++ b/forge.schema.json
@@ -589,6 +589,14 @@
         }
       }
     },
+    "ProviderAuthMethod": {
+      "description": "Authentication method supported by a provider.\n\nOnly the simple (non-OAuth) methods are available here; providers that\nrequire OAuth device or authorization-code flows must be configured via the\nfile-based `provider.json` override instead.",
+      "type": "string",
+      "enum": [
+        "api_key",
+        "google_adc"
+      ]
+    },
     "ProviderEntry": {
       "description": "A single provider entry defined inline in `forge.toml`.\n\nInline providers are merged with the built-in provider list; entries with\nthe same `id` override the corresponding built-in entry field-by-field,\nwhile entries with a new `id` are appended to the list.",
       "type": "object",
@@ -599,6 +607,13 @@
             "string",
             "null"
           ]
+        },
+        "auth_methods": {
+          "description": "Authentication methods supported by this provider; defaults to\n`[\"api_key\"]` when omitted.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ProviderAuthMethod"
+          }
         },
         "custom_headers": {
           "description": "Additional HTTP headers sent with every request to this provider.",
@@ -621,11 +636,26 @@
             "null"
           ]
         },
+        "provider_type": {
+          "description": "Provider category; defaults to `llm` when omitted.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProviderTypeEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "response_type": {
-          "description": "Wire protocol used by this provider. Accepted values: `\"OpenAI\"`,\n`\"Anthropic\"`, `\"Google\"`, `\"Bedrock\"`, `\"OpenAIResponses\"`.",
-          "type": [
-            "string",
-            "null"
+          "description": "Wire protocol used by this provider.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProviderResponseType"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "url": {
@@ -643,6 +673,33 @@
       "required": [
         "id",
         "url"
+      ]
+    },
+    "ProviderResponseType": {
+      "description": "Wire protocol a provider uses for chat completions.",
+      "type": "string",
+      "enum": [
+        "OpenAI",
+        "OpenAIResponses",
+        "Anthropic",
+        "Bedrock",
+        "Google",
+        "OpenCode"
+      ]
+    },
+    "ProviderTypeEntry": {
+      "description": "Category of a provider.",
+      "oneOf": [
+        {
+          "description": "LLM provider for chat completions.",
+          "type": "string",
+          "const": "llm"
+        },
+        {
+          "description": "Context engine provider for code indexing and search.",
+          "type": "string",
+          "const": "context_engine"
+        }
       ]
     },
     "ProviderUrlParam": {


### PR DESCRIPTION
## Summary
Allow users to define custom or override built-in providers directly in `forge.toml`, enabling teams to integrate proprietary or self-hosted LLM endpoints without code changes.

## Context
Previously, adding a new LLM provider or adjusting an existing provider's settings (URL, API key variable, protocol, headers) required modifying the built-in provider registry in Rust source code. This made it impossible for teams to use self-hosted models, enterprise proxies, or custom OpenAI-compatible endpoints through configuration alone.

This feature unlocks a configuration-first workflow: any provider reachable via a supported wire protocol (OpenAI, Anthropic, Google, Bedrock, OpenAIResponses) can now be registered or overridden entirely from `forge.toml`.

## Changes
- Added `ProviderEntry` and `ProviderUrlParam` structs to `forge_config` for inline provider definitions
- Added a `providers` field to `ForgeConfig` that accepts a list of `ProviderEntry` values
- Implemented `From<ProviderEntry>` and `From<ProviderUrlParam>` conversions in `forge_repo` to transform config entries into internal `ProviderConfig` / `UrlParamVarConfig` types
- Updated `forge.schema.json` with full JSON Schema definitions for `ProviderEntry` and `ProviderUrlParam`, enabling editor autocomplete and validation

### Key Implementation Details
Entries with an `id` matching a built-in provider override that provider's fields field-by-field; entries with a new `id` are appended to the provider list. URL templates support `{{VAR}}` placeholders substituted from `url_param_vars` at runtime. Custom HTTP headers can be injected per-provider via `custom_headers`. Wire protocol is set via `response_type` (accepts `"OpenAI"`, `"Anthropic"`, `"Google"`, `"Bedrock"`, `"OpenAIResponses"`).

## Use Cases

**Register a self-hosted OpenAI-compatible endpoint:**
```toml
[[providers]]
id = "my_openai_proxy"
url = "https://proxy.internal/v1/chat/completions"
api_key_var = "PROXY_API_KEY"
response_type = "OpenAI"
```

**Override a built-in provider's base URL with template variables:**
```toml
[[providers]]
id = "azure"
url = "https://{{AZURE_REGION}}.openai.azure.com/openai/deployments/{{AZURE_DEPLOYMENT}}/chat/completions"

[[providers.url_param_vars]]
name = "AZURE_REGION"
options = ["eastus", "westeurope"]

[[providers.url_param_vars]]
name = "AZURE_DEPLOYMENT"
```

**Add custom headers for an enterprise provider:**
```toml
[[providers]]
id = "enterprise_llm"
url = "https://llm.corp.example.com/v1/chat"
api_key_var = "CORP_LLM_KEY"
response_type = "OpenAI"

[providers.custom_headers]
X-Org-ID = "my-org"
X-Cost-Center = "eng"
```

## Testing
```bash
# Run all config and provider repo tests
cargo insta test --accept -p forge_config -p forge_repo

# Verify schema and types compile
cargo check
```
