### PR TITLE
feat(permissions): add MCP tool call permission checks

### DIFF
--- a/crates/forge_app/src/mcp_executor.rs
+++ b/crates/forge_app/src/mcp_executor.rs
@@ -32,4 +32,22 @@ impl<S: McpService> McpExecutor<S> {
             .values()
             .any(|tools| tools.iter().any(|tool| tool.name == *tool_name)))
     }
+
+    /// Returns the server name that owns the given tool, or `None` if not found.
+    /// The returned string is the MCP server's key (e.g. "github", "filesystem").
+    ///
+    /// Note: this method calls `get_mcp_servers()` internally. Callers that have
+    /// just called `contains_tool` will trigger two fetches of the server list.
+    /// This is acceptable because `get_mcp_servers()` is expected to be cached,
+    /// but if that assumption changes, consider combining the two into a single
+    /// method that returns `Option<String>` (server name), falsy when not found.
+    pub async fn server_for_tool(&self, tool_name: &ToolName) -> anyhow::Result<Option<String>> {
+        let mcp_servers = self.services.get_mcp_servers().await?;
+        let server_name = mcp_servers
+            .get_servers()
+            .iter()
+            .find(|(_, tools)| tools.iter().any(|tool| tool.name == *tool_name))
+            .map(|(name, _)| name.to_string());
+        Ok(server_name)
+    }
 }

--- a/crates/forge_app/src/tool_registry.rs
+++ b/crates/forge_app/src/tool_registry.rs
@@ -5,8 +5,8 @@ use anyhow::Context;
 use console::style;
 use forge_domain::{
     Agent, AgentId, AgentInput, ChatResponse, ChatResponseContent, Environment, InputModality,
-    Model, SystemContext, TemplateConfig, ToolCallContext, ToolCallFull, ToolCatalog,
-    ToolDefinition, ToolKind, ToolName, ToolOutput, ToolResult,
+    Model, PermissionOperation, SystemContext, TemplateConfig, TitleFormat, ToolCallContext,
+    ToolCallFull, ToolCatalog, ToolDefinition, ToolKind, ToolName, ToolOutput, ToolResult,
 };
 use forge_template::Element;
 use futures::future::join_all;
@@ -20,6 +20,7 @@ use crate::error::Error;
 use crate::fmt::content::FormatContent;
 use crate::mcp_executor::McpExecutor;
 use crate::tool_executor::ToolExecutor;
+use crate::utils::format_display_path;
 use crate::{
     AgentRegistry, EnvironmentInfra, McpService, PolicyService, ProviderService, Services,
     ToolResolver, WorkspaceService,
@@ -60,32 +61,39 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ToolReg
             })?
     }
 
-    /// Check if a tool operation is allowed based on the workflow policies
+    /// Check if a permission operation is allowed based on workflow policies.
+    /// Returns `true` if the operation was **denied** (caller should bail out).
+    async fn check_permission_for_operation(
+        &self,
+        operation: &PermissionOperation,
+        context: &ToolCallContext,
+    ) -> anyhow::Result<bool> {
+        let decision = self.services.check_operation_permission(operation).await?;
+
+        if let Some(policy_path) = decision.path {
+            context
+                .send_tool_input(
+                    TitleFormat::debug("Permissions Update")
+                        .sub_title(format_display_path(policy_path.as_path(), operation.cwd())),
+                )
+                .await?;
+        }
+        Ok(!decision.allowed)
+    }
+
+    /// Check if a built-in tool operation is allowed based on workflow policies.
+    /// Returns `true` if the operation was **denied** (caller should bail out).
     async fn check_tool_permission(
         &self,
         tool_input: &ToolCatalog,
         context: &ToolCallContext,
     ) -> anyhow::Result<bool> {
         let cwd = self.services.get_environment().cwd;
-        let operation = tool_input.to_policy_operation(cwd.clone());
+        let operation = tool_input.to_policy_operation(cwd);
         if let Some(operation) = operation {
-            let decision = self.services.check_operation_permission(&operation).await?;
-
-            // Send custom policy message to the user when a policy file was created
-            if let Some(policy_path) = decision.path {
-                use forge_domain::TitleFormat;
-
-                use crate::utils::format_display_path;
-                context
-                    .send_tool_input(
-                        TitleFormat::debug("Permissions Update")
-                            .sub_title(format_display_path(policy_path.as_path(), &cwd)),
-                    )
-                    .await?;
-            }
-            if !decision.allowed {
-                return Ok(true);
-            }
+            return self
+                .check_permission_for_operation(&operation, context)
+                .await;
         }
         Ok(false)
     }
@@ -143,7 +151,7 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ToolReg
             if is_restricted && self.check_tool_permission(&tool_input, context).await? {
                 // Send formatted output message for policy denial
                 context
-                    .send(forge_domain::TitleFormat::error("Permission Denied"))
+                    .send(TitleFormat::error("Permission Denied"))
                     .await?;
 
                 return Ok(ToolOutput::text(
@@ -184,6 +192,50 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ToolReg
             .collect::<anyhow::Result<Vec<_>>>()?;
             Ok(ToolOutput::from(outputs.into_iter()))
         } else if self.mcp_executor.contains_tool(&input.name).await? {
+            // Check MCP permissions before executing (only in restricted mode).
+            // This is done BEFORE the timeout to ensure permissions are never timed out.
+            let is_restricted = self.services.get_config().restricted;
+            if is_restricted {
+                let cwd = self.services.get_environment().cwd;
+                // Note: server_for_tool calls get_mcp_servers() again internally. This is a
+                // second call after contains_tool already called it, but MCP server lists are
+                // expected to be cached. If that assumption changes, consider passing the
+                // server name through from contains_tool to avoid the duplicate fetch.
+                //
+                // INVARIANT: contains_tool confirmed the tool exists, so server_for_tool should
+                // always return Some. The "unknown" fallback would cause "*/*" rules to match
+                // but named server rules (e.g. "github/*") to miss, prompting unnecessarily.
+                let server_name = self
+                    .mcp_executor
+                    .server_for_tool(&tool_name)
+                    .await?
+                    .unwrap_or_else(|| {
+                        debug_assert!(
+                            false,
+                            "server_for_tool returned None after contains_tool confirmed tool \
+                             exists: {tool_name}"
+                        );
+                        "unknown".to_string()
+                    });
+                let operation = PermissionOperation::Mcp {
+                    server_name,
+                    tool_name: tool_name.as_str().to_string(),
+                    cwd,
+                };
+                if self
+                    .check_permission_for_operation(&operation, context)
+                    .await?
+                {
+                    context
+                        .send(TitleFormat::error("Permission Denied"))
+                        .await?;
+                    return Ok(ToolOutput::text(
+                        Element::new("permission_denied")
+                            .cdata("User has denied the permission to execute this tool"),
+                    ));
+                }
+            }
+
             let output = self
                 .call_with_timeout(&tool_name, || self.mcp_executor.execute(input, context))
                 .await?;

--- a/crates/forge_domain/src/policies/operation.rs
+++ b/crates/forge_domain/src/policies/operation.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Operations that can be performed and need policy checking
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,4 +23,26 @@ pub enum PermissionOperation {
         cwd: PathBuf,
         message: String,
     },
+    /// MCP tool call operation
+    Mcp {
+        /// The name of the MCP server (e.g. "github", "filesystem")
+        server_name: String,
+        /// The name of the tool being called (e.g. "list_issues", "read_file")
+        tool_name: String,
+        /// The working directory at the time of the tool call
+        cwd: PathBuf,
+    },
+}
+
+impl PermissionOperation {
+    /// Returns the working directory associated with this operation.
+    pub fn cwd(&self) -> &Path {
+        match self {
+            PermissionOperation::Write { cwd, .. } => cwd,
+            PermissionOperation::Read { cwd, .. } => cwd,
+            PermissionOperation::Execute { cwd, .. } => cwd,
+            PermissionOperation::Fetch { cwd, .. } => cwd,
+            PermissionOperation::Mcp { cwd, .. } => cwd,
+        }
+    }
 }

--- a/crates/forge_domain/src/policies/rule.rs
+++ b/crates/forge_domain/src/policies/rule.rs
@@ -39,6 +39,25 @@ pub struct Fetch {
     pub dir: Option<String>,
 }
 
+/// Rule for MCP tool call operations with a "server_name/tool_name" glob pattern
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+pub struct McpRule {
+    /// Glob pattern matched against the combined `"server_name/tool_name"` string.
+    ///
+    /// Examples: `"github/*"` (all tools on the github server), `"*/read_file"` (read_file on any
+    /// server), `"*/*"` (all MCP tools).
+    ///
+    /// **Important:** The `*` wildcard does not cross `/` boundaries (standard glob behaviour).
+    /// A pattern without a `/` (e.g. `"github"`) will **never** match any tool call because the
+    /// target string always contains a `/`. Always include a `/` separator in your pattern.
+    pub mcp: String,
+    /// Optional glob pattern matched against the current working directory.
+    /// When set, the rule only applies when forge is run from a matching directory.
+    /// When absent, the rule applies regardless of working directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dir: Option<String>,
+}
+
 /// Rules that define what operations are covered by a policy
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
@@ -51,6 +70,8 @@ pub enum Rule {
     Execute(ExecuteRule),
     /// Rule for network fetch operations with a URL pattern
     Fetch(Fetch),
+    /// Rule for MCP tool call operations
+    Mcp(McpRule),
 }
 
 impl Rule {
@@ -93,6 +114,16 @@ impl Rule {
                                    * directory */
                 };
                 url_matches && dir_matches
+            }
+            (Rule::Mcp(rule), PermissionOperation::Mcp { server_name, tool_name, cwd }) => {
+                // Match the pattern against "server_name/tool_name"
+                let combined = format!("{server_name}/{tool_name}");
+                let pattern_matches = match_pattern(&rule.mcp, &combined);
+                let dir_matches = match &rule.dir {
+                    Some(wd_pattern) => match_pattern(wd_pattern, cwd),
+                    None => true,
+                };
+                pattern_matches && dir_matches
             }
             _ => false,
         }
@@ -150,6 +181,16 @@ impl Display for Fetch {
     }
 }
 
+impl Display for McpRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(wd) = &self.dir {
+            write!(f, "mcp '{}' in '{}'", self.mcp, wd)
+        } else {
+            write!(f, "mcp '{}'", self.mcp)
+        }
+    }
+}
+
 impl Display for Rule {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -157,6 +198,7 @@ impl Display for Rule {
             Rule::Read(rule) => write!(f, "{rule}"),
             Rule::Execute(rule) => write!(f, "{rule}"),
             Rule::Fetch(rule) => write!(f, "{rule}"),
+            Rule::Mcp(rule) => write!(f, "{rule}"),
         }
     }
 }
@@ -324,5 +366,109 @@ mod tests {
         let actual = fixture.matches(&operation);
 
         assert_eq!(actual, true);
+    }
+
+    fn fixture_mcp_operation() -> PermissionOperation {
+        PermissionOperation::Mcp {
+            server_name: "github".to_string(),
+            tool_name: "list_issues".to_string(),
+            cwd: PathBuf::from("/home/user/project"),
+        }
+    }
+
+    #[test]
+    fn test_mcp_rule_matches_wildcard_all() {
+        let fixture = Rule::Mcp(McpRule { mcp: "*/*".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, true);
+    }
+
+    #[test]
+    fn test_mcp_rule_matches_wildcard_server() {
+        let fixture = Rule::Mcp(McpRule { mcp: "github/*".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, true);
+    }
+
+    #[test]
+    fn test_mcp_rule_does_not_match_different_server() {
+        let fixture = Rule::Mcp(McpRule { mcp: "slack/*".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, false);
+    }
+
+    #[test]
+    fn test_mcp_rule_matches_wildcard_tool() {
+        let fixture = Rule::Mcp(McpRule { mcp: "*/list_issues".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, true);
+    }
+
+    #[test]
+    fn test_mcp_rule_does_not_match_different_tool() {
+        let fixture = Rule::Mcp(McpRule { mcp: "*/write_file".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, false);
+    }
+
+    #[test]
+    fn test_mcp_rule_exact_match() {
+        let fixture = Rule::Mcp(McpRule { mcp: "github/list_issues".to_string(), dir: None });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, true);
+    }
+
+    #[test]
+    fn test_mcp_rule_dir_filter_matches() {
+        let fixture = Rule::Mcp(McpRule {
+            mcp: "github/*".to_string(),
+            dir: Some("/home/user/*".to_string()),
+        });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, true);
+    }
+
+    #[test]
+    fn test_mcp_rule_dir_filter_no_match() {
+        let fixture = Rule::Mcp(McpRule {
+            mcp: "github/*".to_string(),
+            dir: Some("/different/path/*".to_string()),
+        });
+        let operation = fixture_mcp_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, false);
+    }
+
+    #[test]
+    fn test_mcp_rule_does_not_match_write_operation() {
+        let fixture = Rule::Mcp(McpRule { mcp: "*/*".to_string(), dir: None });
+        let operation = fixture_write_operation();
+
+        let actual = fixture.matches(&operation);
+
+        assert_eq!(actual, false);
     }
 }

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -75,7 +75,7 @@ impl Section {
 /// # Output Format
 ///
 /// ```text
-/// 
+///
 /// CONFIGURATION
 ///   model gpt-4
 /// provider openai

--- a/crates/forge_services/src/permissions.default.yaml
+++ b/crates/forge_services/src/permissions.default.yaml
@@ -11,3 +11,6 @@ policies:
   - permission: allow
     rule:
       url: "*"
+  - permission: allow
+    rule:
+      mcp: "*/*"

--- a/crates/forge_services/src/policy.rs
+++ b/crates/forge_services/src/policy.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, LazyLock};
 use anyhow::Context;
 use bytes::Bytes;
 use forge_app::domain::{
-    ExecuteRule, Fetch, Permission, PermissionOperation, Policy, PolicyConfig, PolicyEngine,
-    ReadRule, Rule, WriteRule,
+    ExecuteRule, Fetch, McpRule, Permission, PermissionOperation, Policy, PolicyConfig,
+    PolicyEngine, ReadRule, Rule, WriteRule,
 };
 use forge_app::{
     DirectoryReaderInfra, EnvironmentInfra, FileInfoInfra, FileReaderInfra, FileWriterInfra,
@@ -185,6 +185,11 @@ where
                     PermissionOperation::Fetch { message, .. } => {
                         format!("{message}. How would you like to proceed?")
                     }
+                    PermissionOperation::Mcp { server_name, tool_name, .. } => {
+                        format!(
+                            "Allow MCP tool call '{tool_name}' on server '{server_name}'. How would you like to proceed?"
+                        )
+                    }
                 };
 
                 match self
@@ -262,6 +267,10 @@ fn create_policy_for_operation(
                 }),
             }
         }
+        PermissionOperation::Mcp { server_name, .. } => Some(Policy::Simple {
+            permission: Permission::Allow,
+            rule: Rule::Mcp(McpRule { mcp: format!("{server_name}/*"), dir: None }),
+        }),
     }
 }
 
@@ -423,6 +432,24 @@ mod tests {
         let actual = create_policy_for_operation(&operation, None);
 
         let expected = None;
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_create_policy_for_mcp_operation() {
+        let operation = PermissionOperation::Mcp {
+            server_name: "github".to_string(),
+            tool_name: "list_issues".to_string(),
+            cwd: PathBuf::from("/test/cwd"),
+        };
+
+        let actual = create_policy_for_operation(&operation, None);
+
+        let expected = Some(Policy::Simple {
+            permission: Permission::Allow,
+            rule: Rule::Mcp(McpRule { mcp: "github/*".to_string(), dir: None }),
+        });
 
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
## Summary

MCP tool calls currently bypass the permission system entirely — they skip `check_tool_permission` and execute unconditionally regardless of `restricted` mode. This PR wires MCP tool calls into the existing policy engine so they're subject to the same allow/deny/confirm flow as built-in tools.

## Changes

### `crates/forge_domain/src/policies/operation.rs`
- Added `PermissionOperation::Mcp { server_name, tool_name, cwd }` variant

### `crates/forge_domain/src/policies/rule.rs`
- Added `McpRule { mcp: String, dir: Option<String> }` struct — the `mcp` field is a glob pattern matched against `"server_name/tool_name"` (e.g. `"github/*"`, `"*/read_file"`, `"*/*"`)
- Added `Rule::Mcp(McpRule)` variant with `matches()` arm, `Display` impl, and unit tests

### `crates/forge_app/src/mcp_executor.rs`
- Added `server_for_tool(&ToolName) -> Option<String>` to resolve which MCP server owns a given tool

### `crates/forge_app/src/tool_registry.rs`
- Added MCP permission check in `call_inner` before dispatching to `McpExecutor`, gated on `restricted` mode — mirrors the existing built-in tool permission check exactly

### `crates/forge_services/src/policy.rs`
- Added `PermissionOperation::Mcp` arm to `create_policy_for_operation` — "Accept and Remember" generates `server_name/*` to allow all tools from that server
- Added `PermissionOperation::Mcp` arm to the confirmation message match

### `crates/forge_services/src/permissions.default.yaml`
- Added default `allow: mcp: "*/*"` entry so existing users see zero behavior change on upgrade

## Behavior

- **Non-restricted mode** (`restricted: false`, the default): no change, MCP tools execute freely
- **Restricted mode** (`restricted: true`): MCP tool calls go through the policy engine
  - If a matching `mcp` rule exists in `permissions.yaml` → allow or deny per the rule
  - If no rule matches → user gets an interactive `Accept / Reject / Accept and Remember` prompt
  - "Accept and Remember" writes `server_name/*` to `permissions.yaml`

## Configuration

Users can control MCP permissions in `permissions.yaml` using the new `mcp` rule type:

```yaml
policies:
  # Allow all tools from the github server
  - permission: allow
    rule:
      mcp: "github/*"

  # Deny all filesystem MCP tools
  - permission: deny
    rule:
      mcp: "filesystem/*"

  # Allow a specific tool only
  - permission: allow
    rule:
      mcp: "slack/post_message"
```

## Verification

Step by step:
```
1. Set up simple MCP server

# Install npx if not present, then:
forge mcp add
# Name: filesystem
# Command: npx
# Args: @modelcontextprotocol/server-filesystem /tmp

Or manually write a .mcp.json in your test directory:
{
  "mcpServers": {
    "filesystem": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
    }
  }
}

2. Enable restricted mode

3. Run the binary build from this branch in scope of config

4. Trigger an MCP tool call
```

Example:
<img width="1497" height="378" alt="image" src="https://github.com/user-attachments/assets/21ed86d9-9127-4e7e-901b-7d04a2d70612" />
<img width="1509" height="418" alt="image" src="https://github.com/user-attachments/assets/dbda4a5b-5799-45a8-a78c-de66a66f5cd4" />

checked as well that accept and remember dont re ask prompt for tool call
