### PR TITLE
fix(openai): handle providers emitting both reasoning and reasoning_content fields

### DIFF
--- a/crates/forge_app/src/dto/openai/fixtures/chutes_completion_response.json
+++ b/crates/forge_app/src/dto/openai/fixtures/chutes_completion_response.json
@@ -1,0 +1,23 @@
+{
+  "id": "chatcmpl-a9db7cc9005c6568",
+  "object": "chat.completion.chunk",
+  "created": 1775233185,
+  "model": "moonshotai/Kimi-K2.5-TEE",
+  "choices": [
+    {
+      "index": 0,
+      "delta": { "reasoning": " The", "reasoning_content": " The" },
+      "logprobs": null,
+      "finish_reason": null,
+      "token_ids": null,
+      "hidden_states": null
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 8764,
+    "total_tokens": 8765,
+    "completion_tokens": 1,
+    "reasoning_tokens": 1
+  },
+  "chutes_verification": "6bbeaf04d5800d774cc497b0a619acee"
+}

--- a/crates/forge_app/src/dto/openai/response.rs
+++ b/crates/forge_app/src/dto/openai/response.rs
@@ -136,11 +136,19 @@ pub enum Choice {
     },
 }
 
+/// A message returned by a provider, used for both streaming deltas and
+/// non-streaming responses.
+///
+/// `reasoning` and `reasoning_content` are kept as separate private fields
+/// because some providers (e.g. `moonshotai/Kimi-K2.5-TEE`) emit **both**
+/// keys in the same delta object. Using `#[serde(alias)]` would cause a
+/// `duplicate_field` error in that case. Use [`ResponseMessage::reasoning`]
+/// to read the value in preference order.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ResponseMessage {
     pub content: Option<String>,
-    #[serde(alias = "reasoning_content")]
-    pub reasoning: Option<String>,
+    reasoning: Option<String>,
+    reasoning_content: Option<String>,
     pub role: Option<String>,
     pub tool_calls: Option<Vec<ToolCall>>,
     pub refusal: Option<String>,
@@ -150,6 +158,16 @@ pub struct ResponseMessage {
     pub reasoning_opaque: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_content: Option<ExtraContent>,
+}
+
+impl ResponseMessage {
+    /// Returns the reasoning text, preferring `reasoning` over
+    /// `reasoning_content` when both are present.
+    pub fn reasoning(&self) -> Option<&str> {
+        self.reasoning
+            .as_deref()
+            .or(self.reasoning_content.as_deref())
+    }
 }
 
 impl From<ReasoningDetail> for forge_domain::ReasoningDetail {
@@ -319,8 +337,8 @@ impl TryFrom<Response> for ChatCompletionMessage {
                                     .clone()
                                     .and_then(|s| FinishReason::from_str(&s).ok()),
                             );
-                            if let Some(reasoning) = &message.reasoning {
-                                resp = resp.reasoning(Content::full(reasoning.clone()));
+                            if let Some(reasoning) = message.reasoning() {
+                                resp = resp.reasoning(Content::full(reasoning.to_owned()));
                             }
 
                             if let Some(thought_signature) = message
@@ -387,8 +405,8 @@ impl TryFrom<Response> for ChatCompletionMessage {
                                     .and_then(|s| FinishReason::from_str(&s).ok()),
                             );
 
-                            if let Some(reasoning) = &delta.reasoning {
-                                resp = resp.reasoning(Content::part(reasoning.clone()));
+                            if let Some(reasoning) = delta.reasoning() {
+                                resp = resp.reasoning(Content::part(reasoning.to_owned()));
                             }
 
                             if let Some(thought_signature) = delta
@@ -571,6 +589,17 @@ mod tests {
         assert!(Fixture::test_response_compatibility(event));
     }
 
+    #[tokio::test]
+    async fn test_kimi_k2_both_reasoning_keys_event() {
+        // moonshotai/Kimi-K2.5-TEE emits both "reasoning" and "reasoning_content"
+        // in the same delta object. This must parse without a duplicate_field error.
+        let fixture = load_fixture("chutes_completion_response.json").await;
+        let actual = serde_json::from_value::<Response>(fixture);
+        assert!(actual.is_ok(), "Failed to parse: {:?}", actual.err());
+        let completion_result = ChatCompletionMessage::try_from(actual.unwrap());
+        assert!(completion_result.is_ok());
+    }
+
     #[test]
     fn test_fireworks_response_event_missing_arguments() {
         let event = "{\"id\":\"gen-1749331907-SttL6PXleVHnrdLMABfU\",\"provider\":\"Fireworks\",\"model\":\"qwen/qwen3-235b-a22b\",\"object\":\"chat.completion.chunk\",\"created\":1749331907,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_Wl2L8rrzHwrXSeiciIvU65IS\",\"type\":\"function\",\"function\":{\"name\":\"attempt_completion\"}}]},\"finish_reason\":null,\"native_finish_reason\":null,\"logprobs\":null}]}";
@@ -632,6 +661,7 @@ mod tests {
                 message: ResponseMessage {
                     content: Some("test content".to_string()),
                     reasoning: None,
+                    reasoning_content: None,
                     role: Some("assistant".to_string()),
                     tool_calls: None,
                     refusal: None,
@@ -669,6 +699,7 @@ mod tests {
                 delta: ResponseMessage {
                     content: Some("test content".to_string()),
                     reasoning: None,
+                    reasoning_content: None,
                     role: Some("assistant".to_string()),
                     tool_calls: None,
                     refusal: None,
@@ -706,6 +737,7 @@ mod tests {
                 message: ResponseMessage {
                     content: Some("Hello, world!".to_string()),
                     reasoning: None,
+                    reasoning_content: None,
                     role: Some("assistant".to_string()),
                     tool_calls: None,
                     refusal: None,

--- a/crates/forge_app/src/dto/openai/response.rs
+++ b/crates/forge_app/src/dto/openai/response.rs
@@ -565,6 +565,63 @@ mod tests {
 
     struct Fixture;
 
+    fn response_message(reasoning: Option<&str>, reasoning_content: Option<&str>) -> ResponseMessage {
+        ResponseMessage {
+            content: None,
+            reasoning: reasoning.map(str::to_owned),
+            reasoning_content: reasoning_content.map(str::to_owned),
+            role: None,
+            tool_calls: None,
+            refusal: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            extra_content: None,
+        }
+    }
+
+    #[test]
+    fn test_reasoning_only_reasoning_field() {
+        let fixture = response_message(Some("hello"), None);
+        assert_eq!(fixture.reasoning(), Some("hello"));
+    }
+
+    #[test]
+    fn test_reasoning_only_reasoning_content_field() {
+        let fixture = response_message(None, Some("hello"));
+        assert_eq!(fixture.reasoning(), Some("hello"));
+    }
+
+    #[test]
+    fn test_reasoning_both_returns_longer() {
+        let fixture = response_message(Some("short"), Some("much longer text"));
+        assert_eq!(fixture.reasoning(), Some("much longer text"));
+    }
+
+    #[test]
+    fn test_reasoning_both_equal_length_returns_reasoning() {
+        let fixture = response_message(Some("aaa"), Some("bbb"));
+        assert_eq!(fixture.reasoning(), Some("aaa"));
+    }
+
+    #[test]
+    fn test_reasoning_both_present_one_empty_returns_non_empty() {
+        let fixture = response_message(Some(""), Some("content"));
+        assert_eq!(fixture.reasoning(), Some("content"));
+    }
+
+    #[test]
+    fn test_reasoning_both_empty_returns_none() {
+        let fixture = response_message(Some(""), Some(""));
+        assert_eq!(fixture.reasoning(), None);
+    }
+
+    #[test]
+    fn test_reasoning_neither_present_returns_none() {
+        let fixture = response_message(None, None);
+        assert_eq!(fixture.reasoning(), None);
+    }
+
     async fn load_fixture(filename: &str) -> serde_json::Value {
         let fixture_path = format!("src/dto/openai/fixtures/{}", filename);
         let fixture_content = tokio::fs::read_to_string(&fixture_path)

--- a/crates/forge_app/src/dto/openai/response.rs
+++ b/crates/forge_app/src/dto/openai/response.rs
@@ -147,6 +147,10 @@ pub enum Choice {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ResponseMessage {
     pub content: Option<String>,
+    // Private: some providers (e.g. moonshotai/Kimi-K2.5-TEE) emit both keys
+    // in the same delta object. Exposing them directly would let callers
+    // accidentally read only one and miss the other. Use `reasoning()` instead,
+    // which merges them in preference order.
     reasoning: Option<String>,
     reasoning_content: Option<String>,
     pub role: Option<String>,
@@ -161,12 +165,24 @@ pub struct ResponseMessage {
 }
 
 impl ResponseMessage {
-    /// Returns the reasoning text, preferring `reasoning` over
-    /// `reasoning_content` when both are present.
+    /// Returns the reasoning text. When both `reasoning` and
+    /// `reasoning_content` are present, the longer non-empty value is
+    /// returned; otherwise whichever is non-empty is used.
     pub fn reasoning(&self) -> Option<&str> {
-        self.reasoning
-            .as_deref()
-            .or(self.reasoning_content.as_deref())
+        match (self.reasoning.as_deref(), self.reasoning_content.as_deref()) {
+            (Some(a), Some(b)) => {
+                let a = a.trim();
+                let b = b.trim();
+                match (a.is_empty(), b.is_empty()) {
+                    (true, _) => Some(b).filter(|s| !s.is_empty()),
+                    (_, true) => Some(a).filter(|s| !s.is_empty()),
+                    _ => Some(if b.len() > a.len() { b } else { a }),
+                }
+            }
+            (Some(a), None) => Some(a).filter(|s| !s.trim().is_empty()),
+            (None, Some(b)) => Some(b).filter(|s| !s.trim().is_empty()),
+            (None, None) => None,
+        }
     }
 }
 

--- a/crates/forge_app/src/dto/openai/response.rs
+++ b/crates/forge_app/src/dto/openai/response.rs
@@ -565,7 +565,10 @@ mod tests {
 
     struct Fixture;
 
-    fn response_message(reasoning: Option<&str>, reasoning_content: Option<&str>) -> ResponseMessage {
+    fn response_message(
+        reasoning: Option<&str>,
+        reasoning_content: Option<&str>,
+    ) -> ResponseMessage {
         ResponseMessage {
             content: None,
             reasoning: reasoning.map(str::to_owned),


### PR DESCRIPTION
## Summary
Fix a deserialization panic when providers (e.g. `moonshotai/Kimi-K2.5-TEE` via Chutes) emit both `reasoning` and `reasoning_content` fields in the same delta object.

## Context
Some OpenAI-compatible providers — notably `moonshotai/Kimi-K2.5-TEE` served through Chutes — include **both** `reasoning` and `reasoning_content` keys inside a single streaming delta. The previous implementation used `#[serde(alias = "reasoning_content")]` on the `reasoning` field, which causes serde to emit a `duplicate_field` error when both keys are present, crashing the stream parser.

## Changes
- Replaced the `#[serde(alias)]` approach with two separate private fields (`reasoning` and `reasoning_content`) on `ResponseMessage`
- Added a public `ResponseMessage::reasoning()` method that merges the two fields by returning the longer non-empty value (favours content over an empty/whitespace-only entry)
- Updated all call-sites that previously read `message.reasoning` directly to use the new `message.reasoning()` accessor
- Added a fixture file (`chutes_completion_response.json`) capturing a real Chutes/Kimi-K2.5-TEE delta with both keys present
- Added a regression test (`test_kimi_k2_both_reasoning_keys_event`) that asserts the response parses successfully end-to-end

### Key Implementation Details
The merge strategy in `reasoning()`: when both fields are non-empty, the longer string wins. This handles the observed behaviour where both values are identical (Kimi-K2.5-TEE) while staying correct if a future provider sends subtly different content in each key.

## Testing
```bash
# Run the targeted test
cargo test -p forge_app test_kimi_k2_both_reasoning_keys_event

# Run the full openai response test suite
cargo test -p forge_app dto::openai::response
```

## Links
- Chutes provider reference: https://chutes.ai
