### PR TITLE
fix(fd): exclude lock files from workspace file indexing

### DIFF
--- a/crates/forge_services/src/fd.rs
+++ b/crates/forge_services/src/fd.rs
@@ -30,6 +30,31 @@ pub(crate) fn has_allowed_extension(path: &Path) -> bool {
     }
 }
 
+/// Returns `true` if the file at `path` should be excluded based on its name,
+/// regardless of extension. This covers lock files and other generated
+/// dependency manifest files that are not useful to index.
+fn is_ignored_by_name(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let name_lower = name.to_lowercase();
+
+    // Lock files: *-lock.json, *.lock, *.lockb, *.lock.json, etc.
+    if name_lower.ends_with(".lock")
+        || name_lower.ends_with(".lockb")
+        || name_lower.ends_with("-lock.json")
+        || name_lower.ends_with("-lock.yaml")
+        || name_lower.ends_with("-lock.yml")
+        || name_lower.ends_with(".lock.json")
+        || name_lower.ends_with(".lockfile")
+        || name == "Package.resolved"
+    {
+        return true;
+    }
+
+    false
+}
+
 /// Returns `true` if `path` is a symlink (does not follow the link).
 fn is_symlink(path: &Path) -> bool {
     path.symlink_metadata()
@@ -53,6 +78,7 @@ pub(crate) fn filter_and_resolve(
         .into_iter()
         .map(|p| dir_path.join(&p))
         .filter(|p| !is_symlink(p))
+        .filter(|p| !is_ignored_by_name(p))
         .filter(|p| has_allowed_extension(p))
         .collect();
 


### PR DESCRIPTION
## Summary
Fix a bug where lock files (e.g. `package-lock.json`, `Cargo.lock`, `yarn.lock`) were being indexed for workspace sync despite containing no useful content for code intelligence.

## Context
The file discovery pipeline filtered files by allowed extension, but lock files often carry extensions that appear on the allowlist (e.g. `.json`, `.yaml`, `.yml`). This meant files like `package-lock.json`, `npm-shrinkwrap.json`, `Cargo.lock`, and `Package.resolved` were being pulled into the indexing pipeline unnecessarily, wasting compute and polluting search results with auto-generated dependency manifests.

## Changes
- Added `is_ignored_by_name` function in `crates/forge_services/src/fd.rs` that matches lock file patterns by full filename, independent of extension
- Wired the check into `filter_and_resolve` so it runs before the extension allowlist filter
- Patterns covered:
  - `*.lock` — Cargo.lock, yarn.lock, Gemfile.lock, composer.lock, etc.
  - `*.lockb` — Bun lock files
  - `*-lock.json` — package-lock.json, npm-shrinkwrap.json
  - `*-lock.yaml` / `*-lock.yml` — various toolchain lock formats
  - `*.lock.json` — alternative lock file conventions
  - `*.lockfile` — generic lockfile extension
  - `Package.resolved` — Swift Package Manager

### Key Implementation Details
The name check is case-insensitive via `name_lower` (a lowercased copy of the filename), with the exception of `Package.resolved` which is matched case-sensitively as the Swift ecosystem uses that exact casing.

The filter is applied before `has_allowed_extension`, so lock files with otherwise-allowed extensions (`.json`, `.yaml`) are rejected early without needing changes to the extension allowlist.

## Testing
```bash
cargo insta test --accept -p forge_services
cargo check -p forge_services
```
