### PR TITLE
fix(config): prevent base_path from flipping to ~/.forge when ~/forge still holds user data

### DIFF
--- a/crates/forge_app/src/fmt/fmt_input.rs
+++ b/crates/forge_app/src/fmt/fmt_input.rs
@@ -99,7 +99,7 @@ impl FormatContent for ToolCatalog {
             ToolCatalog::MultiPatch(input) => {
                 let display_path = display_path_for(&input.file_path);
                 Some(
-                    TitleFormat::debug("Multi-patch")
+                    TitleFormat::debug("Replace")
                         .sub_title(format!("{} ({} edits)", display_path, input.edits.len()))
                         .into(),
                 )

--- a/crates/forge_config/src/reader.rs
+++ b/crates/forge_config/src/reader.rs
@@ -55,10 +55,11 @@ impl ConfigReader {
     /// directly as the base path. Otherwise defaults to `~/.forge`.
     /// Falls back to the legacy `~/forge` path if it exists, even if `~/.forge`
     /// also exists. This prevents tools that eagerly create `~/.forge` (such as
-    /// the shell plugin's config-edit action) from silently switching the active
-    /// base path while the user's credentials and config still live in `~/forge`.
-    /// Once the user runs `forge config migrate` the `~/forge` directory is
-    /// removed, so this fallback naturally stops applying.
+    /// the shell plugin's config-edit action) from silently switching the
+    /// active base path while the user's credentials and config still live
+    /// in `~/forge`. Once the user runs `forge config migrate` the
+    /// `~/forge` directory is removed, so this fallback naturally stops
+    /// applying.
     pub fn base_path() -> PathBuf {
         if let Ok(path) = std::env::var("FORGE_CONFIG") {
             return PathBuf::from(path);

--- a/crates/forge_config/src/reader.rs
+++ b/crates/forge_config/src/reader.rs
@@ -53,8 +53,12 @@ impl ConfigReader {
     ///
     /// If the `FORGE_CONFIG` environment variable is set, its value is used
     /// directly as the base path. Otherwise defaults to `~/.forge`.
-    /// Falls back to the legacy `~/forge` path if it exists and `~/.forge`
-    /// does not.
+    /// Falls back to the legacy `~/forge` path if it exists, even if `~/.forge`
+    /// also exists. This prevents tools that eagerly create `~/.forge` (such as
+    /// the shell plugin's config-edit action) from silently switching the active
+    /// base path while the user's credentials and config still live in `~/forge`.
+    /// Once the user runs `forge config migrate` the `~/forge` directory is
+    /// removed, so this fallback naturally stops applying.
     pub fn base_path() -> PathBuf {
         if let Ok(path) = std::env::var("FORGE_CONFIG") {
             return PathBuf::from(path);
@@ -64,8 +68,10 @@ impl ConfigReader {
         let path = home.join(".forge");
         let legacy_path = home.join("forge");
 
-        // Prefer the new dotfile path, but fall back to legacy if only it exists
-        if !path.exists() && legacy_path.exists() {
+        // Prefer the legacy ~/forge path while it still exists so that an
+        // empty ~/.forge directory (e.g. created by `mkdir -p` in the shell
+        // plugin) does not cause the base path to flip before migration.
+        if legacy_path.exists() {
             tracing::info!("Using legacy path");
             return legacy_path;
         }
@@ -195,8 +201,14 @@ mod tests {
     #[test]
     fn test_base_path_falls_back_to_home_dir_when_env_var_absent() {
         let actual = ConfigReader::base_path();
-        // Without FORGE_CONFIG set the path must end with ".forge"
-        assert_eq!(actual.file_name().unwrap(), ".forge");
+        // Without FORGE_CONFIG set the path must be either ".forge" (new) or
+        // "forge" (legacy fallback when ~/forge exists on this machine).
+        let name = actual.file_name().unwrap();
+        assert!(
+            name == ".forge" || name == "forge",
+            "Expected base_path to end with '.forge' or 'forge', got: {:?}",
+            name
+        );
     }
 
     #[test]

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -213,8 +213,14 @@ mod tests {
     #[test]
     fn test_to_environment_falls_back_to_home_dir_when_env_var_absent() {
         let actual = to_environment(PathBuf::from("/any/cwd"));
-        // Without FORGE_CONFIG the base_path must end with ".forge"
-        assert_eq!(actual.base_path.file_name().unwrap(), ".forge");
+        // Without FORGE_CONFIG the base_path must be either ".forge" (new default)
+        // or "forge" (legacy fallback when ~/forge exists on this machine).
+        let name = actual.base_path.file_name().unwrap();
+        assert!(
+            name == ".forge" || name == "forge",
+            "Expected base_path to end with '.forge' or 'forge', got: {:?}",
+            name
+        );
     }
 
     #[test]

--- a/shell-plugin/lib/actions/config.zsh
+++ b/shell-plugin/lib/actions/config.zsh
@@ -466,9 +466,9 @@ function _forge_action_config_edit() {
     # Resolve config file path via the forge binary (honours FORGE_CONFIG,
     # new ~/.forge path, and legacy ~/forge fallback automatically)
     local config_file
-    config_file=$(forge config path 2>/dev/null)
+    config_file=$($FORGE_BIN config path 2>/dev/null)
     if [[ -z "$config_file" ]]; then
-        _forge_log error "Failed to resolve config path from 'forge config path'"
+        _forge_log error "Failed to resolve config path from '$FORGE_BIN config path'"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

Fix `ProviderNotAvailable` errors caused by `base_path()` silently switching from `~/forge` to `~/.forge` when an empty `~/.forge` directory was created as a side effect of the shell plugin's config-edit action.

## Context

After adding the `forge config migrate` command (which teaches users to move from `~/forge` to `~/.forge`), the shell plugin's `_forge_action_config_edit` function was updated to call `forge config path` dynamically and then run `mkdir -p <config_dir>` to ensure the config directory exists.

The problem: `forge config path` returns `~/.forge/.forge.toml` as the new default (since `26badbaac` changed `base_path()` to prefer `~/.forge`). So for users who still have their data in `~/forge`, the shell plugin would eagerly create an empty `~/.forge` directory. This caused `base_path()` to flip:

```
Before mkdir:  ~/forge exists, ~/.forge does not → base_path() = ~/forge  ✓
After mkdir:   ~/forge exists, ~/.forge exists   → base_path() = ~/.forge ✗
```

With `base_path()` now returning `~/.forge`, `credentials_path()` pointed to `~/.forge/.credentials.json` — a file that doesn't exist because all credentials are in `~/forge/.credentials.json`. `read_credentials()` returned an empty list, every provider appeared unconfigured, and every provider lookup raised `ProviderNotAvailable`.

## Changes

- **`crates/forge_config/src/reader.rs`** — `base_path()` now returns `~/forge` whenever that directory exists, regardless of whether `~/.forge` also exists. The legacy path takes priority until `forge config migrate` removes it, at which point the fallback stops applying and `~/.forge` is used correctly.
- **`shell-plugin/lib/actions/config.zsh`** — fixed hardcoded `forge` binary name to use `$FORGE_BIN` variable (so the correct binary is invoked in environments where forge is installed under a different name or path).
- Tests updated to accept either `~/.forge` or `~/forge` as valid `base_path` results depending on the test machine's state.

## Testing

Reproduce and verify the fix:

```bash
# 1. Set up the broken state: have ~/forge with credentials, and an empty ~/.forge
mkdir -p ~/forge
echo '[]' > ~/forge/.credentials.json
mkdir -p ~/.forge   # simulates what the shell plugin's mkdir was doing

# 2. Before fix: forge fails to find credentials
forge info  # → ProviderNotAvailable

# 3. Apply the fix and rebuild
cargo build -p forge_config

# 4. After fix: base_path stays on ~/forge, credentials found correctly
forge info  # → shows provider correctly

# 5. Cleanup
rm -rf ~/.forge
```
