### PR TITLE
fix(update): replace stale antinomyhq/forge references with tailcallhq/forgecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 <p align="center"><code>curl -fsSL https://forgecode.dev/cli | sh</code></p>
 
-[![CI Status](https://img.shields.io/github/actions/workflow/status/antinomyhq/forge/ci.yml?style=for-the-badge)](https://github.com/antinomyhq/forge/actions)
-[![GitHub Release](https://img.shields.io/github/v/release/antinomyhq/forge?style=for-the-badge)](https://github.com/antinomyhq/forge/releases)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/tailcallhq/forgecode/ci.yml?style=for-the-badge)](https://github.com/tailcallhq/forgecode/actions)
+[![GitHub Release](https://img.shields.io/github/v/release/tailcallhq/forgecode?style=for-the-badge)](https://github.com/tailcallhq/forgecode/releases)
 [![Discord](https://img.shields.io/discord/1044859667798568962?style=for-the-badge&cacheSeconds=120&logo=discord)](https://discord.gg/kRZBPpkgwq)
-[![CLA assistant](https://cla-assistant.io/readme/badge/antinomyhq/forge?style=for-the-badge)](https://cla-assistant.io/antinomyhq/forge)
+[![CLA assistant](https://cla-assistant.io/readme/badge/tailcallhq/forgecode?style=for-the-badge)](https://cla-assistant.io/tailcallhq/forgecode)
 
 ![Code-Forge Demo](https://assets.antinomy.ai/images/forge_demo_2x.gif)
 
@@ -1090,7 +1090,7 @@ MCP tools can be used as part of multi-agent workflows, allowing specialized age
 
 ## Documentation
 
-For comprehensive documentation on all features and capabilities, please visit the [documentation site](https://github.com/antinomyhq/forge/tree/main/docs).
+For comprehensive documentation on all features and capabilities, please visit the [documentation site](https://github.com/tailcallhq/forgecode/tree/main/docs).
 
 ---
 
@@ -1101,7 +1101,7 @@ For comprehensive documentation on all features and capabilities, please visit t
 curl -fsSL https://forgecode.dev/cli | sh
 
 # Package managers
-nix run github:antinomyhq/forge # for latest dev branch
+nix run github:tailcallhq/forgecode # for latest dev branch
 ```
 
 ---

--- a/benchmarks/evals/multi_file_patch/task.yml
+++ b/benchmarks/evals/multi_file_patch/task.yml
@@ -1,6 +1,6 @@
 run:
   # Clone into `tmp/task` dir
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 parallelism: 50
 timeout: 120

--- a/benchmarks/evals/parallel_tool_calls/task.yml
+++ b/benchmarks/evals/parallel_tool_calls/task.yml
@@ -1,7 +1,7 @@
 # No before_run needed - binary should be pre-built
 run:
   - # Clone into `tmp/task` dir
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 parallelism: 5
 timeout: 120

--- a/benchmarks/evals/read_over_cat/task.yml
+++ b/benchmarks/evals/read_over_cat/task.yml
@@ -1,5 +1,5 @@
 run:
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 parallelism: 10
 timeout: 180

--- a/benchmarks/evals/redundant_cd_with_cwd/task.yml
+++ b/benchmarks/evals/redundant_cd_with_cwd/task.yml
@@ -1,5 +1,5 @@
 run:
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - mkdir ../test-dir && cd ../test-dir
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 parallelism: 5

--- a/benchmarks/evals/search_over_find/task.yml
+++ b/benchmarks/evals/search_over_find/task.yml
@@ -1,5 +1,5 @@
 run:
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 parallelism: 10
 timeout: 180

--- a/benchmarks/evals/sem_search/task.yml
+++ b/benchmarks/evals/sem_search/task.yml
@@ -1,6 +1,6 @@
 run:
   # Clone into `tmp/task` dir
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - forge workspace init --yes
   - forge workspace sync
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.jsonl' FORGE_SESSION__PROVIDER_ID=open_router FORGE_SESSION__MODEL_ID={{model}} forge -p '{{task}}'
@@ -118,7 +118,7 @@ sources:
       - task: "Lets have upload take a glob pattern for upload"      
       - task: "Check this for security issues: eval(user_input)"
       - task: "Update the vector dimension to be 4096"
-      - task: "Fix this - 'docker run antinomyhq/forge-ce'"      
+      - task: "Fix this - 'docker run tailcallhq/forgecode'"      
       - task: "Document the adapter registration and discovery mechanism"
       - task: "There are multiple places where we throw - \"Conversation not found\" how do u suggest we consolidate and reuse."      
       - task: "Is there a crate for humanizing date time format that we are using?"            

--- a/benchmarks/evals/semantic_search_quality/task.yml
+++ b/benchmarks/evals/semantic_search_quality/task.yml
@@ -4,7 +4,7 @@ before_run:
 
 run:
   # Clone into `tmp/task` dir
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - forgee workspace sync
   - FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee --provider open_router --model {{model}} -p '{{task}}'
 

--- a/benchmarks/evals/todo_write_usage/task.yml
+++ b/benchmarks/evals/todo_write_usage/task.yml
@@ -1,6 +1,6 @@
 # Evaluation for checking appropriate todo_write tool usage
 run:
-  - git clone --depth=1 --branch main https://github.com/antinomyhq/forge .
+  - git clone --depth=1 --branch main https://github.com/tailcallhq/forgecode .
   - FORGE_OVERRIDE_PROVIDER=open_router FORGE_OVERRIDE_MODEL={{model}} FORGE_DEBUG_REQUESTS='{{dir}}/context.json' forgee -p '{{task}}'
 parallelism: 3
 timeout: 240

--- a/crates/forge_main/src/update.rs
+++ b/crates/forge_main/src/update.rs
@@ -78,7 +78,7 @@ pub async fn on_update(api: Arc<impl API>, update: Option<&Update>) {
         return;
     }
 
-    let informer = update_informer::new(registry::GitHub, "antinomyhq/forge", VERSION)
+    let informer = update_informer::new(registry::GitHub, "tailcallhq/forgecode", VERSION)
         .interval(frequency.into());
 
     if let Some(version) = informer.check_version().ok().flatten()

--- a/plans/2026-01-22-Fix Auto-Sync Workspace Registration Issue-v1.md
+++ b/plans/2026-01-22-Fix Auto-Sync Workspace Registration Issue-v1.md
@@ -1,6 +1,6 @@
 # Fix Auto-Sync Workspace Registration Issue
 
-**Issue:** [#2288](https://github.com/antinomyhq/forge/issues/2288)
+**Issue:** [#2288](https://github.com/tailcallhq/forgecode/issues/2288)
 
 **Problem:** The zsh plugin automatically syncs workspaces in the background on every directory change, causing unintended parent directories to be registered as workspaces. When users run `forge workspace list`, ancestor directories appear as "Current" instead of the actual working directory.
 

--- a/plans/2026-01-22-Fix Auto-Sync Workspace Registration Issue-v2.md
+++ b/plans/2026-01-22-Fix Auto-Sync Workspace Registration Issue-v2.md
@@ -1,6 +1,6 @@
 # Fix Auto-Sync Workspace Registration Issue
 
-**Issue:** [#2288](https://github.com/antinomyhq/forge/issues/2288)
+**Issue:** [#2288](https://github.com/tailcallhq/forgecode/issues/2288)
 
 **Problem:** The zsh plugin automatically syncs workspaces in the background on every directory change, causing unintended parent directories to be registered as workspaces. When users run `forge workspace list`, ancestor directories appear as "Current" instead of the actual working directory.
 


### PR DESCRIPTION
## Summary

`forge update` fails with a 404 because the install script and `update-informer` still reference old repository names (`antinomyhq/forge` / `tailcallhq/forge`) that no longer resolve to release assets. This PR updates all stale references to `tailcallhq/forgecode`.

Closes #2929

## Changes

- **`crates/forge_main/src/update.rs`** — `update-informer` registry target changed from `antinomyhq/forge` to `tailcallhq/forgecode` so version checks hit the correct GitHub repo
- **`README.md`** — CI badge, release badge, CLA assistant, docs link, and nix run URL updated
- **`benchmarks/evals/`** (8 files) — `git clone` URLs in eval task definitions updated to prevent CI failures
- **`plans/`** (2 files) — issue links updated to current repo

## Context

The repo was transferred from `antinomyhq/forge` → `tailcallhq/forgecode`. GitHub's API redirects the old `antinomyhq/forge` path (301), so `update-informer` version checks happened to still work. However:

- The install script at `forgecode.dev/cli` uses `tailcallhq/forge` (not `antinomyhq`), and GitHub does **not** redirect same-org renames for `/releases/` URLs → **404 on download**
- All README badges/links pointed to the old org

| URL | Before | After |
|---|---|---|
| `github.com/antinomyhq/forge` | 301 redirect (fragile) | ✅ Direct |
| `github.com/tailcallhq/forge/releases/...` | **404** | N/A |
| `github.com/tailcallhq/forgecode/releases/...` | N/A | ✅ Direct |

> **Note**: The install script served at `https://forgecode.dev/cli` also hardcodes `tailcallhq/forge` in its download URLs — that is the primary cause of the `forge update` 404 but lives outside this repo. See #2929 for details.