### PR TITLE
fix(http): append linebreak to debug file writes for valid jsonl format

### DIFF
--- a/crates/forge_infra/src/http.rs
+++ b/crates/forge_infra/src/http.rs
@@ -238,7 +238,9 @@ impl<F: forge_app::FileWriterInfra + 'static> ForgeHttpInfra<F> {
             let body_clone = body.clone();
             let debug_path = debug_path.clone();
             tokio::spawn(async move {
-                let _ = file_writer.append(&debug_path, body_clone).await;
+                let mut data = body_clone.to_vec();
+                data.push(b'\n');
+                let _ = file_writer.append(&debug_path, Bytes::from(data)).await;
             });
         }
     }
@@ -402,7 +404,9 @@ mod tests {
         let writes = file_writer.get_writes().await;
         assert_eq!(writes.len(), 1, "Should write one file");
         assert_eq!(writes[0].0, debug_path);
-        assert_eq!(writes[0].1, body);
+        let mut expected = body.to_vec();
+        expected.push(b'\n');
+        assert_eq!(writes[0].1, Bytes::from(expected));
     }
 
     #[tokio::test]
@@ -423,7 +427,9 @@ mod tests {
         let writes = file_writer.get_writes().await;
         assert_eq!(writes.len(), 1, "Should write one file");
         assert_eq!(writes[0].0, debug_path);
-        assert_eq!(writes[0].1, body);
+        let mut expected = body.to_vec();
+        expected.push(b'\n');
+        assert_eq!(writes[0].1, Bytes::from(expected));
     }
 
     #[tokio::test]
@@ -470,7 +476,9 @@ mod tests {
             "Should write one file for POST when debug_requests is set"
         );
         assert_eq!(writes[0].0, debug_path);
-        assert_eq!(writes[0].1, body);
+        let mut expected = body.to_vec();
+        expected.push(b'\n');
+        assert_eq!(writes[0].1, Bytes::from(expected));
     }
 
     #[tokio::test]
@@ -494,7 +502,9 @@ mod tests {
         // Should write to debug_path (no parent dir needed)
         assert_eq!(writes.len(), 1, "Should write one file");
         assert_eq!(writes[0].0, debug_path);
-        assert_eq!(writes[0].1, body);
+        let mut expected = body.to_vec();
+        expected.push(b'\n');
+        assert_eq!(writes[0].1, Bytes::from(expected));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix HTTP debug file writes to append a newline after each entry, ensuring the output is valid JSONL (JSON Lines) format.

## Context
When the `debug_requests` feature is enabled, HTTP request/response bodies are appended to a debug file. However, each write was missing a trailing newline, meaning entries were written back-to-back without any delimiter. This breaks the JSONL format, where each line must be a separate, complete JSON object. Tools that consume JSONL files (log parsers, analytics pipelines, etc.) would fail to parse the debug output correctly.

## Changes
- Updated `ForgeHttpInfra` to append a `\n` byte after each body write to the debug file, producing valid JSONL output.
- Updated all related unit tests to reflect the new expected output (body + newline).

### Key Implementation Details
The fix is minimal and targeted: before calling `file_writer.append`, the body bytes are cloned into a `Vec<u8>`, a newline byte (`b'\n'`) is pushed, and the result is converted back to `Bytes`. This ensures no existing data is mutated and the change is fully backward-compatible.

## Testing
```bash
# Run the affected crate's tests
cargo insta test --accept -p forge_infra
```

All four existing debug-write tests have been updated to assert the newline is present and continue to pass.

## Links
- Affected file: `crates/forge_infra/src/http.rs`
