### PR TITLE
fix(reasoning): respect user config and Effort::None for models without effort support

### DIFF
--- a/crates/forge_app/src/agent.rs
+++ b/crates/forge_app/src/agent.rs
@@ -249,12 +249,17 @@ mod tests {
 
         let actual = agent.apply_config(&config).reasoning;
 
-        let expected = Some(ReasoningConfig::default().enabled(false).effort(Effort::None));
+        let expected = Some(
+            ReasoningConfig::default()
+                .enabled(false)
+                .effort(Effort::None),
+        );
 
         assert_eq!(actual, expected);
     }
 
-    /// When the user config leaves fields unset, the agent's defaults fill them.
+    /// When the user config leaves fields unset, the agent's defaults fill
+    /// them.
     #[test]
     fn test_reasoning_agent_fills_unset_config_fields() {
         let config = ForgeConfig::default()

--- a/crates/forge_app/src/agent.rs
+++ b/crates/forge_app/src/agent.rs
@@ -144,7 +144,7 @@ impl AgentExt for Agent {
         }
 
         // Apply workflow reasoning configuration to agents.
-        // Agent-level fields take priority; config fills in any unset fields.
+        // User config takes priority; agent defaults fill in any unset fields.
         if let Some(ref config_reasoning) = config.reasoning {
             use forge_config::Effort as ConfigEffort;
             let config_as_domain = ReasoningConfig {
@@ -161,9 +161,9 @@ impl AgentExt for Agent {
                 exclude: config_reasoning.exclude,
                 enabled: config_reasoning.enabled,
             };
-            // Start from the agent's own settings and fill unset fields from config.
-            let mut merged = agent.reasoning.clone().unwrap_or_default();
-            merged.merge(config_as_domain);
+            // Start from user config; agent defaults fill unset fields.
+            let mut merged = config_as_domain;
+            merged.merge(agent.reasoning.clone().unwrap_or_default());
             agent.reasoning = Some(merged);
         }
 
@@ -208,10 +208,10 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    /// When the agent already has reasoning fields set, those fields take
-    /// priority; config only fills in fields the agent left unset.
+    /// When both the agent and config set reasoning fields, user config
+    /// takes priority; agent values only fill in fields the config left unset.
     #[test]
-    fn test_reasoning_agent_fields_take_priority_over_config() {
+    fn test_reasoning_config_fields_take_priority_over_agent() {
         let config = ForgeConfig::default().reasoning(
             ConfigReasoningConfig::default()
                 .enabled(true)
@@ -219,16 +219,61 @@ mod tests {
                 .max_tokens(1024_usize),
         );
 
-        // Agent overrides effort but leaves enabled and max_tokens unset.
+        // Agent overrides effort but config takes priority.
         let agent = fixture_agent().reasoning(ReasoningConfig::default().effort(Effort::High));
 
         let actual = agent.apply_config(&config).reasoning;
 
         let expected = Some(
             ReasoningConfig::default()
-                .effort(Effort::High) // agent's value wins
+                .effort(Effort::Low) // config's value wins
                 .enabled(true) // filled in from config
                 .max_tokens(1024_usize), // filled in from config
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    /// When the user sets enabled=false in config, it overrides the agent's
+    /// enabled=true.  This is the core scenario from issue #2924.
+    #[test]
+    fn test_reasoning_config_enabled_false_overrides_agent() {
+        let config = ForgeConfig::default().reasoning(
+            ConfigReasoningConfig::default()
+                .enabled(false)
+                .effort(ConfigEffort::None),
+        );
+
+        // Agent has enabled=true (like forge.md).
+        let agent = fixture_agent().reasoning(ReasoningConfig::default().enabled(true));
+
+        let actual = agent.apply_config(&config).reasoning;
+
+        let expected = Some(ReasoningConfig::default().enabled(false).effort(Effort::None));
+
+        assert_eq!(actual, expected);
+    }
+
+    /// When the user config leaves fields unset, the agent's defaults fill them.
+    #[test]
+    fn test_reasoning_agent_fills_unset_config_fields() {
+        let config = ForgeConfig::default()
+            .reasoning(ConfigReasoningConfig::default().effort(ConfigEffort::Medium));
+
+        // Agent has enabled=true and max_tokens=2048; config has neither.
+        let agent = fixture_agent().reasoning(
+            ReasoningConfig::default()
+                .enabled(true)
+                .max_tokens(2048_usize),
+        );
+
+        let actual = agent.apply_config(&config).reasoning;
+
+        let expected = Some(
+            ReasoningConfig::default()
+                .effort(Effort::Medium) // from config
+                .enabled(true) // from agent (config had None)
+                .max_tokens(2048_usize), // from agent (config had None)
         );
 
         assert_eq!(actual, expected);

--- a/crates/forge_app/src/dto/anthropic/request.rs
+++ b/crates/forge_app/src/dto/anthropic/request.rs
@@ -727,7 +727,10 @@ mod tests {
 
         let actual = Request::try_from(fixture).unwrap();
 
-        assert_eq!(actual.output_config, Some(OutputConfig { effort: OutputEffort::Low }));
+        assert_eq!(
+            actual.output_config,
+            Some(OutputConfig { effort: OutputEffort::Low })
+        );
         assert_eq!(actual.thinking, None);
     }
 

--- a/crates/forge_app/src/dto/anthropic/request.rs
+++ b/crates/forge_app/src/dto/anthropic/request.rs
@@ -144,19 +144,24 @@ impl TryFrom<forge_domain::Context> for Request {
                         None,
                     )
                 } else if let Some(effort) = reasoning.effort {
-                    // Effort without budget → newer output_config API.
-                    let output_effort = match effort {
-                        forge_domain::Effort::Low => OutputEffort::Low,
-                        forge_domain::Effort::High => OutputEffort::High,
-                        forge_domain::Effort::Max => OutputEffort::Max,
-                        // Map unsupported variants to the nearest Anthropic-valid effort.
-                        forge_domain::Effort::None | forge_domain::Effort::Minimal => {
-                            OutputEffort::Low
-                        }
-                        forge_domain::Effort::Medium => OutputEffort::Medium,
-                        forge_domain::Effort::XHigh => OutputEffort::Max,
-                    };
-                    (None, Some(OutputConfig { effort: output_effort }))
+                    if matches!(effort, forge_domain::Effort::None) {
+                        // "None" means skip reasoning entirely.
+                        (None, None)
+                    } else {
+                        // Effort without budget → newer output_config API.
+                        let output_effort = match effort {
+                            forge_domain::Effort::Low | forge_domain::Effort::Minimal => {
+                                OutputEffort::Low
+                            }
+                            forge_domain::Effort::Medium => OutputEffort::Medium,
+                            forge_domain::Effort::High => OutputEffort::High,
+                            forge_domain::Effort::Max | forge_domain::Effort::XHigh => {
+                                OutputEffort::Max
+                            }
+                            forge_domain::Effort::None => unreachable!(),
+                        };
+                        (None, Some(OutputConfig { effort: output_effort }))
+                    }
                 } else {
                     // Enabled-only → thinking with default budget.
                     (
@@ -677,6 +682,52 @@ mod tests {
 
         let actual = Request::try_from(fixture).unwrap();
 
+        assert_eq!(actual.thinking, None);
+    }
+
+    #[test]
+    fn test_effort_none_with_enabled_skips_reasoning() {
+        // Effort::None means "skip reasoning entirely", even if enabled=true.
+        let fixture = Context::default().reasoning(ReasoningConfig {
+            enabled: Some(true),
+            effort: Some(forge_domain::Effort::None),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let actual = Request::try_from(fixture).unwrap();
+
+        assert_eq!(actual.thinking, None);
+        assert_eq!(actual.output_config, None);
+    }
+
+    #[test]
+    fn test_effort_none_with_disabled_skips_reasoning() {
+        let fixture = Context::default().reasoning(ReasoningConfig {
+            enabled: Some(false),
+            effort: Some(forge_domain::Effort::None),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let actual = Request::try_from(fixture).unwrap();
+
+        assert_eq!(actual.thinking, None);
+        assert_eq!(actual.output_config, None);
+    }
+
+    #[test]
+    fn test_effort_minimal_maps_to_low() {
+        let fixture = Context::default().reasoning(ReasoningConfig {
+            enabled: Some(true),
+            effort: Some(forge_domain::Effort::Minimal),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let actual = Request::try_from(fixture).unwrap();
+
+        assert_eq!(actual.output_config, Some(OutputConfig { effort: OutputEffort::Low }));
         assert_eq!(actual.thinking, None);
     }
 


### PR DESCRIPTION
## Summary

Fixes two interacting bugs that caused reasoning parameters to be sent to models that don't support them (e.g. Claude Haiku 4.5), even when the user explicitly disabled reasoning in `.forge.toml`.

Fixes #2924.

### Bug 1: Config merge direction (`agent.rs`)

The reasoning config merge used `overwrite_none` with the agent as base, so the forge agent's hardcoded `enabled: true` silently overrode the user's `enabled: false`. Reversed the merge direction to match the compact config pattern already used in the same file: user config as base, agent defaults fill gaps.

### Bug 2: `Effort::None` semantics (`request.rs`)

`Effort::None` is documented as "No reasoning; skips the thinking step entirely" but the Anthropic DTO mapped it to `OutputEffort::Low`, actively enabling reasoning. Now returns `(None, None)` to skip reasoning entirely, matching the OpenAI path which already handled this correctly.

## Test plan

- [x] New test: user `enabled=false` overrides agent `enabled=true` (the #2924 scenario)
- [x] New test: `Effort::None` with `enabled=true` skips reasoning on Anthropic
- [x] New test: `Effort::None` with `enabled=false` skips reasoning on Anthropic
- [x] New test: `Effort::Minimal` still maps to `OutputEffort::Low`
- [x] New test: agent fills unset config fields
- [x] Updated test: config fields take priority over agent (reversed from before)
- [x] `RUSTFLAGS='-Dwarnings' cargo check -p forge_app` passes
- [x] `cargo test -p forge_app` (576 tests) passes
- [x] `cargo test -p forge_domain` passes

## Note

The Google provider (`crates/forge_app/src/dto/google/request.rs`) has the same class of bug: `Effort::None` + `enabled=true` still emits a `ThinkingConfig`, and `effort` is never mapped to `thinking_level`. That is a pre-existing issue outside the scope of this PR.