### PR TITLE
fix(executor): append newline when shell command stdout lacks trailing newline

### DIFF
--- a/crates/forge_infra/src/executor.rs
+++ b/crates/forge_infra/src/executor.rs
@@ -117,11 +117,21 @@ impl ForgeCommandExecutorService {
         } else {
             let stdout_writer = OutputPrinterWriter::stdout(self.output_printer.clone());
             let stderr_writer = OutputPrinterWriter::stderr(self.output_printer.clone());
-            tokio::try_join!(
+            let result = tokio::try_join!(
                 child.wait(),
                 stream(&mut stdout_pipe, stdout_writer),
                 stream(&mut stderr_pipe, stderr_writer)
-            )?
+            )?;
+
+            // If the command's stdout did not end with a newline, the terminal
+            // cursor is left mid-line. Write a newline so that subsequent output
+            // (e.g. the LLM response) starts on a fresh line.
+            if result.1.last() != Some(&b'\n') && !result.1.is_empty() {
+                let _ = self.output_printer.write(b"\n");
+                let _ = self.output_printer.flush();
+            }
+
+            result
         };
 
         // Drop happens after `try_join` due to <https://github.com/tokio-rs/tokio/issues/4309>


### PR DESCRIPTION
## Summary

Fix a display bug where forge's LLM response text was concatenated onto the same line as shell command output when the command did not emit a trailing newline.

## Context

When running a shell command that produces output without a trailing newline (e.g. `printf 'abc'`), the terminal cursor is left mid-line. Because forge streams command stdout directly to the printer — bypassing the `StreamingWriter`'s `ends_with_newline` tracker — forge had no awareness that the cursor was mid-line. As a result, the LLM's response text would immediately follow the command output on the same line, producing garbled output like:

```
● [11:39:31] Execute [/bin/zsh] printf 'abc'
abcabc printed without a trailing newline using printf 'abc'.
```

## Changes

- In `execute_command_internal` (`crates/forge_infra/src/executor.rs`), after streaming non-silent stdout, check if the last byte written was not a newline and the buffer is non-empty. If so, write a `\n` to the printer to move the cursor to a fresh line before any subsequent forge output.

### Key Implementation Details

The fix is in `ForgeCommandExecutorService::execute_command_internal`. After the `tokio::try_join!` that streams stdout/stderr, the captured stdout buffer (`result.1`) is inspected. If its last byte is not `\n` and the buffer is non-empty, a newline is written directly to the `output_printer`. This is intentionally done at the infrastructure layer — right after the raw bytes are streamed — so every code path that renders shell output benefits automatically, regardless of which agent or tool triggered the command.

## Use Cases

- Any command that intentionally omits a trailing newline (e.g. `printf 'abc'`, `echo -n foo`, custom scripts) will now produce clean, separated output.
- Before the fix: `abcThe command ran successfully.`
- After the fix:
  ```
  abc
  The command ran successfully.
  ```

## Testing

```bash
cargo run -- -p "Use the shell command to print abc without a new line"
```

Expected output (after fix):
```
● [...] Execute [/bin/zsh] printf 'abc'
abc
Output: abc (no trailing newline)
● [...] Finished ...
```

The response text should appear on a new line after `abc`, not concatenated to it.
