### PR TITLE
perf(display): cache terminal theme detection with 100ms timeout

### DIFF
--- a/crates/forge_display/src/code.rs
+++ b/crates/forge_display/src/code.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
@@ -6,6 +8,12 @@ use syntect::parsing::SyntaxSet;
 use syntect::util::as_24_bit_terminal_escaped;
 use terminal_colorsaurus::{QueryOptions, ThemeMode, theme_mode};
 use two_face::theme::EmbeddedThemeName;
+
+/// Maximum time to wait for a terminal color query response.
+const THEME_DETECT_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Process-wide cache for whether the terminal uses a dark background.
+static IS_DARK_THEME: OnceLock<bool> = OnceLock::new();
 
 /// Loads and caches syntax highlighting resources.
 #[derive(Clone)]
@@ -25,12 +33,19 @@ impl Default for SyntaxHighlighter {
 }
 
 impl SyntaxHighlighter {
-    /// Detects whether the terminal is using a dark or light background.
+    /// Detects whether the terminal is using a dark or light background,
+    /// querying the terminal at most once per process lifetime. Subsequent
+    /// calls return the cached result. Falls back to dark mode on timeout or
+    /// if the terminal does not support color queries.
     fn is_dark_theme() -> bool {
-        match theme_mode(QueryOptions::default()) {
-            Ok(ThemeMode::Light) => false,
-            Ok(ThemeMode::Dark) | Err(_) => true,
-        }
+        *IS_DARK_THEME.get_or_init(|| {
+            let mut opts = QueryOptions::default();
+            opts.timeout = THEME_DETECT_TIMEOUT;
+            match theme_mode(opts) {
+                Ok(ThemeMode::Light) => false,
+                Ok(ThemeMode::Dark) | Err(_) => true,
+            }
+        })
     }
 
     /// Syntax-highlights `code` for the given language token (e.g. `"toml"`,

--- a/crates/forge_display/src/code.rs
+++ b/crates/forge_display/src/code.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use syntect::easy::HighlightLines;

--- a/crates/forge_markdown_stream/src/utils.rs
+++ b/crates/forge_markdown_stream/src/utils.rs
@@ -1,5 +1,8 @@
 //! Utility functions for the markdown renderer.
 
+use std::sync::OnceLock;
+use std::time::Duration;
+
 /// Terminal theme mode (dark or light).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeMode {
@@ -9,12 +12,24 @@ pub enum ThemeMode {
     Light,
 }
 
-/// Detects the terminal theme mode (dark or light).
-pub fn detect_theme_mode() -> ThemeMode {
-    use terminal_colorsaurus::{QueryOptions, ThemeMode as ColorsaurusThemeMode, theme_mode};
+/// Maximum time to wait for a terminal color query response.
+const THEME_DETECT_TIMEOUT: Duration = Duration::from_millis(100);
 
-    match theme_mode(QueryOptions::default()) {
-        Ok(ColorsaurusThemeMode::Light) => ThemeMode::Light,
-        Ok(ColorsaurusThemeMode::Dark) | Err(_) => ThemeMode::Dark,
-    }
+/// Process-wide cache for the detected terminal theme mode.
+static THEME_MODE: OnceLock<ThemeMode> = OnceLock::new();
+
+/// Detects the terminal theme mode (dark or light), querying the terminal at
+/// most once per process lifetime. Subsequent calls return the cached result.
+/// Falls back to dark mode if the terminal does not respond within the timeout.
+pub fn detect_theme_mode() -> ThemeMode {
+    *THEME_MODE.get_or_init(|| {
+        use terminal_colorsaurus::{QueryOptions, ThemeMode as ColorsaurusThemeMode, theme_mode};
+
+        let mut opts = QueryOptions::default();
+        opts.timeout = THEME_DETECT_TIMEOUT;
+        match theme_mode(opts) {
+            Ok(ColorsaurusThemeMode::Light) => ThemeMode::Light,
+            Ok(ColorsaurusThemeMode::Dark) | Err(_) => ThemeMode::Dark,
+        }
+    })
 }


### PR DESCRIPTION
## Summary
Cache terminal theme detection with a 100ms timeout to avoid repeated blocking queries on every syntax-highlighted output.

## Context
Terminal theme detection (`terminal_colorsaurus::theme_mode`) was called on every invocation of syntax highlighting and markdown rendering. This sends an escape-sequence query to the terminal and waits for a response, which is an I/O-bound operation that adds latency to every render cycle. In non-interactive environments (CI, piped output, some terminal emulators) the query can block for the full default timeout before falling back to dark mode, visibly slowing down output.

## Changes
- Added a `OnceLock<bool>` / `OnceLock<ThemeMode>` process-wide cache in both `forge_display` and `forge_markdown_stream` so the terminal is queried at most once per process lifetime.
- Set an explicit 100 ms upper-bound timeout on the `QueryOptions` in both crates, replacing the library default (which can be several seconds).
- Added `THEME_DETECT_TIMEOUT` constants and doc-comments explaining the caching and fallback behaviour.

### Key Implementation Details
`std::sync::OnceLock` provides lock-free reads after the first initialization, making subsequent calls to `is_dark_theme()` / `detect_theme_mode()` essentially free (a single atomic load). The 100 ms timeout is a safe upper bound: real terminals respond in < 10 ms, while environments that do not support the query will now fail-fast instead of stalling.

## Testing
```bash
# Run display and markdown-stream crate tests
cargo insta test --accept -p forge_display -p forge_markdown_stream

# Observe that syntax-highlighted output is rendered without noticeable delay
# even when running in a piped/non-TTY context
cargo run -- "print hello world" 2>&1 | cat
```
