### PR TITLE
refactor(shell-plugin): rename _FORGE_TERM_ENABLED to _FORGE_TERM

### DIFF
--- a/shell-plugin/lib/config.zsh
+++ b/shell-plugin/lib/config.zsh
@@ -38,7 +38,7 @@ typeset -h _FORGE_SESSION_REASONING_EFFORT
 
 # Terminal context capture settings
 # Master switch for terminal context capture (preexec/precmd hooks)
-typeset -h _FORGE_TERM_ENABLED="${FORGE_TERM_ENABLED:-true}"
+typeset -h _FORGE_TERM="${FORGE_TERM:-true}"
 # Maximum number of commands to keep in the ring buffer (metadata: cmd + exit code)
 typeset -h _FORGE_TERM_MAX_COMMANDS="${FORGE_TERM_MAX_COMMANDS:-5}"
 # OSC 133 semantic prompt marker emission: "auto", "on", or "off"

--- a/shell-plugin/lib/context.zsh
+++ b/shell-plugin/lib/context.zsh
@@ -67,7 +67,7 @@ typeset -g _FORGE_TERM_PENDING_TS=""
 # Called before each command executes.
 # Records the command text and timestamp, emits OSC 133 B+C markers.
 function _forge_context_preexec() {
-    [[ "$_FORGE_TERM_ENABLED" != "true" ]] && return
+    [[ "$_FORGE_TERM" != "true" ]] && return
     _FORGE_TERM_PENDING_CMD="$1"
     _FORGE_TERM_PENDING_TS="$(date +%s)"
     # OSC 133 B: prompt end / command start
@@ -87,7 +87,7 @@ function _forge_context_precmd() {
     # even when context capture is disabled.
     _forge_osc133_emit "D;$last_exit"
 
-    [[ "$_FORGE_TERM_ENABLED" != "true" ]] && return
+    [[ "$_FORGE_TERM" != "true" ]] && return
 
     # Only record if we have a pending command from preexec
     if [[ -n "$_FORGE_TERM_PENDING_CMD" ]]; then
@@ -115,7 +115,7 @@ function _forge_context_precmd() {
 # Register using standard zsh hook arrays for coexistence with other plugins.
 # precmd is prepended so it runs first and captures the real $? from the
 # command, before other plugins (powerlevel10k, starship, etc.) overwrite it.
-if [[ "$_FORGE_TERM_ENABLED" == "true" ]]; then
+if [[ "$_FORGE_TERM" == "true" ]]; then
     preexec_functions+=(_forge_context_preexec)
     precmd_functions=(_forge_context_precmd "${precmd_functions[@]}")
 fi

--- a/shell-plugin/lib/helpers.zsh
+++ b/shell-plugin/lib/helpers.zsh
@@ -29,7 +29,7 @@ function _forge_exec() {
     # can legitimately contain colons (URLs, port mappings, paths, etc.).
     # Use `local -x` so the variables are exported only to the child forge
     # process and do not leak into the caller's shell environment.
-    if [[ "$_FORGE_TERM_ENABLED" == "true" && ${#_FORGE_TERM_COMMANDS} -gt 0 ]]; then
+    if [[ "$_FORGE_TERM" == "true" && ${#_FORGE_TERM_COMMANDS} -gt 0 ]]; then
         # Join the ring-buffer arrays with the ASCII Unit Separator (\x1F).
         # We use IFS-based joining ("${arr[*]}") rather than ${(j.SEP.)arr} because
         # zsh does NOT expand $'...' ANSI-C escapes inside parameter expansion flags.
@@ -66,7 +66,7 @@ function _forge_exec_interactive() {
     # Use `local -x` so the variables are exported only for the duration of
     # this function call (i.e. inherited by the child forge process) and do
     # not leak into the caller's shell environment.
-    if [[ "$_FORGE_TERM_ENABLED" == "true" && ${#_FORGE_TERM_COMMANDS} -gt 0 ]]; then
+    if [[ "$_FORGE_TERM" == "true" && ${#_FORGE_TERM_COMMANDS} -gt 0 ]]; then
         local _old_ifs="$IFS" _sep=$'\x1f'
         IFS="$_sep"
         local -x _FORGE_TERM_COMMANDS="${_FORGE_TERM_COMMANDS[*]}"


### PR DESCRIPTION
## Summary
Rename the internal shell-plugin variable `_FORGE_TERM_ENABLED` to `_FORGE_TERM` and its corresponding user-facing environment variable `FORGE_TERM_ENABLED` to `FORGE_TERM` for a shorter, more consistent naming convention.

## Context
The variable `_FORGE_TERM_ENABLED` served as the master switch for terminal context capture (preexec/precmd hooks). The `_ENABLED` suffix was redundant — the variable's boolean value already communicates enablement state. Dropping it aligns with the naming style of other `_FORGE_TERM_*` variables in the plugin (e.g., `_FORGE_TERM_MAX_COMMANDS`, `_FORGE_TERM_COMMANDS`) and reduces visual noise in the shell config.

## Changes
- Renamed `_FORGE_TERM_ENABLED` → `_FORGE_TERM` across all shell plugin files
- Renamed the user-facing env var `FORGE_TERM_ENABLED` → `FORGE_TERM` in `config.zsh`
- Updated all reference sites in `config.zsh`, `context.zsh`, and `helpers.zsh`

### Key Implementation Details
The rename is purely mechanical — no logic, defaults, or behavior changed. The variable still defaults to `"true"` and controls registration of the `preexec`/`precmd` hooks as well as terminal command context forwarding to the forge process.

## Testing
```bash
# Source the plugin and verify terminal context capture still works
source shell-plugin/forge.plugin.zsh

# Confirm the new variable name is respected
export FORGE_TERM=false
# Run a command — context should NOT be captured

export FORGE_TERM=true
# Run a command — context SHOULD be captured
```
