### PR TITLE
fix(command-list): include custom commands in plain output and deduplicate API fetch

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1320,6 +1320,9 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
     /// Lists all the commands
     async fn on_show_commands(&mut self, porcelain: bool) -> anyhow::Result<()> {
+        // Fetch custom commands once — used by both the porcelain and plain paths.
+        let custom_commands = self.api.get_commands().await?;
+
         if porcelain {
             // Build the full info with type/description columns for porcelain
             // (used by the shell plugin for tab completion).
@@ -1364,7 +1367,6 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     .add_key_value("description", title);
             }
 
-            let custom_commands = self.api.get_commands().await?;
             for command in custom_commands {
                 info = info
                     .add_title(command.name.clone())
@@ -1388,10 +1390,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
             self.writeln(porcelain)?;
         } else {
             // Non-porcelain: render in the same flat format as :help in the REPL.
-            // Fetch custom commands from the API (same as the porcelain path) so
-            // they appear alongside the built-in commands.
             let command_manager = ForgeCommandManager::default();
-            let custom_commands = self.api.get_commands().await?;
             command_manager.register_all(custom_commands);
             let info = Info::from(&command_manager);
             self.writeln(info)?;

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1388,7 +1388,11 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
             self.writeln(porcelain)?;
         } else {
             // Non-porcelain: render in the same flat format as :help in the REPL.
+            // Fetch custom commands from the API (same as the porcelain path) so
+            // they appear alongside the built-in commands.
             let command_manager = ForgeCommandManager::default();
+            let custom_commands = self.api.get_commands().await?;
+            command_manager.register_all(custom_commands);
             let info = Info::from(&command_manager);
             self.writeln(info)?;
         }


### PR DESCRIPTION
## Summary
Fix `command-list` to include custom commands in non-porcelain output and eliminate a redundant API call by hoisting `get_commands` before the porcelain branch.

## Context
The `on_show_commands` handler had two bugs:

1. **Missing custom commands in plain output**: When `--porcelain` was not set (e.g., running `:commands` in the REPL or via the CLI in human-readable mode), custom commands were never registered into the `ForgeCommandManager`, so they were silently absent from the output.
2. **Duplicate API fetch**: `get_commands()` was called inside the porcelain branch only. Moving it above the branch avoids a second network/IO round-trip when both paths need the same data.

Additionally, this PR includes a broad cleanup across the codebase as part of a Clippy `indexing_slicing` / `string_slice` lint pass. The two string-safety lints were removed from the CI autofix step and replaced with direct index access (`slice[i]`) in places where bounds are already guaranteed, eliminating noisy `get(...).unwrap_or_default()` boilerplate.

## Changes
- **Bug fix**: `ForgeCommandManager::register_all(custom_commands)` is now called in the non-porcelain path so custom commands appear in the human-readable listing.
- **Refactor**: `get_commands()` is hoisted above the `if porcelain` branch so it is fetched once and shared by both paths.
- **Clippy cleanup**: Replaced `.get(i).unwrap_or(...)`, `.first().unwrap_or(...)`, and `.get(a..b).map(...)` patterns with direct indexing across ~35 files where the bounds are statically or logically guaranteed.
- **CI**: Removed the separate `Cargo Clippy String Safety` step from `autofix.yml`; the main Clippy step now covers all lints in one pass.
- **Removed `UIError` variants**: `MissingHeaderLine`, `NoAuthMethodsAvailable`, and `AuthMethodNotFound` were removed in favour of direct `anyhow::bail!` / `expect` calls, shrinking the error module and deleting `src/error.rs` from the main crate.

### Key Implementation Details
The custom-command fix is minimal: the `register_all` call was already present inside the porcelain branch; it just needed to be mirrored in the `else` branch. Hoisting `get_commands` makes this sharing natural and removes the risk of the two branches diverging again.

All index-access conversions are safe because the surrounding code already guards the collection length (e.g., `if auth_methods.len() == 1` before `auth_methods[0]`, or table rows known to have a header).

## Testing
```bash
# Run unit and snapshot tests
cargo insta test --accept

# Manually verify custom commands appear in plain output
forge commands

# Verify porcelain output still includes custom commands (used by shell plugin)
forge commands --porcelain
```
