### PR TITLE
fix(command-list): deduplicate agent names in list commands porcelain output

### DIFF
--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -759,6 +759,15 @@ impl AppCommand {
                 | AppCommand::Rename { .. }
         )
     }
+
+    /// Returns true for variants that are pure agent-switch shorthands whose
+    /// canonical name matches a built-in agent (forge, muse, sage).  These
+    /// commands are already emitted as AGENT rows by the agent-info loop in
+    /// `on_show_commands`, so they must be excluded from the COMMAND loop to
+    /// avoid duplicate entries in `list commands --porcelain`.
+    pub fn is_agent_switch(&self) -> bool {
+        matches!(self, AppCommand::Forge | AppCommand::Muse | AppCommand::Sage)
+    }
 }
 
 #[cfg(test)]

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -766,7 +766,10 @@ impl AppCommand {
     /// `on_show_commands`, so they must be excluded from the COMMAND loop to
     /// avoid duplicate entries in `list commands --porcelain`.
     pub fn is_agent_switch(&self) -> bool {
-        matches!(self, AppCommand::Forge | AppCommand::Muse | AppCommand::Sage)
+        matches!(
+            self,
+            AppCommand::Forge | AppCommand::Muse | AppCommand::Sage
+        )
     }
 }
 

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1333,7 +1333,10 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
             // the list always stays in sync with what the REPL actually supports.
             // Internal/meta variants (Message, Custom, Shell, AgentSwitch, Rename)
             // are excluded via is_internal().
-            for cmd in AppCommand::iter().filter(|c| !c.is_internal()) {
+            // Agent-switch shorthands (forge, muse, sage) are excluded via
+            // is_agent_switch() because they are already emitted as AGENT rows
+            // by the agent-info loop below, and must not appear twice.
+            for cmd in AppCommand::iter().filter(|c| !c.is_internal() && !c.is_agent_switch()) {
                 info = info
                     .add_title(cmd.name())
                     .add_key_value("type", CommandType::Command)


### PR DESCRIPTION
## Summary
Fix `:muse`, `:sage`, and `:forge` ZSH commands failing with "command not found" by removing duplicate entries from `list commands --porcelain` output.

## Context
`AppCommand::Forge`, `AppCommand::Muse`, and `AppCommand::Sage` are REPL shortcut variants that switch agents. In `on_show_commands`, they were being emitted twice: once by the `AppCommand::iter()` loop (as `COMMAND`) and again by the agent-info loop (as `AGENT`). The ZSH shell plugin's `_forge_action_default` used `grep` to find the command row, received two matching lines, and ended up with `command_type = "AGENT\nCOMMAND"` — a multi-line string that failed the `[[ "${command_type:l}" == "agent" ]]` check, causing the "command not found" error.

## Changes
- Added `is_agent_switch()` method to `AppCommand` in `model.rs` that returns `true` for `Forge`, `Muse`, and `Sage`
- Updated `on_show_commands` in `ui.rs` to filter out agent-switch shorthands from the COMMAND loop, so they appear exactly once — as `AGENT` — in the porcelain output

## Testing
```bash
# Verify no duplicates in output
forge list commands --porcelain | grep -E "^(forge|muse|sage)\b"
# Expected: exactly 3 lines, all typed AGENT

# In ZSH with the shell plugin loaded:
:muse   # should set muse as active agent
:sage   # should set sage as active agent
:forge  # should set forge as active agent
```

Fixes https://github.com/tailcallhq/forgecode/issues/3009