### PR TITLE
Fix multiline paste on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,13 +1177,11 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+source = "git+https://github.com/crossterm-rs/crossterm?rev=e81d5d643700f6a1de17c130327acfd7df70420f#e81d5d643700f6a1de17c130327acfd7df70420f"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "derive_more",
- "document-features",
  "mio",
  "parking_lot",
  "rustix 1.1.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,3 +163,8 @@ forge_test_kit = { path = "crates/forge_test_kit" }
 
 forge_markdown_stream = { path = "crates/forge_markdown_stream" }
 forge_config = { path = "crates/forge_config" }
+
+# Patch crossterm with Windows VT input support (bracketed paste)
+# https://github.com/crossterm-rs/crossterm/pull/1030
+[patch.crates-io]
+crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "e81d5d643700f6a1de17c130327acfd7df70420f" }


### PR DESCRIPTION
Uses crossterm-rs/crossterm#1030 for the time being.

The other option is to take the Codex path and detect "frequent newline" as multiline which isn't great - the right way to fix it is on the crossterm side.