### PR TITLE
fix(repo): run conversation SQLite operations on spawn_blocking

### DIFF
--- a/crates/forge_repo/src/conversation/conversation_repo.rs
+++ b/crates/forge_repo/src/conversation/conversation_repo.rs
@@ -1012,6 +1012,110 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_concurrent_operations_dont_block_runtime() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        let repo = Arc::new(repository()?);
+        let heartbeat = Arc::new(AtomicUsize::new(0));
+
+        // Heartbeat task - if runtime is blocked, this won't increment
+        let heartbeat_clone = heartbeat.clone();
+        let heartbeat_handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                heartbeat_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        // Spawn many concurrent DB operations
+        let mut handles = vec![];
+        let start = Instant::now();
+
+        for i in 0..20 {
+            let repo = repo.clone();
+            let handle = tokio::spawn(async move {
+                for j in 0..10 {
+                    let conversation = Conversation::new(ConversationId::generate())
+                        .title(Some(format!("Task {} - Write {}", i, j)));
+                    repo.upsert_conversation(conversation).await?;
+                }
+                anyhow::Result::<()>::Ok(())
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all operations
+        for handle in handles {
+            handle.await??;
+        }
+        let elapsed = start.elapsed();
+
+        // Stop heartbeat
+        heartbeat_handle.abort();
+
+        // Verify runtime wasn't blocked
+        let heartbeat_count = heartbeat.load(Ordering::Relaxed);
+        let expected_heartbeats = elapsed.as_millis() as usize / 10;
+
+        // Heartbeat should have fired at least 80% of expected times
+        assert!(
+            heartbeat_count > expected_heartbeats * 8 / 10,
+            "Runtime was blocked! Expected ~{} heartbeats, got {}",
+            expected_heartbeats,
+            heartbeat_count
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mixed_read_write_contention() -> anyhow::Result<()> {
+        let repo = Arc::new(repository()?);
+        let mut handles = vec![];
+
+        // Pre-populate some data
+        for i in 0..10 {
+            let conv = Conversation::new(ConversationId::generate())
+                .title(Some(format!("Initial {}", i)));
+            repo.upsert_conversation(conv).await?;
+        }
+
+        // Spawn writers
+        for i in 0..10 {
+            let repo = repo.clone();
+            handles.push(tokio::spawn(async move {
+                for j in 0..10 {
+                    let conv = Conversation::new(ConversationId::generate())
+                        .title(Some(format!("Writer {} - {}", i, j)));
+                    repo.upsert_conversation(conv).await?;
+                }
+                anyhow::Result::<()>::Ok(())
+            }));
+        }
+
+        // Spawn readers (interleave with writers)
+        for _ in 0..10 {
+            let repo = repo.clone();
+            handles.push(tokio::spawn(async move {
+                for _ in 0..10 {
+                    // Read all conversations
+                    let _ = repo.get_all_conversations(Some(50)).await?;
+                    tokio::task::yield_now().await;
+                }
+                anyhow::Result::<()>::Ok(())
+            }));
+        }
+
+        // All should complete without timeout
+        for handle in handles {
+            handle.await??;
+        }
+
+        Ok(())
+    }
+
     #[test]
     fn test_legacy_tool_value_file_diff_deserialization() {
         use crate::conversation::conversation_record::ToolOutputRecord;

--- a/crates/forge_repo/src/conversation/conversation_repo.rs
+++ b/crates/forge_repo/src/conversation/conversation_repo.rs
@@ -4,8 +4,8 @@ use diesel::prelude::*;
 use forge_domain::{Conversation, ConversationId, ConversationRepository, WorkspaceHash};
 
 use crate::conversation::conversation_record::ConversationRecord;
-use crate::database::DatabasePool;
 use crate::database::schema::conversations;
+use crate::database::{DatabasePool, PooledSqliteConnection};
 
 pub struct ConversationRepositoryImpl {
     pool: Arc<DatabasePool>,
@@ -28,14 +28,24 @@ impl ConversationRepositoryImpl {
             .await
             .map_err(|e| anyhow::anyhow!("Conversation repository task failed: {e}"))?
     }
+
+    async fn run_with_connection<F, T>(&self, operation: F) -> anyhow::Result<T>
+    where
+        F: FnOnce(&mut PooledSqliteConnection, WorkspaceHash) -> anyhow::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.run_blocking(move |pool, wid| {
+            let mut connection = pool.get_connection()?;
+            operation(&mut connection, wid)
+        })
+        .await
+    }
 }
 
 #[async_trait::async_trait]
 impl ConversationRepository for ConversationRepositoryImpl {
     async fn upsert_conversation(&self, conversation: Conversation) -> anyhow::Result<()> {
-        self.run_blocking(move |pool, wid| {
-            let mut connection = pool.get_connection()?;
-
+        self.run_with_connection(move |connection, wid| {
             let record = ConversationRecord::new(conversation, wid);
             diesel::insert_into(conversations::table)
                 .values(&record)
@@ -47,7 +57,7 @@ impl ConversationRepository for ConversationRepositoryImpl {
                     conversations::updated_at.eq(record.updated_at),
                     conversations::metrics.eq(&record.metrics),
                 ))
-                .execute(&mut connection)?;
+                .execute(connection)?;
             Ok(())
         })
         .await
@@ -58,12 +68,10 @@ impl ConversationRepository for ConversationRepositoryImpl {
         conversation_id: &ConversationId,
     ) -> anyhow::Result<Option<Conversation>> {
         let conversation_id = *conversation_id;
-        self.run_blocking(move |pool, _wid| {
-            let mut connection = pool.get_connection()?;
-
+        self.run_with_connection(move |connection, _wid| {
             let record: Option<ConversationRecord> = conversations::table
                 .filter(conversations::conversation_id.eq(conversation_id.into_string()))
-                .first(&mut connection)
+                .first(connection)
                 .optional()?;
 
             match record {
@@ -78,9 +86,7 @@ impl ConversationRepository for ConversationRepositoryImpl {
         &self,
         limit: Option<usize>,
     ) -> anyhow::Result<Option<Vec<Conversation>>> {
-        self.run_blocking(move |pool, wid| {
-            let mut connection = pool.get_connection()?;
-
+        self.run_with_connection(move |connection, wid| {
             let workspace_id = wid.id() as i64;
             let mut query = conversations::table
                 .filter(conversations::workspace_id.eq(&workspace_id))
@@ -92,7 +98,7 @@ impl ConversationRepository for ConversationRepositoryImpl {
                 query = query.limit(limit_value as i64);
             }
 
-            let records: Vec<ConversationRecord> = query.load(&mut connection)?;
+            let records: Vec<ConversationRecord> = query.load(connection)?;
 
             if records.is_empty() {
                 return Ok(None);
@@ -106,14 +112,13 @@ impl ConversationRepository for ConversationRepositoryImpl {
     }
 
     async fn get_last_conversation(&self) -> anyhow::Result<Option<Conversation>> {
-        self.run_blocking(move |pool, wid| {
-            let mut connection = pool.get_connection()?;
+        self.run_with_connection(move |connection, wid| {
             let workspace_id = wid.id() as i64;
             let record: Option<ConversationRecord> = conversations::table
                 .filter(conversations::workspace_id.eq(&workspace_id))
                 .filter(conversations::context.is_not_null())
                 .order(conversations::updated_at.desc())
-                .first(&mut connection)
+                .first(connection)
                 .optional()?;
             let conversation = match record {
                 Some(record) => Some(Conversation::try_from(record)?),
@@ -126,15 +131,14 @@ impl ConversationRepository for ConversationRepositoryImpl {
 
     async fn delete_conversation(&self, conversation_id: &ConversationId) -> anyhow::Result<()> {
         let conversation_id = *conversation_id;
-        self.run_blocking(move |pool, wid| {
-            let mut connection = pool.get_connection()?;
+        self.run_with_connection(move |connection, wid| {
             let workspace_id = wid.id() as i64;
 
             // Security: Ensure users can only delete conversations within their workspace
             diesel::delete(conversations::table)
                 .filter(conversations::workspace_id.eq(&workspace_id))
                 .filter(conversations::conversation_id.eq(conversation_id.into_string()))
-                .execute(&mut connection)?;
+                .execute(connection)?;
 
             Ok(())
         })

--- a/crates/forge_repo/src/conversation/conversation_repo.rs
+++ b/crates/forge_repo/src/conversation/conversation_repo.rs
@@ -16,101 +16,129 @@ impl ConversationRepositoryImpl {
     pub fn new(pool: Arc<DatabasePool>, workspace_id: WorkspaceHash) -> Self {
         Self { pool, wid: workspace_id }
     }
+
+    async fn run_blocking<F, T>(&self, operation: F) -> anyhow::Result<T>
+    where
+        F: FnOnce(Arc<DatabasePool>, WorkspaceHash) -> anyhow::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let pool = self.pool.clone();
+        let wid = self.wid;
+        tokio::task::spawn_blocking(move || operation(pool, wid))
+            .await
+            .map_err(|e| anyhow::anyhow!("Conversation repository task failed: {e}"))?
+    }
 }
 
 #[async_trait::async_trait]
 impl ConversationRepository for ConversationRepositoryImpl {
     async fn upsert_conversation(&self, conversation: Conversation) -> anyhow::Result<()> {
-        let mut connection = self.pool.get_connection()?;
+        self.run_blocking(move |pool, wid| {
+            let mut connection = pool.get_connection()?;
 
-        let wid = self.wid;
-        let record = ConversationRecord::new(conversation, wid);
-        diesel::insert_into(conversations::table)
-            .values(&record)
-            .on_conflict(conversations::conversation_id)
-            .do_update()
-            .set((
-                conversations::title.eq(&record.title),
-                conversations::context.eq(&record.context),
-                conversations::updated_at.eq(record.updated_at),
-                conversations::metrics.eq(&record.metrics),
-            ))
-            .execute(&mut connection)?;
-        Ok(())
+            let record = ConversationRecord::new(conversation, wid);
+            diesel::insert_into(conversations::table)
+                .values(&record)
+                .on_conflict(conversations::conversation_id)
+                .do_update()
+                .set((
+                    conversations::title.eq(&record.title),
+                    conversations::context.eq(&record.context),
+                    conversations::updated_at.eq(record.updated_at),
+                    conversations::metrics.eq(&record.metrics),
+                ))
+                .execute(&mut connection)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_conversation(
         &self,
         conversation_id: &ConversationId,
     ) -> anyhow::Result<Option<Conversation>> {
-        let mut connection = self.pool.get_connection()?;
+        let conversation_id = *conversation_id;
+        self.run_blocking(move |pool, _wid| {
+            let mut connection = pool.get_connection()?;
 
-        let record: Option<ConversationRecord> = conversations::table
-            .filter(conversations::conversation_id.eq(conversation_id.into_string()))
-            .first(&mut connection)
-            .optional()?;
+            let record: Option<ConversationRecord> = conversations::table
+                .filter(conversations::conversation_id.eq(conversation_id.into_string()))
+                .first(&mut connection)
+                .optional()?;
 
-        match record {
-            Some(record) => Ok(Some(Conversation::try_from(record)?)),
-            None => Ok(None),
-        }
+            match record {
+                Some(record) => Ok(Some(Conversation::try_from(record)?)),
+                None => Ok(None),
+            }
+        })
+        .await
     }
 
     async fn get_all_conversations(
         &self,
         limit: Option<usize>,
     ) -> anyhow::Result<Option<Vec<Conversation>>> {
-        let mut connection = self.pool.get_connection()?;
+        self.run_blocking(move |pool, wid| {
+            let mut connection = pool.get_connection()?;
 
-        let workspace_id = self.wid.id() as i64;
-        let mut query = conversations::table
-            .filter(conversations::workspace_id.eq(&workspace_id))
-            .filter(conversations::context.is_not_null())
-            .order(conversations::updated_at.desc())
-            .into_boxed();
+            let workspace_id = wid.id() as i64;
+            let mut query = conversations::table
+                .filter(conversations::workspace_id.eq(&workspace_id))
+                .filter(conversations::context.is_not_null())
+                .order(conversations::updated_at.desc())
+                .into_boxed();
 
-        if let Some(limit_value) = limit {
-            query = query.limit(limit_value as i64);
-        }
+            if let Some(limit_value) = limit {
+                query = query.limit(limit_value as i64);
+            }
 
-        let records: Vec<ConversationRecord> = query.load(&mut connection)?;
+            let records: Vec<ConversationRecord> = query.load(&mut connection)?;
 
-        if records.is_empty() {
-            return Ok(None);
-        }
+            if records.is_empty() {
+                return Ok(None);
+            }
 
-        let conversations: Result<Vec<Conversation>, _> =
-            records.into_iter().map(Conversation::try_from).collect();
-        Ok(Some(conversations?))
+            let conversations: Result<Vec<Conversation>, _> =
+                records.into_iter().map(Conversation::try_from).collect();
+            Ok(Some(conversations?))
+        })
+        .await
     }
 
     async fn get_last_conversation(&self) -> anyhow::Result<Option<Conversation>> {
-        let mut connection = self.pool.get_connection()?;
-        let workspace_id = self.wid.id() as i64;
-        let record: Option<ConversationRecord> = conversations::table
-            .filter(conversations::workspace_id.eq(&workspace_id))
-            .filter(conversations::context.is_not_null())
-            .order(conversations::updated_at.desc())
-            .first(&mut connection)
-            .optional()?;
-        let conversation = match record {
-            Some(record) => Some(Conversation::try_from(record)?),
-            None => None,
-        };
-        Ok(conversation)
+        self.run_blocking(move |pool, wid| {
+            let mut connection = pool.get_connection()?;
+            let workspace_id = wid.id() as i64;
+            let record: Option<ConversationRecord> = conversations::table
+                .filter(conversations::workspace_id.eq(&workspace_id))
+                .filter(conversations::context.is_not_null())
+                .order(conversations::updated_at.desc())
+                .first(&mut connection)
+                .optional()?;
+            let conversation = match record {
+                Some(record) => Some(Conversation::try_from(record)?),
+                None => None,
+            };
+            Ok(conversation)
+        })
+        .await
     }
 
     async fn delete_conversation(&self, conversation_id: &ConversationId) -> anyhow::Result<()> {
-        let mut connection = self.pool.get_connection()?;
-        let workspace_id = self.wid.id() as i64;
+        let conversation_id = *conversation_id;
+        self.run_blocking(move |pool, wid| {
+            let mut connection = pool.get_connection()?;
+            let workspace_id = wid.id() as i64;
 
-        // Security: Ensure users can only delete conversations within their workspace
-        diesel::delete(conversations::table)
-            .filter(conversations::workspace_id.eq(&workspace_id))
-            .filter(conversations::conversation_id.eq(conversation_id.into_string()))
-            .execute(&mut connection)?;
+            // Security: Ensure users can only delete conversations within their workspace
+            diesel::delete(conversations::table)
+                .filter(conversations::workspace_id.eq(&workspace_id))
+                .filter(conversations::conversation_id.eq(conversation_id.into_string()))
+                .execute(&mut connection)?;
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/crates/forge_repo/src/conversation/conversation_repo.rs
+++ b/crates/forge_repo/src/conversation/conversation_repo.rs
@@ -1077,8 +1077,8 @@ mod tests {
 
         // Pre-populate some data
         for i in 0..10 {
-            let conv = Conversation::new(ConversationId::generate())
-                .title(Some(format!("Initial {}", i)));
+            let conv =
+                Conversation::new(ConversationId::generate()).title(Some(format!("Initial {}", i)));
             repo.upsert_conversation(conv).await?;
         }
 


### PR DESCRIPTION
## Summary
Move conversation repository SQLite operations to `spawn_blocking` so database work does not block async runtime worker threads.

## Context
Conversation persistence uses Diesel with SQLite, which performs blocking I/O. Running these operations directly in async paths can starve runtime threads under load.

This PR extracts only the non-blocking database operation change from the earlier broader fix.

Resolves #3021.

## Changes
- Added `run_blocking` helper in `ConversationRepositoryImpl` that executes DB operations inside `tokio::task::spawn_blocking`
- Updated all repository methods to use `run_blocking`:
  - `upsert_conversation`
  - `get_conversation`
  - `get_all_conversations`
  - `get_last_conversation`
  - `delete_conversation`
- Preserved existing query and workspace-filter semantics while moving blocking work off async runtime threads

### Key Implementation Details
- `run_blocking` clones the shared DB pool and workspace hash, executes closure logic on a blocking thread, and propagates join errors with context.
- `ConversationId` is copied before entering blocking closures where needed so closures remain `'static` and `Send`.

## Use Cases
- Parallel agent workflows that frequently read/write conversation state
- High-concurrency sessions where blocking DB calls could otherwise reduce async task responsiveness

## Testing
```bash
cargo check -p forge_repo
cargo test -p forge_repo -- conversation_repo
```

## Links
- Related issue: #3021
