### PR TITLE
refactor(config-reader): cache base path resolution

### DIFF
--- a/crates/forge_config/src/reader.rs
+++ b/crates/forge_config/src/reader.rs
@@ -30,6 +30,9 @@ static LOAD_DOT_ENV: LazyLock<()> = LazyLock::new(|| {
     }
 });
 
+/// Caches base-path resolution for the process lifetime.
+static BASE_PATH: LazyLock<PathBuf> = LazyLock::new(ConfigReader::resolve_base_path);
+
 /// Merges [`ForgeConfig`] from layered sources using a builder pattern.
 #[derive(Default)]
 pub struct ConfigReader {
@@ -58,6 +61,10 @@ impl ConfigReader {
     ///    existing directory without disruption.
     /// 3. `~/.forge` as the default path.
     pub fn base_path() -> PathBuf {
+        BASE_PATH.clone()
+    }
+
+    fn resolve_base_path() -> PathBuf {
         if let Ok(path) = std::env::var("FORGE_CONFIG") {
             return PathBuf::from(path);
         }
@@ -199,7 +206,7 @@ mod tests {
     #[test]
     fn test_base_path_uses_forge_config_env_var() {
         let _guard = EnvGuard::set(&[("FORGE_CONFIG", "/custom/forge/dir")]);
-        let actual = ConfigReader::base_path();
+        let actual = ConfigReader::resolve_base_path();
         let expected = PathBuf::from("/custom/forge/dir");
         assert_eq!(actual, expected);
     }
@@ -210,7 +217,7 @@ mod tests {
         // cannot race with test_base_path_uses_forge_config_env_var.
         let _guard = EnvGuard::set_and_remove(&[], &["FORGE_CONFIG"]);
 
-        let actual = ConfigReader::base_path();
+        let actual = ConfigReader::resolve_base_path();
         // Without FORGE_CONFIG set the path must be either "forge" (legacy,
         // preferred when ~/forge exists) or ".forge" (default new path).
         let name = actual.file_name().unwrap();

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -172,10 +172,22 @@ mod tests {
     }
 
     #[test]
-    fn test_to_environment_uses_config_reader_base_path() {
-        let actual = to_environment(PathBuf::from("/any/cwd"));
-        let expected = ConfigReader::base_path();
-        assert_eq!(actual.base_path, expected);
+    fn test_to_environment_base_path_is_stable_after_env_var_change() {
+        let fixture_cwd = PathBuf::from("/any/cwd");
+        let expected = to_environment(fixture_cwd.clone()).base_path;
+
+        let previous = std::env::var("FORGE_CONFIG").ok();
+        unsafe { std::env::set_var("FORGE_CONFIG", "/custom/config/dir") };
+
+        let actual = to_environment(fixture_cwd).base_path;
+
+        if let Some(value) = previous {
+            unsafe { std::env::set_var("FORGE_CONFIG", value) };
+        } else {
+            unsafe { std::env::remove_var("FORGE_CONFIG") };
+        }
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/forge_infra/src/env.rs
+++ b/crates/forge_infra/src/env.rs
@@ -158,42 +158,11 @@ impl EnvironmentInfra for ForgeEnvironmentInfra {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::{Mutex, MutexGuard};
 
     use forge_config::ForgeConfig;
     use pretty_assertions::assert_eq;
 
     use super::*;
-
-    /// Serializes tests that mutate environment variables to prevent races.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
-
-    /// Holds env vars set for a test's duration and removes them on drop,
-    /// while holding [`ENV_MUTEX`].
-    struct EnvGuard {
-        keys: Vec<&'static str>,
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl EnvGuard {
-        #[must_use]
-        fn set(pairs: &[(&'static str, &str)]) -> Self {
-            let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-            let keys = pairs.iter().map(|(k, _)| *k).collect();
-            for (key, value) in pairs {
-                unsafe { std::env::set_var(key, value) };
-            }
-            Self { keys, _lock: lock }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for key in &self.keys {
-                unsafe { std::env::remove_var(key) };
-            }
-        }
-    }
 
     #[test]
     fn test_to_environment_sets_cwd() {
@@ -203,10 +172,9 @@ mod tests {
     }
 
     #[test]
-    fn test_to_environment_uses_forge_config_env_var() {
-        let _guard = EnvGuard::set(&[("FORGE_CONFIG", "/custom/config/dir")]);
+    fn test_to_environment_uses_config_reader_base_path() {
         let actual = to_environment(PathBuf::from("/any/cwd"));
-        let expected = PathBuf::from("/custom/config/dir");
+        let expected = ConfigReader::base_path();
         assert_eq!(actual.base_path, expected);
     }
 


### PR DESCRIPTION
## Summary
Stabilize Forge config path behavior so the process uses a single consistent base directory decision for the full runtime.

## Context
Config path selection influences where Forge reads and writes user settings. Recomputing that decision repeatedly in one process can introduce unnecessary variability and make behavior harder to reason about when environment state changes between calls. This change makes path resolution deterministic for the process lifetime while preserving current legacy/default fallback semantics.

## Changes
- Cache the resolved config base path once per process and return that cached value from `base_path()`.
- Keep resolver logic in a dedicated function so tests can continue validating path precedence behavior directly.
- Update base-path tests to assert resolver behavior explicitly.

## Testing
- `cargo build -p forge_main`
- `FORGE_LOG=debug ./target/debug/forge`
- `FORGE_LOG=debug ./target/debug/forge`
- `cargo +nightly fmt --all && cargo +nightly clippy --all-features --workspace --all-targets --fix --allow-dirty -- -D warnings`
