### PR TITLE
fix: retry server_is_overloaded for OpenAI Responses stream failures

### DIFF
--- a/crates/forge_repo/src/provider/openai_responses/response.rs
+++ b/crates/forge_repo/src/provider/openai_responses/response.rs
@@ -5,6 +5,9 @@ use forge_app::domain::{
     ChatCompletionMessage, Content, FinishReason, MessagePhase, TokenCount, ToolCall,
     ToolCallArguments, ToolCallFull, ToolCallId, ToolCallPart, ToolName, Usage,
 };
+use forge_app::dto::openai::{
+    Error as OpenAIError, ErrorCode as OpenAIErrorCode, ErrorResponse as OpenAIErrorResponse,
+};
 use forge_domain::{BoxStream, ResultStream};
 use futures::StreamExt;
 use serde::{Deserialize, Deserializer};
@@ -266,6 +269,23 @@ fn retain_encrypted_reasoning_details(
     }
 }
 
+fn into_response_failed_error(failed: oai::ResponseFailedEvent) -> anyhow::Error {
+    let Some(error) = failed.response.error else {
+        return anyhow::anyhow!("Upstream response failed: no error object returned");
+    };
+
+    let mut response_error = OpenAIErrorResponse::default();
+    if !error.code.is_empty() {
+        response_error = response_error.code(OpenAIErrorCode::String(error.code));
+    }
+
+    if !error.message.is_empty() {
+        response_error = response_error.message(error.message);
+    }
+
+    anyhow::Error::from(OpenAIError::Response(response_error)).context("Upstream response failed")
+}
+
 impl IntoDomain for BoxStream<StreamItem, anyhow::Error> {
     type Domain = ResultStream<ChatCompletionMessage, anyhow::Error>;
 
@@ -437,10 +457,7 @@ impl IntoDomain for BoxStream<StreamItem, anyhow::Error> {
                                 Some(Ok(message))
                             }
                             oai::ResponseStreamEvent::ResponseFailed(failed) => {
-                                Some(Err(anyhow::anyhow!(
-                                    "Upstream response failed: {:?}",
-                                    failed.response.error
-                                )))
+                                Some(Err(into_response_failed_error(failed)))
                             }
                             oai::ResponseStreamEvent::ResponseError(err) => {
                                 Some(Err(anyhow::anyhow!("Upstream error: {}", err.message)))
@@ -683,7 +700,7 @@ mod tests {
         .unwrap()
     }
 
-    fn fixture_response_failed() -> oai::Response {
+    fn fixture_response_failed_with_code(code: &str, message: &str) -> oai::Response {
         serde_json::from_value(serde_json::json!({
             "id": "resp_1",
             "created_at": 0,
@@ -692,12 +709,16 @@ mod tests {
             "status": "failed",
             "output": [],
             "error": {
-                "code": "rate_limit",
-                "message": "Rate limit exceeded",
+                "code": code,
+                "message": message,
                 "type": "invalid_request_error"
             }
         }))
         .unwrap()
+    }
+
+    fn fixture_response_failed() -> oai::Response {
+        fixture_response_failed_with_code("rate_limit", "Rate limit exceeded")
     }
 
     fn fixture_response_incomplete(text: &str) -> oai::Response {
@@ -1338,6 +1359,36 @@ mod tests {
                 .to_string()
                 .contains("Upstream response failed")
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_with_response_failed_preserves_error_code() -> anyhow::Result<()> {
+        let response = fixture_response_failed_with_code(
+            "server_is_overloaded",
+            "Our servers are currently overloaded. Please try again later.",
+        );
+        let failed = oai::ResponseFailedEvent { sequence_number: 2, response };
+
+        let stream: ResponseStream = Box::pin(tokio_stream::iter([event(
+            oai::ResponseStreamEvent::ResponseFailed(failed),
+        )]));
+
+        let mut stream_domain = stream.into_domain()?;
+        let actual = stream_domain.next().await.unwrap().unwrap_err();
+
+        let expected = Some("server_is_overloaded");
+        let actual = actual
+            .downcast_ref::<OpenAIError>()
+            .and_then(|error| match error {
+                OpenAIError::Response(error) => {
+                    error.get_code_deep().and_then(|code| code.as_str())
+                }
+                OpenAIError::InvalidStatusCode(_) => None,
+            });
+
+        assert_eq!(actual, expected);
 
         Ok(())
     }

--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -348,7 +348,9 @@ mod tests {
         let error = anyhow::Error::from(Error::Response(
             ErrorResponse::default()
                 .code(ErrorCode::String("server_is_overloaded".to_string()))
-                .message("Our servers are currently overloaded. Please try again later.".to_string()),
+                .message(
+                    "Our servers are currently overloaded. Please try again later.".to_string(),
+                ),
         ));
 
         assert!(is_retryable(into_retry(error, &retry_config)));

--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -1,9 +1,10 @@
 use forge_app::domain::Error as DomainError;
 use forge_app::dto::anthropic::Error as AnthropicError;
-use forge_app::dto::openai::{Error, ErrorResponse};
+use forge_app::dto::openai::{Error, ErrorCode, ErrorResponse};
 use forge_config::RetryConfig;
 
 const TRANSPORT_ERROR_CODES: [&str; 3] = ["ERR_STREAM_PREMATURE_CLOSE", "ECONNRESET", "ETIMEDOUT"];
+const OPENAI_OVERLOADED_ERROR_CODE: &str = "server_is_overloaded";
 
 pub fn into_retry(error: anyhow::Error, retry_config: &RetryConfig) -> anyhow::Error {
     if let Some(code) = get_req_status_code(&error)
@@ -19,6 +20,7 @@ pub fn into_retry(error: anyhow::Error, retry_config: &RetryConfig) -> anyhow::E
         || is_event_transport_error(&error)
         || is_empty_error(&error)
         || is_anthropic_overloaded_error(&error)
+        || is_openai_overloaded_error(&error)
     {
         return DomainError::Retryable(error).into();
     }
@@ -65,24 +67,49 @@ fn get_event_req_status_code(error: &anyhow::Error) -> Option<u16> {
         })
 }
 
-fn has_transport_error_code(error: &ErrorResponse) -> bool {
-    // Check if the current level has a transport error code
+#[derive(Clone, Copy)]
+enum RetryableApiErrorCode {
+    Transport,
+    OpenAIOverloaded,
+}
+
+impl RetryableApiErrorCode {
+    fn matches(self, code: &ErrorCode) -> bool {
+        let Some(code) = code.as_str() else {
+            return false;
+        };
+
+        match self {
+            RetryableApiErrorCode::Transport => TRANSPORT_ERROR_CODES.contains(&code),
+            RetryableApiErrorCode::OpenAIOverloaded => code == OPENAI_OVERLOADED_ERROR_CODE,
+        }
+    }
+}
+
+fn has_error_code(error: &ErrorResponse, retryable_code: RetryableApiErrorCode) -> bool {
+    // Check if the current level has a matching error code.
     let has_direct_code = error
         .code
         .as_ref()
-        .and_then(|code| code.as_str())
-        .is_some_and(|code| {
-            TRANSPORT_ERROR_CODES
-                .into_iter()
-                .any(|message| message == code)
-        });
+        .is_some_and(|code| retryable_code.matches(code));
 
     if has_direct_code {
         return true;
     }
 
-    // Recursively check nested errors
-    error.error.as_deref().is_some_and(has_transport_error_code)
+    // Recursively check nested errors.
+    error
+        .error
+        .as_deref()
+        .is_some_and(|nested| has_error_code(nested, retryable_code))
+}
+
+fn has_transport_error_code(error: &ErrorResponse) -> bool {
+    has_error_code(error, RetryableApiErrorCode::Transport)
+}
+
+fn has_overloaded_error_code(error: &ErrorResponse) -> bool {
+    has_error_code(error, RetryableApiErrorCode::OpenAIOverloaded)
 }
 
 fn is_api_transport_error(error: &anyhow::Error) -> bool {
@@ -90,6 +117,15 @@ fn is_api_transport_error(error: &anyhow::Error) -> bool {
         .downcast_ref::<Error>()
         .is_some_and(|error| match error {
             Error::Response(error) => has_transport_error_code(error),
+            _ => false,
+        })
+}
+
+fn is_openai_overloaded_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<Error>()
+        .is_some_and(|error| match error {
+            Error::Response(error) => has_overloaded_error_code(error),
             _ => false,
         })
 }
@@ -303,6 +339,25 @@ mod tests {
         assert!(get_api_status_code(&error).is_none());
         assert!(get_req_status_code(&error).is_none());
         assert!(get_event_req_status_code(&error).is_none());
+    }
+
+    #[test]
+    fn test_openai_server_overloaded_error_is_retryable() {
+        let retry_config = fixture_retry_config(vec![]);
+
+        let error = anyhow::Error::from(Error::Response(
+            ErrorResponse::default()
+                .code(ErrorCode::String("server_is_overloaded".to_string()))
+                .message("Our servers are currently overloaded. Please try again later.".to_string()),
+        ));
+
+        assert!(is_retryable(into_retry(error, &retry_config)));
+
+        let error = anyhow::Error::from(Error::Response(
+            ErrorResponse::default().code(ErrorCode::String("rate_limit".to_string())),
+        ));
+
+        assert!(!is_retryable(into_retry(error, &retry_config)));
     }
 
     #[test]

--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -104,19 +104,11 @@ fn has_error_code(error: &ErrorResponse, retryable_code: RetryableApiErrorCode) 
         .is_some_and(|nested| has_error_code(nested, retryable_code))
 }
 
-fn has_transport_error_code(error: &ErrorResponse) -> bool {
-    has_error_code(error, RetryableApiErrorCode::Transport)
-}
-
-fn has_overloaded_error_code(error: &ErrorResponse) -> bool {
-    has_error_code(error, RetryableApiErrorCode::OpenAIOverloaded)
-}
-
 fn is_api_transport_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<Error>()
         .is_some_and(|error| match error {
-            Error::Response(error) => has_transport_error_code(error),
+            Error::Response(error) => has_error_code(error, RetryableApiErrorCode::Transport),
             _ => false,
         })
 }
@@ -125,7 +117,9 @@ fn is_openai_overloaded_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<Error>()
         .is_some_and(|error| match error {
-            Error::Response(error) => has_overloaded_error_code(error),
+            Error::Response(error) => {
+                has_error_code(error, RetryableApiErrorCode::OpenAIOverloaded)
+            }
             _ => false,
         })
 }
@@ -288,21 +282,21 @@ mod tests {
         for code in transport_codes {
             let error = ErrorResponse::default().code(ErrorCode::String(code.to_string()));
             assert!(
-                has_transport_error_code(&error),
+                has_error_code(&error, RetryableApiErrorCode::Transport),
                 "Code {code} should be transport error"
             );
         }
 
         let error = ErrorResponse::default().code(ErrorCode::String("UNKNOWN".to_string()));
-        assert!(!has_transport_error_code(&error));
+        assert!(!has_error_code(&error, RetryableApiErrorCode::Transport));
 
         let error = ErrorResponse::default();
-        assert!(!has_transport_error_code(&error));
+        assert!(!has_error_code(&error, RetryableApiErrorCode::Transport));
 
         // Nested transport codes
         let nested = ErrorResponse::default().code(ErrorCode::String("ECONNRESET".to_string()));
         let error = ErrorResponse::default().error(Box::new(nested));
-        assert!(has_transport_error_code(&error));
+        assert!(has_error_code(&error, RetryableApiErrorCode::Transport));
 
         // is_empty_error
         let error = anyhow::Error::from(Error::Response(ErrorResponse::default()));


### PR DESCRIPTION
## Summary
Make OpenAI Responses stream overload failures retryable by preserving structured upstream error codes and classifying `server_is_overloaded` as retryable.

## Context
OpenAI Responses streaming failures were being surfaced as formatted strings (`Upstream response failed: ...`), which dropped structured provider error metadata. Because of that, retry classification could not reliably identify the `server_is_overloaded` code from stream failures and the request was not retried.

## Changes
- Preserved `response.failed` stream errors as structured OpenAI DTO errors instead of debug-only strings.
- Added OpenAI overloaded error classification in retry mapping for `server_is_overloaded`.
- Kept transport-code retry matching centralized with `TRANSPORT_ERROR_CODES`.
- Added regression tests for both stream error-code preservation and retryability behavior.

### Key Implementation Details
- Added `into_response_failed_error(...)` to convert `ResponseFailedEvent` into `forge_app::dto::openai::Error::Response`, retaining `code` and `message` fields from upstream payloads.
- Updated stream event handling to use structured conversion for `ResponseFailed` events.
- Extended retry logic with a typed `RetryableApiErrorCode` classifier and recursive code lookup through nested OpenAI error payloads.
- Added explicit overloaded-code constant (`server_is_overloaded`) and transport constant usage (`TRANSPORT_ERROR_CODES`).

## Use Cases
- If OpenAI Responses stream emits:
  - `code: "server_is_overloaded"`
  - `message: "Our servers are currently overloaded. Please try again later."`
  then Forge now marks the failure as retryable.
- Existing transport retry behavior for `ERR_STREAM_PREMATURE_CLOSE`, `ECONNRESET`, and `ETIMEDOUT` remains intact.

## Testing
```bash
cargo test -p forge_repo test_stream_with_response_failed_preserves_error_code
cargo test -p forge_repo test_openai_server_overloaded_error_is_retryable
cargo test -p forge_repo test_into_retry_with_transport_errors
```

## Links
- Related issues: N/A
