### PR TITLE
fix(config): move currency keys above [reasoning] table header

### DIFF
--- a/crates/forge_config/.forge.toml
+++ b/crates/forge_config/.forge.toml
@@ -28,6 +28,8 @@ tool_timeout_secs = 300
 top_k = 30
 top_p = 0.8
 verify_todos = true
+currency_symbol = "$"
+currency_conversion_rate = 1.0
 
 [retry]
 backoff_factor = 2
@@ -66,6 +68,3 @@ frequency = "daily"
 [reasoning]
 enabled = true
 effort = "high"
-
-currency_symbol = "$"
-currency_conversion_rate = 1.0


### PR DESCRIPTION
`currency_symbol` and `currency_conversion_rate` were added below the `[reasoning]` table header in #2887. TOML scopes them as `reasoning.*`, but the fields are defined on the root `ForgeConfig` struct — silently dropped during deserialization, defaulting to `""` / `0.0`.

Fix: move both keys above the first table header so they're parsed as top-level config.