### PR TITLE
fix(deps): drop unmaintained atty crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,17 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,7 +2263,6 @@ dependencies = [
  "anyhow",
  "arboard",
  "async-recursion",
- "atty",
  "chrono",
  "clap",
  "clap_complete",
@@ -4014,15 +4002,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"

--- a/crates/forge_main/Cargo.toml
+++ b/crates/forge_main/Cargo.toml
@@ -57,7 +57,6 @@ dirs.workspace = true
 open.workspace = true
 humantime.workspace = true
 num-format.workspace = true
-atty = "0.2"
 url.workspace = true
 forge_embed.workspace = true
 include_dir.workspace = true

--- a/crates/forge_main/src/main.rs
+++ b/crates/forge_main/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::panic;
 use std::path::PathBuf;
 
@@ -91,7 +91,7 @@ async fn run() -> Result<()> {
     let mut cli = Cli::parse();
 
     // Check if there's piped input
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         let mut stdin_content = String::new();
         std::io::stdin().read_to_string(&mut stdin_content)?;
         let trimmed_content = stdin_content.trim();


### PR DESCRIPTION
## Why

Resolves [Dependabot alert #8](https://github.com/tailcallhq/forgecode/security/dependabot/8) ([GHSA-g98v-hv3f-hcfr](https://github.com/advisories/GHSA-g98v-hv3f-hcfr)).

The `atty` crate is **unmaintained** (last release ~3 years ago) and carries a low-severity advisory for a potential unaligned read on Windows. Upstream has not published a patched version and is unlikely to, so the advisory explicitly recommends replacing it.

## Why this approach

`std::io::IsTerminal` has been stable since Rust 1.70 and provides exactly the TTY-detection capability we were using `atty` for. Leaning on the standard library is preferable to pulling in another third-party crate (e.g. `is-terminal`) because it:

- Removes a security-flagged dependency without introducing a new one.
- Reduces the dependency surface and build time.
- Is maintained by the Rust project itself, so future soundness concerns are covered upstream.

## Scope

`atty` had exactly one caller in the workspace (stdin pipe detection in `forge_main`). Behavior is preserved: piped stdin still populates the piped-input path, and interactive TTY sessions still bypass the stdin read.

## Verification

- `cargo tree -i atty --workspace` confirms the crate is no longer in the graph.
- `cargo check` passes.
- Behavior was validated end-to-end via tmux (TTY path) and multiple pipe variants (non-TTY path): empty pipe, single-line, multi-line, and `/dev/null` redirect. Interactive TUI launches and exits cleanly; piped commands do not hang.

Co-Authored-By: ForgeCode <noreply@forgecode.dev>