### PR TITLE
chore(labels): add severity low, high, and critical labels

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -327,5 +327,23 @@
     "color": "F9C74F",
     "description": "This bounty has been completed and the reward paid out.",
     "aliases": ["bounty:rewarded", "bounty:earned"]
+  },
+  {
+    "name": "severity: low",
+    "color": "FFEB3B",
+    "description": "Minor impact; does not significantly affect functionality.",
+    "aliases": ["severity:low"]
+  },
+  {
+    "name": "severity: high",
+    "color": "FF9800",
+    "description": "Significant impact; core functionality is impaired.",
+    "aliases": ["severity:high"]
+  },
+  {
+    "name": "severity: critical",
+    "color": "B71C1C",
+    "description": "Severe impact; system is unusable or data is at risk.",
+    "aliases": ["severity:critical", "critical"]
   }
 ]


### PR DESCRIPTION
## Summary
Add three severity labels (`severity: low`, `severity: high`, `severity: critical`) to the GitHub labels configuration to enable better triage and prioritization of issues.

## Context
The project's label system lacked a standardized way to communicate the impact level of bugs and issues. Without severity labels, it's difficult for contributors and maintainers to quickly assess which issues need urgent attention versus those that can be addressed later in the backlog.

## Changes
- Added `severity: low` label (yellow `#FFEB3B`) — for minor issues that don't significantly affect functionality
- Added `severity: high` label (orange `#FF9800`) — for significant issues where core functionality is impaired
- Added `severity: critical` label (dark red `#B71C1C`) — for severe issues where the system is unusable or data is at risk
- Each label includes aliases for backward compatibility (`severity:low`, `severity:high`, `severity:critical`, `critical`)

## Testing
Labels will be automatically synced to GitHub when the label sync workflow runs. You can verify the labels are applied correctly by checking the repository's Labels page after the workflow completes.

## Links
- Labels configuration: `.github/labels.json`
