### PR TITLE
chore(release-drafter): move provider label to patch version bucket

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,7 +44,6 @@ version-resolver:
   minor:
     labels:
       - "type: feature"
-      - "type: provider"
     # Add direct commit message pattern matching for features
     commits:
       - "feat:"
@@ -58,6 +57,7 @@ version-resolver:
       - "type: bug"
       - "type: testing"
       - "type: refactor"
+      - "type: provider"
     # Add direct commit message pattern matching for patches
     commits:
       - "fix:"


### PR DESCRIPTION
## Summary
Move the `type: provider` label from the `minor` version bucket to the `patch` bucket in the release-drafter configuration so that provider additions trigger patch releases instead of minor releases.

## Context
Provider-related changes (adding or updating LLM providers) were previously categorized under `minor` version bumps alongside feature work. In practice, provider additions are incremental and non-breaking — they should follow the same versioning cadence as bug fixes and refactors (`patch`), not feature releases (`minor`). This reordering corrects that classification.

## Changes
- Removed `type: provider` from the `minor` labels list in `.github/release-drafter.yml`
- Added `type: provider` to the `patch` labels list

## Testing
Verify the release-drafter configuration is valid by opening a PR with the `type: provider` label and confirming that the drafted release resolves to a patch version bump rather than a minor bump.

## Links
- Config file: `.github/release-drafter.yml`
