### PR TITLE
chore(forge_config): lower default reasoning effort to medium

### DIFF
--- a/crates/forge_config/.forge.toml
+++ b/crates/forge_config/.forge.toml
@@ -69,4 +69,4 @@ frequency = "daily"
 
 [reasoning]
 enabled = true
-effort = "high"
+effort = "medium"


### PR DESCRIPTION
## Summary
Lower the default reasoning effort in `forge_config` from `high` to `medium` for a better balance between response quality, latency, and cost on everyday tasks.

## Context
The shipped default of `high` was overly aggressive for the majority of user interactions. It increased latency and token cost without delivering a proportional quality improvement for typical coding and Q&A workloads. `medium` is a more sensible out-of-the-box setting; users who need deeper reasoning can still opt in to `high` via their own config.

## Changes
- `crates/forge_config/.forge.toml`: set `[reasoning].effort` from `"high"` to `"medium"`.

## Testing
```bash
# Verify config loads and default value is picked up
cargo check -p forge_config
cargo insta test -p forge_config --accept
```

Manually confirm new sessions start with `medium` effort unless the user overrides it in their own `.forge.toml`.
