### PR TITLE
fix(openai): enforce strict tool schema for Kimi Coding API

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use forge_domain::{DefaultTransformation, Provider, ProviderId, Transformer};
 use url::Url;
 
@@ -72,6 +74,7 @@ impl Transformer for ProviderPipeline<'_> {
 
         let trim_tool_call_ids = TrimToolCallIds.when(move |_| provider.id == ProviderId::OPENAI);
 
+        let kimi_coding = ProviderId::from_str("kimi_coding").unwrap();
         let strict_schema = EnforceStrictToolSchema
             .pipe(EnforceStrictResponseFormatSchema)
             .when(move |_| {
@@ -79,6 +82,7 @@ impl Transformer for ProviderPipeline<'_> {
                     || provider.id == ProviderId::OPENCODE_ZEN
                     || provider.id == ProviderId::OPENCODE_GO
                     || provider.id == ProviderId::XAI
+                    || provider.id == kimi_coding
             });
 
         let mut combined = zai_thinking


### PR DESCRIPTION
## Problem

The Kimi Coding endpoint (\`https://api.kimi.com/coding/v1\`) validates tool JSON schemas strictly and rejects schemas that include nullable enum patterns (e.g. \`null\` inside \`enum\`) that Forge already normalizes for other providers via \`EnforceStrictToolSchema\`.

The \`kimi_coding\` provider was not included in that pipeline, so requests with tools could fail against the Kimi Coding API.

## Change

Include the \`kimi_coding\` provider in the same strict-schema branch as Fireworks, OpenCode Zen/Go, and XAI.

## Testing

- \`cargo build -p forge_main --release\` (local)

Made with [Cursor](https://cursor.com)